### PR TITLE
Moves rich endpoint description from OpenAPI to MDX

### DIFF
--- a/_snippets/reference/silo/entries/create-an-entry-desc.mdx
+++ b/_snippets/reference/silo/entries/create-an-entry-desc.mdx
@@ -1,0 +1,15 @@
+The <code>data</code> field may contain either GOBL Envelope or Document, and
+will be validated before being persisted.
+
+New entries may also be created based on a previous entry using the
+<code>previous_id</code> field. Using a previous entry allows you to provide
+patch data instead of a new full document or envelope by setting the patch type
+in the <code>content_type</code> field to either:
+
+  - <code>application/json-patch+json</code> - for JSON Patch (RFC 6902)
+  - <code>application/merge-patch+json</code> - for JSON Merge Patch (RFC 7396)
+
+The <code>previous_id</code> field can also be used to make corrective documents
+by adding the corrective option data in the <code>correct</code> field. For more
+details on this, see the <a href="https://docs.gobl.org/draft-0/bill/correction_options">GOBL documentation
+for correction options</a>.

--- a/openapi/silo_v1.yaml
+++ b/openapi/silo_v1.yaml
@@ -127,21 +127,8 @@ paths:
                 $ref: '#/components/schemas/SiloEntry'
           description: OK
     put:
-      description: |
-        Create a new silo entry idempotently with the given UUIDv1 (other versions not supported).
-        The <code>data</code> field may contain either GOBL Envelope or Document, and will be validated
-        before being persisted.
-
-        New entries may also be created based on a previous entry using the <code>previous_id</code> field.
-        Using a previous entry allows you to provide patch data instead of a new full document or envelope
-        by setting the patch type in the <code>content_type</code> field to either:
-
-         - <code>application/json-patch+json</code> - for JSON Patch (RFC 6902)
-         - <code>application/merge-patch+json</code> - for JSON Merge Patch (RFC 7396)
-
-        The <code>previous_id</code> field can also be used to make corrective documents by adding
-        the corrective option data in the <code>correct</code> field. For more details on this,
-        see the <a href="https://docs.gobl.org">GOBL documentation site</a>.
+      description: Create a new silo entry idempotently with the given UUIDv1 (other
+        versions not supported).
       parameters:
       - description: The UUIDv1 (other versions not supported) of the silo entry to
           create.

--- a/reference/silo/entries/create-an-entry-post.mdx
+++ b/reference/silo/entries/create-an-entry-post.mdx
@@ -3,3 +3,5 @@ title: "Create an entry (non-idempotent)"
 sidebarTitle: "Create an entry (POST)"
 openapi: "POST /silo/v1/entries"
 ---
+
+<Warning>This is a non-idempotent endpoint. It must be used for developing and testing only. In production, please use [the idempotent version](./create-an-entry-put). More info [here](/introduction/idempotency).</Warning>

--- a/reference/silo/entries/create-an-entry-post.mdx
+++ b/reference/silo/entries/create-an-entry-post.mdx
@@ -5,3 +5,5 @@ openapi: "POST /silo/v1/entries"
 ---
 
 <Warning>This is a non-idempotent endpoint. It must be used for developing and testing only. In production, please use [the idempotent version](./create-an-entry-put). More info [here](/introduction/idempotency).</Warning>
+
+<Snippet file="reference/silo/entries/create-an-entry-desc.mdx" />

--- a/reference/silo/entries/create-an-entry-put.mdx
+++ b/reference/silo/entries/create-an-entry-put.mdx
@@ -2,3 +2,5 @@
 title: "Create an entry"
 openapi: "PUT /silo/v1/entries/{id}"
 ---
+
+<Snippet file="reference/silo/entries/create-an-entry-desc.mdx" />

--- a/reference/transform/jobs/create-a-job-post.mdx
+++ b/reference/transform/jobs/create-a-job-post.mdx
@@ -3,3 +3,5 @@ title: "Create a job (non-idempotent)"
 sidebarTitle: "Create a job (POST)"
 openapi: "POST /transform/v1/jobs"
 ---
+
+<Warning>This is a non-idempotent endpoint. It must be used for developing and testing only. In production, please use [the idempotent version](./create-a-job-put). More info [here](/introduction/idempotency).</Warning>


### PR DESCRIPTION
* This PR moves (along with https://github.com/invopop/api/pull/35) the rich description of the silo entries create endpoint from the OpenAPI spec to the MDX so that mintlify renders it nicely.
* It also adds a warning about the use of non-idempotent endpoints.

Before:
![image](https://github.com/invopop/docs.invopop.com/assets/856/343d8d01-b9ee-4a6d-ac35-e2d58b4130c9)

After:
![image](https://github.com/invopop/docs.invopop.com/assets/856/8ecd5a75-530d-4ba1-a928-559dbaa5b472)


