### PR TITLE
Update MX examples post codes to one in central TZ

### DIFF
--- a/snippets/invoices/mx/sat-b2b.mdx
+++ b/snippets/invoices/mx/sat-b2b.mdx
@@ -2,11 +2,13 @@
 {
   "$schema": "https://gobl.org/draft-0/bill/invoice",
   "$regime": "MX",
-  "$addons": ["mx-cfdi-v4"],
+  "$addons": [
+    "mx-cfdi-v4"
+  ],
   "series": "XXMX",
   "tax": {
     "ext": {
-      "mx-cfdi-issue-place": "21000"
+      "mx-cfdi-issue-place": "44100"
     }
   },
   "supplier": {
@@ -19,9 +21,9 @@
     "addresses": [
       {
         "street": "Julia Navarrete No. 1430",
-        "locality": "Mexicali",
-        "region": "Baja California",
-        "code": "21000",
+        "locality": "Guadalajara",
+        "region": "Jalisco",
+        "code": "44100",
         "country": "MX"
       }
     ],
@@ -31,8 +33,7 @@
       }
     ],
     "ext": {
-      "mx-cfdi-fiscal-regime": "601",
-      "mx-cfdi-post-code": "21000"
+      "mx-cfdi-fiscal-regime": "601"
     }
   },
   "customer": {
@@ -57,7 +58,6 @@
   },
   "lines": [
     {
-      "i": 1,
       "quantity": "1",
       "item": {
         "name": "Standard Plan",

--- a/snippets/invoices/mx/sat-credit-note.mdx
+++ b/snippets/invoices/mx/sat-credit-note.mdx
@@ -1,84 +1,92 @@
 ```json SAT Mexico credit note example
 {
-    "$schema": "https://gobl.org/draft-0/bill/invoice",
-    "$addons": [
-        "mx-cfdi-v4"
-    ],
-    "uuid": "3aea7b56-59d8-4beb-90bd-f8f280d852a0",
-    "issue_date": "2023-05-29",
-    "issue_time": "12:00:00",
-    "type": "credit-note",
-    "series": "CN",
-    "code": "0003",
-    "currency": "MXN",
-    "preceding": [
+  "$schema": "https://gobl.org/draft-0/bill/invoice",
+  "$addons": [
+    "mx-cfdi-v4"
+  ],
+  "uuid": "3aea7b56-59d8-4beb-90bd-f8f280d852a0",
+  "issue_date": "2023-05-29",
+  "issue_time": "12:00:00",
+  "type": "credit-note",
+  "series": "CN",
+  "code": "0003",
+  "currency": "MXN",
+  "preceding": [
+    {
+      "series": "TEST",
+      "code": "0001",
+      "issue_date": "2023-07-10",
+      "issue_time": "12:00:00",
+      "stamps": [
         {
-        "series": "TEST",
-        "code": "0001",
-        "issue_date": "2023-07-10",
-        "issue_time": "12:00:00",
-        "stamps": [
-            {
-            "prv": "sat-uuid",
-            "val": "1fac4464-1111-0000-1111-cd37179db12e"
-            }
-        ]
+          "prv": "sat-uuid",
+          "val": "1fac4464-1111-0000-1111-cd37179db12e"
         }
-    ],
-    "supplier": {
-        "name": "ESCUELA KEMPER URGATE",
-        "tax_id": {
-        "country": "MX",
-        "code": "EKU9003173C9"
-        },
-        "addresses": [
-        {
-            "street": "Calle 1",
-            "locality": "Ciudad de México",
-            "region": "CDMX",
-            "code": "21000",
-            "country": "MX"
-        }
-        ],
-        "ext": {
-        "mx-cfdi-fiscal-regime": "615"
-        }
-    },
-    "customer": {
-        "name": "UNIVERSIDAD ROBOTICA ESPAÑOLA",
-        "tax_id": {
-        "country": "MX",
-        "zone": "65000",
-        "code": "URE180429TM6"
-        },
-        "ext": {
-        "mx-cfdi-fiscal-regime": "624",
-        "mx-cfdi-use": "G01"
-        }
-    },
-    "lines": [
-        {
-        "quantity": "2",
-        "item": {
-            "name": "Cigarros",
-            "ext": {
-            "mx-cfdi-prod-serv": "50211502"
-            },
-            "price": "100.1010",
-            "unit": "piece"
-        },
-        "taxes": [
-            {
-            "cat": "VAT",
-            "rate": "standard"
-            }
-        ],
-        "total": "200.2020"
-        }
-    ],
-    "payment": {
-        "terms": {
-        "notes": "Pago a 30 días."
-        }
+      ]
     }
+  ],
+  "supplier": {
+    "name": "ESCUELA KEMPER URGATE",
+    "tax_id": {
+      "country": "MX",
+      "code": "EKU9003173C9"
+    },
+    "addresses": [
+      {
+        "street": "Julia Navarrete No. 1430",
+        "locality": "Guadalajara",
+        "region": "Jalisco",
+        "code": "44100",
+        "country": "MX"
+      }
+    ],
+    "ext": {
+      "mx-cfdi-fiscal-regime": "615"
+    }
+  },
+  "customer": {
+    "name": "UNIVERSIDAD ROBOTICA ESPAÑOLA",
+    "tax_id": {
+      "country": "MX",
+      "code": "URE180429TM6"
+    },
+    "addresses": [
+      {
+        "locality": "Ciudad de Mexico",
+        "region": "Ciudad de Mexico",
+        "code": "86991",
+        "country": "MX"
+      }
+    ],
+    "ext": {
+      "mx-cfdi-fiscal-regime": "624",
+      "mx-cfdi-use": "G01"
+    }
+  },
+  "lines": [
+    {
+      "quantity": "2",
+      "item": {
+        "name": "Cigarros",
+        "ext": {
+          "mx-cfdi-prod-serv": "50211502"
+        },
+        "price": "100.1010",
+        "unit": "piece"
+      },
+      "taxes": [
+        {
+          "cat": "VAT",
+          "rate": "standard"
+        }
+      ],
+      "total": "200.2020"
+    }
+  ],
+  "payment": {
+    "terms": {
+      "notes": "Pago a 30 días."
+    }
+  }
 }
+```

--- a/snippets/invoices/mx/sat-global.mdx
+++ b/snippets/invoices/mx/sat-global.mdx
@@ -1,78 +1,78 @@
 ```json SAT Mexico global invoice example
 {
-	"$schema": "https://gobl.org/draft-0/bill/invoice",
-	"$addons": [
-		"mx-cfdi-v4"
-	],
-	"$tags": [
-		"global"
-	],
-	"uuid": "3aea7b56-59d8-4beb-90bd-f8f280d852a0",
-	"series": "GLOBAL",
-	"code": "0001",
-	"issue_date": "2025-04-01",
-	"issue_time": "12:00:00",
-	"tax": {
-		"ext": {
-			"mx-cfdi-global-month": "03",
-			"mx-cfdi-global-period": "04",
-			"mx-cfdi-global-year": "2025",
-			"mx-cfdi-issue-place": "21000"
-		}
-	},
-	"supplier": {
-		"name": "ESCUELA KEMPER URGATE",
-		"tax_id": {
-			"country": "MX",
-			"code": "EKU9003173C9"
-		},
-		"ext": {
-			"mx-cfdi-fiscal-regime": "601"
-		}
-	},
-	"lines": [
-		{
-			"quantity": "1",
-			"item": {
-				"ref": "SALE1",
-				"name": "Sale 1",
-				"price": "10.00"
-			},
-			"discounts": [
-				{
-					"percent": "10.0%"
-				}
-			],
-			"taxes": [
-				{
-					"cat": "VAT",
-					"rate": "standard"
-				}
-			]
-		},
-		{
-			"quantity": "1",
-			"item": {
-				"ref": "SALE2",
-				"name": "Sale 2",
-				"price": "20.00"
-			},
-			"taxes": [
-				{
-					"cat": "VAT",
-					"rate": "standard"
-				}
-			]
-		}
-	],
-	"payment": {
-		"advances": [
-			{
-				"key": "cash",
-				"description": "Prepaid",
-				"percent": "100%"
-			}
-		]
-	}
+  "$schema": "https://gobl.org/draft-0/bill/invoice",
+  "$addons": [
+    "mx-cfdi-v4"
+  ],
+  "$tags": [
+    "global"
+  ],
+  "uuid": "3aea7b56-59d8-4beb-90bd-f8f280d852a0",
+  "series": "GLOBAL",
+  "code": "0001",
+  "issue_date": "2025-04-01",
+  "issue_time": "12:00:00",
+  "tax": {
+    "ext": {
+      "mx-cfdi-global-month": "03",
+      "mx-cfdi-global-period": "04",
+      "mx-cfdi-global-year": "2025",
+      "mx-cfdi-issue-place": "44100"
+    }
+  },
+  "supplier": {
+    "name": "ESCUELA KEMPER URGATE",
+    "tax_id": {
+      "country": "MX",
+      "code": "EKU9003173C9"
+    },
+    "ext": {
+      "mx-cfdi-fiscal-regime": "601"
+    }
+  },
+  "lines": [
+    {
+      "quantity": "1",
+      "item": {
+        "ref": "SALE1",
+        "name": "Sale 1",
+        "price": "10.00"
+      },
+      "discounts": [
+        {
+          "percent": "10.0%"
+        }
+      ],
+      "taxes": [
+        {
+          "cat": "VAT",
+          "rate": "standard"
+        }
+      ]
+    },
+    {
+      "quantity": "1",
+      "item": {
+        "ref": "SALE2",
+        "name": "Sale 2",
+        "price": "20.00"
+      },
+      "taxes": [
+        {
+          "cat": "VAT",
+          "rate": "standard"
+        }
+      ]
+    }
+  ],
+  "payment": {
+    "advances": [
+      {
+        "key": "cash",
+        "description": "Prepaid",
+        "percent": "100%"
+      }
+    ]
+  }
 }
 ```

--- a/snippets/invoices/mx/sat-simplified.mdx
+++ b/snippets/invoices/mx/sat-simplified.mdx
@@ -1,77 +1,83 @@
 ```json SAT Mexico simplified invoice example
 {
-	"$schema": "https://gobl.org/draft-0/bill/invoice",
-	"$addons": [
-		"mx-cfdi-v4"
-	],
-	"$tags": [
-		"simplified"
-	],
-	"uuid": "3aea7b56-59d8-4beb-90bd-f8f280d852a0",
-	"series": "TEST",
-	"code": "00001",
-	"issue_date": "2023-07-10",
-	"issue_time": "12:00:00",
-	"tax": {
-		"ext": {
-			"mx-cfdi-issue-place": "21000"
-		}
-	},
-	"supplier": {
-		"name": "ESCUELA KEMPER URGATE",
-		"tax_id": {
-			"country": "MX",
-			"code": "EKU9003173C9"
-		},
-		"ext": {
-			"mx-cfdi-fiscal-regime": "601"
-		}
-	},
-	"lines": [
-		{
-			"quantity": "1",
-			"item": {
-				"name": "Cobro por tarjetas",
-				"price": "10.00",
-				"ext": {
-					"mx-cfdi-prod-serv": "84141602"
-				}
-			},
-			"discounts": [
-				{
-					"percent": "10.0%"
-				}
-			],
-			"taxes": [
-				{
-					"cat": "VAT",
-					"rate": "standard"
-				}
-			]
-		},
-		{
-			"quantity": "1",
-			"item": {
-				"name": "Porcentaje sobre GMV",
-				"price": "10.00",
-				"unit": "service",
-				"ext": {
-					"mx-cfdi-prod-serv": "80141628"
-				}
-			},
-			"taxes": [
-				{
-					"cat": "VAT",
-					"rate": "standard"
-				}
-			]
-		}
-	],
-	"payment": {
-		"terms": {
-			"notes": "Condiciones de pago"
-		}
-	}
+  "$schema": "https://gobl.org/draft-0/bill/invoice",
+  "$regime": "MX",
+  "$addons": [
+    "mx-cfdi-v4"
+  ],
+  "$tags": [
+    "simplified"
+  ],
+  "uuid": "3aea7b56-59d8-4beb-90bd-f8f280d852a0",
+  "type": "standard",
+  "series": "TEST",
+  "code": "00001",
+  "issue_date": "2023-07-10",
+  "issue_time": "12:00:00",
+  "currency": "MXN",
+  "tax": {
+    "ext": {
+      "mx-cfdi-doc-type": "I",
+      "mx-cfdi-issue-place": "44100"
+    }
+  },
+  "supplier": {
+    "name": "ESCUELA KEMPER URGATE",
+    "tax_id": {
+      "country": "MX",
+      "code": "EKU9003173C9"
+    },
+    "ext": {
+      "mx-cfdi-fiscal-regime": "601"
+    }
+  },
+  "lines": [
+    {
+      "quantity": "1",
+      "item": {
+        "name": "Cobro por tarjetas",
+        "price": "10.00",
+        "ext": {
+          "mx-cfdi-prod-serv": "84141602"
+        }
+      },
+      "discounts": [
+        {
+          "percent": "10.0%",
+          "amount": "1.00"
+        }
+      ],
+      "taxes": [
+        {
+          "cat": "VAT",
+          "rate": "standard",
+          "percent": "16.0%"
+        }
+      ]
+    },
+    {
+      "quantity": "1",
+      "item": {
+        "name": "Porcentaje sobre GMV",
+        "price": "10.00",
+        "unit": "service",
+        "ext": {
+          "mx-cfdi-prod-serv": "80141628"
+        }
+      },
+      "taxes": [
+        {
+          "cat": "VAT",
+          "rate": "standard",
+          "percent": "16.0%"
+        }
+      ]
+    }
+  ],
+  "payment": {
+    "terms": {
+      "notes": "Condiciones de pago"
+    }
+  }
 }
-
 ```


### PR DESCRIPTION
* Uses a post code in Mexico Central TZ to avoid errors when sending with the default `issue_time`
* Harmonizes formatting
* Removes deprecated extensions