### PR TITLE
Changing custom fields' prefix

### DIFF
--- a/guides/integrations/chargebee.mdx
+++ b/guides/integrations/chargebee.mdx
@@ -142,33 +142,35 @@ The following prefixes are used to map custom data from Chargebee to GOBL:
 
 | Prefix | Description | Type | Custom field example |
 |--------|-------------|------|---------------------|
-| `gobl-tax-` | Invoice tax extension | Single line text | `cf_gobl_tax_gr_mydata_invoice_type` |
-| `gobl-customer-` | Customer extension | Single line text | `cf_gobl_customer_mx_cfdi_fiscal_regime` |
-| `gobl-customer-identity-` | Customer identity | Single line text | `cf_gobl_customer_identity_de_tax_number` |
-| `gobl-customer-inbox-` | Customer inbox | Single line text | `cf_gobl_customer_inbox_it_sdi_pec` |
-| `gobl-item-` | Item extension | Single line text | `cf_gobl_item_br_nfse_service` |
-| `gobl-line-vat-` | VAT extension | Single line text | `cf_gobl_line_vat_pt_saft_exemption` |
-| `gobl-purchase-identity-` | Ordering purchase identity | Single line text | `cf_gobl_purchase_identity_CIG` |
+| `gobl_tax_` | Invoice tax extension | Single line text | `cf_gobl_tax_gr_mydata_invoice_type` |
+| `gobl_customer_` | Customer extension | Single line text | `cf_gobl_customer_mx_cfdi_fiscal_regime` |
+| `gobl_customer_identity_` | Customer identity | Single line text | `cf_gobl_customer_identity_de_tax_number` |
+| `gobl_customer_inbox_` | Customer inbox | Single line text | `cf_gobl_customer_inbox_it_sdi_pec` |
+| `gobl_item_` | Item extension | Single line text | `cf_gobl_item_br_nfse_service` |
+| `gobl_line_vat_` | VAT extension | Single line text | `cf_gobl_line_vat_pt_saft_exemption` |
+| `gobl_purchase_identity_` | Ordering purchase identity | Single line text | `cf_gobl_purchase_identity_CIG` |
+
+<note>Notice that all custom fields in Chargebee must start with `cf_`, so make sure you add it to your prefix, as shown in the examples </note>
 
 In addition to the prefixes above, the following keys can be used to set specific GOBL fields:
 
 | Key | Description | Type | Custom field example |
 |-----|-------------|------|---------------------|
-| `gobl-tags` | Invoice tags (comma-separated list) | Single line text | `cf_gobl_tags` |
-| `gobl-addons` | Invoice addons (comma-separated list) | Single line text | `cf_gobl_addons` |
-| `gobl-ordering` | Invoice ordering (full JSON) | Single line text | `cf_gobl_ordering` |
+| `gobl_tags` | Invoice tags (comma-separated list) | Single line text | `cf_gobl_tags` |
+| `gobl_addons` | Invoice addons (comma-separated list) | Single line text | `cf_gobl_addons` |
+| `gobl_ordering` | Invoice ordering (full JSON) | Single line text | `cf_gobl_ordering` |
 
 Finally, you can use the following custom fields to choose which customer's invoices Invopop should import and which ones we shouldn't or to route specific customers to a different workflow:
 
 | Key | Description | Type | Custom field example |
 |-----|-------------|------|---------------------|
-| `invopop-include` | Customer to include when importing (if "True") | Checkbox | `cf_invopop_include` |
-| `invopop-exclude` | Customer to exclude when importing (if "True") | Checkbox | `cf_invopop_exclude` |
-| `invopop-workflow` | Workflow to use for this Customer (overrides the default one) | Dropdown | `cf_invopop_workflow` |
+| `invopop_include` | Customer to include when importing (if "True") | Checkbox | `cf_invopop_include` |
+| `invopop_exclude` | Customer to exclude when importing (if "True") | Checkbox | `cf_invopop_exclude` |
+| `invopop_workflow` | Workflow to use for this Customer (overrides the default one) | Dropdown | `cf_invopop_workflow` |
 
 [Here](https://youtu.be/WgWofLDzDg4) is a video of how you can set up the `invopop-include` in your Chargebee site.
 <Tip>
-You would typically use either `invopop-include` to allowlist the customers to be imported, or `invopop-exclude` to denylist them, but not both. They are optional, though, and if not set, all customers' invoices will be imported.
+You would typically use either `invopop_include` to allowlist the customers to be imported, or `invopop_exclude` to denylist them, but not both. They are optional, though, and if not set, all customers' invoices will be imported.
 </Tip>
 
 <Warning>


### PR DESCRIPTION
@samlown had a hard time understanding what prefixes meant, and part of it was that examples had underscores and prefix hyphen