### PR TITLE
Fix typo "Authentication" -> "Authorization"

### DIFF
--- a/introduction/authentication.mdx
+++ b/introduction/authentication.mdx
@@ -9,13 +9,14 @@ presented with a screen showing the new token. You **must** copy and paste this
 token, as we do not store it anywhere. If you loose it, you'll need to create a
 new one.
 
-Tokens must be included in the `Authentication` HTTP header in all requests as a
+Tokens must be included in the `Authorization` HTTP header in all requests as a
 type `Bearer`.
 
 Test everything is working correctly using the [ping](/reference/utils/ping)
 endpoint and curl:
 
 ```bash
-$ curl -H "Authentication: Bearer " https://api.invopop.com/utils/v1/ping
+$ curl -H "Authorization: Bearer [token]" https://api.invopop.com/utils/v1/ping
+
 {"ping":"pong"}
 ```


### PR DESCRIPTION
Fix typo `Authentication` -> `Authorization` in Authentication docs. 