### PR TITLE
fix typo in MX invoice issue example

### DIFF
--- a/guides/mx-sat.mdx
+++ b/guides/mx-sat.mdx
@@ -171,7 +171,7 @@ Copy and paste the following example in the workflow editor:
                 "generate_pdf": false,
                 "prepaid": false
             },
-            "provider": "sat-mx",
+            "provider": "sat-mx"
         },
         {
             "id": "7a645420-1358-11ef-af96-a18cfb3774fa",


### PR DESCRIPTION
fixes extra comma on the workflow example