### PR TITLE
Clarify KSeF guide: separate send-only vs send & receive setup

### DIFF
--- a/guides/pl-ksef.mdx
+++ b/guides/pl-ksef.mdx
@@ -76,11 +76,6 @@ The initial connection requires no configuration.
 </Step>
 
 <Step title="Connect the Cron app (receive only)">
-
-  <Info>
-    This step is only required if you want to **receive** invoices from KSeF. If you only need to send invoices, skip this step.
-  </Info>
-
   1. Navigate to **Configuration** → **Apps**
   2. Find **Cron** in the app discovery list
   3. Click **Connect** to activate
@@ -121,10 +116,6 @@ The initial connection requires no configuration.
 
 <Step title="Configure invoice import workflow (receive only)">
 
-<Info>
-  This step is only required if you want to **receive** invoices from KSeF. If you only need to send invoices, skip this step.
-</Info>
-
 This workflow imports individual invoices from KSeF when they are received. It is automatically triggered by the sync workflow for each invoice found.
 
 <Tabs>
@@ -164,10 +155,6 @@ This workflow imports individual invoices from KSeF when they are received. It i
 </Step>
 
 <Step title="Configure invoice sync workflow (receive only)">
-
-<Info>
-  This step is only required if you want to **receive** invoices from KSeF. If you only need to send invoices, skip this step.
-</Info>
 
 This workflow syncs all received invoices for a party within a specific time range. It creates import jobs for each invoice found.
 

--- a/guides/pl-ksef.mdx
+++ b/guides/pl-ksef.mdx
@@ -20,7 +20,7 @@ Invoices are encoded in FA(3), a strict XML format that enforces standardized fi
 
 This guide covers three key processes:
 
-- [Party registration](#register-a-party-for-test-environment): Registering suppliers in the KSeF system
+- [Party registration](#running): Registering suppliers in the KSeF system
 - [Invoice issuance](#send-an-invoice): Creating and sending FA(3) invoices through KSeF
 - [Invoice import](#import-received-invoices): Importing received invoices from KSeF
 

--- a/guides/pl-ksef.mdx
+++ b/guides/pl-ksef.mdx
@@ -5,7 +5,8 @@ description: "Register suppliers and issue electronic invoices through Poland's 
 ---
 
 import PolandResources from '/snippets/tables/poland-resources.mdx';
-import PartyRegistrationWorkflow from '/snippets/workflows/pl/pl-register.mdx';
+import PartyRegistrationSendWorkflow from '/snippets/workflows/pl/pl-register.mdx';
+import PartyRegistrationReceiveWorkflow from '/snippets/workflows/pl/pl-register-receive.mdx';
 import SendInvoiceWorkflow from '/snippets/workflows/pl/pl-send.mdx';
 import ExampleAccordion from '/snippets/invoices/pl/accordion.mdx';
 import ImportInvoiceWorkflow from '/snippets/workflows/pl/pl-import.mdx';
@@ -17,11 +18,27 @@ KSeF (Krajowy System e-Faktur) 2.0 is Poland's mandatory national e-invoicing sy
 
 Invoices are encoded in FA(3), a strict XML format that enforces standardized fields for domestic and cross-border transactions. The KSeF system validates all submitted invoices in real-time and assigns a unique KSeF ID upon successful clearance.
 
-This guide covers two key processes:
+This guide covers three key processes:
 
-- [Party Registration](#register-a-party-for-test-environment): Registering suppliers in the KSeF system
-- [Invoice Issuance](#send-an-invoice): Creating and sending FA(3) invoices through KSeF
-- [Invoice Import](#invoice-import): Importing received invoices from KSeF
+- [Party registration](#register-a-party-for-test-environment): Registering suppliers in the KSeF system
+- [Invoice issuance](#send-an-invoice): Creating and sending FA(3) invoices through KSeF
+- [Invoice import](#import-received-invoices): Importing received invoices from KSeF
+
+Invopop supports two use cases that require different configurations:
+
+- **Send only**: You issue invoices through KSeF on behalf of your suppliers. This is the simplest setup and does not require the Cron app or import/sync workflows.
+- **Send & receive**: In addition to sending, you also want to automatically import invoices received by your suppliers from KSeF. This requires the Cron app to periodically check for new invoices.
+
+The table below summarizes which components are needed for each use case:
+
+| Component | Send only | Send & receive |
+|-----------|:---------:|:--------------:|
+| Poland app | ✓ | ✓ |
+| Cron app | — | ✓ |
+| Send invoice workflow | ✓ | ✓ |
+| Import invoice workflow | — | ✓ |
+| Sync invoices workflow | — | ✓ |
+| Registration workflow | Send | Receive |
 
 
 
@@ -42,15 +59,7 @@ To issue invoices through KSeF, you will need:
 
 ## Setup
 
-There are six key processes to prepare:
-- Connect the Poland app
-- Connect the Cron app
-- Configure an invoice sending workflow
-- Configure an invoice import workflow
-- Configure an invoice sync workflow
-- Configure a party registration workflow
-
-All of the following steps must be carried out from the [Invopop Console](https://console.invopop.com).
+All of the following steps must be carried out from the [Invopop Console](https://console.invopop.com). If you only need to **send** invoices, you can skip the steps marked as "receive only".
 
 <Steps>
 
@@ -66,7 +75,12 @@ All of the following steps must be carried out from the [Invopop Console](https:
 The initial connection requires no configuration.
 </Step>
 
-<Step title="Connect the Cron app">
+<Step title="Connect the Cron app (receive only)">
+
+  <Info>
+    This step is only required if you want to **receive** invoices from KSeF. If you only need to send invoices, skip this step.
+  </Info>
+
   1. Navigate to **Configuration** → **Apps**
   2. Find **Cron** in the app discovery list
   3. Click **Connect** to activate
@@ -105,7 +119,11 @@ The initial connection requires no configuration.
 
 </Step>
 
-<Step title="Configure invoice import workflow">
+<Step title="Configure invoice import workflow (receive only)">
+
+<Info>
+  This step is only required if you want to **receive** invoices from KSeF. If you only need to send invoices, skip this step.
+</Info>
 
 This workflow imports individual invoices from KSeF when they are received. It is automatically triggered by the sync workflow for each invoice found.
 
@@ -145,7 +163,11 @@ This workflow imports individual invoices from KSeF when they are received. It i
 
 </Step>
 
-<Step title="Configure invoice sync workflow">
+<Step title="Configure invoice sync workflow (receive only)">
+
+<Info>
+  This step is only required if you want to **receive** invoices from KSeF. If you only need to send invoices, skip this step.
+</Info>
 
 This workflow syncs all received invoices for a party within a specific time range. It creates import jobs for each invoice found.
 
@@ -190,6 +212,11 @@ Configure the **Sync received invoices from KSeF** step to reference the import 
 
 <Step title="Configure party registration workflow">
 
+There are two registration workflow templates depending on your use case:
+
+- **Send only**: Registers the party in KSeF so you can issue invoices on their behalf. Does not require the Cron app.
+- **Send & receive**: Registers the party and subscribes them to periodic invoice imports via the [Cron app](/apps/cron). Requires the import and sync workflows configured in the previous steps.
+
 <Frame>
   <img
     width="400"
@@ -207,13 +234,15 @@ Configure the **Sync received invoices from KSeF** step to reference the import 
 
   In **live workspaces** no configuration is available, all suppliers are registered in the KSeF production environment.
 
+#### Send only
+
+Use this template if you only need to **send** invoices through KSeF.
+
 <Tabs>
   <Tab title="Template">
-    <Card iconType="duotone" title="KSeF party registration workflow" icon="code-branch" href="https://console.invopop.com/redirect/workflows/new?template=pl-register" cta="Add to my workspace">
-      Registers a party (supplier) with the KSeF system and subscribes them to periodic invoice imports.
+    <Card iconType="duotone" title="KSeF party registration workflow (send)" icon="code-branch" href="https://console.invopop.com/redirect/workflows/new?template=pl-register" cta="Add to my workspace">
+      Registers a party (supplier) with the KSeF system for sending invoices.
     </Card>
-
-    After adding the template, open the **Subscribe to periodic import** step and set the **Workflow** field to the sync workflow created in the previous step and the **Interval** to your preferred frequency.
   </Tab>
   <Tab title="Code">
     Copy and paste into a new [Empty Party workflow](https://console.invopop.com/redirect/workflows/new?template=empty-party) code view.
@@ -222,21 +251,58 @@ Configure the **Sync received invoices from KSeF** step to reference the import 
       The template uses test mode by default (for sandbox). To use demo mode in sandbox, add `"config": {"environment": "demo"}` to the **Register for KSeF** step. In Invopop production, the workflow automatically targets the KSeF production environment.
     </Note>
 
-    <PartyRegistrationWorkflow />
-
-    After pasting the code, switch to the form view, open the **Subscribe to periodic import** step and set the **Workflow** field to the sync workflow and the **Interval** to your preferred frequency.
+    <PartyRegistrationSendWorkflow />
   </Tab>
   <Tab title="Build from scratch">
     Before starting, review the [workflows guide](/guides/workflows) to understand the general setup process.
 
-    In [Console](https://console.invopop.com), create a new workflow and choose [Empty Party workflow](https://console.invopop.com/redirect/workflows/new?template=empty-party) as the base. Then name the workflow with a descriptive label such as "KSeF Register Party".
+    In [Console](https://console.invopop.com), create a new workflow and choose [Empty Party workflow](https://console.invopop.com/redirect/workflows/new?template=empty-party) as the base. Then name the workflow with a descriptive label such as "KSeF Register Party (Send)".
 
     The new workflow will need to perform these steps:
 
     1. **Set state** - To `Processing`
     2. **Register party in KSeF (Poland)** - Registers the party with KSeF and generates a registration link. Configure with your chosen environment (test, demo, or production).
     3. **Wait for KSeF certificate upload** - Waits for the supplier to generate and upload their KSeF certificate (automatically skipped in test mode)
-    4. **Subscribe to periodic import** - Uses the [Cron app](/apps/cron) to schedule periodic execution of the sync workflow. Configure with the sync workflow and your preferred interval.
+    4. **Set state** - To `Registered`
+
+    Finally, in the **Error handling** area, add the **Set state** action and select `Error`.
+  </Tab>
+</Tabs>
+
+#### Send & receive
+
+Use this template if you also need to **receive** invoices from KSeF. This template includes a Cron subscription step that periodically triggers the sync workflow to check for new invoices.
+
+<Tabs>
+  <Tab title="Template">
+    <Card iconType="duotone" title="KSeF party registration workflow (receive)" icon="code-branch" href="https://console.invopop.com/redirect/workflows/new?template=pl-register-receive" cta="Add to my workspace">
+      Registers a party (supplier) with the KSeF system and subscribes them to periodic invoice imports.
+    </Card>
+
+    After adding the template, open the **Subscribe to periodic KSeF sync** step and set the **Workflow** field to the sync workflow created in the previous step and the **Interval** to your preferred frequency.
+  </Tab>
+  <Tab title="Code">
+    Copy and paste into a new [Empty Party workflow](https://console.invopop.com/redirect/workflows/new?template=empty-party) code view.
+
+    <Note>
+      The template uses test mode by default (for sandbox). To use demo mode in sandbox, add `"config": {"environment": "demo"}` to the **Register for KSeF** step. In Invopop production, the workflow automatically targets the KSeF production environment.
+    </Note>
+
+    <PartyRegistrationReceiveWorkflow />
+
+    After pasting the code, switch to the form view, open the **Subscribe to periodic KSeF sync** step and set the **Workflow** field to the sync workflow and the **Interval** to your preferred frequency.
+  </Tab>
+  <Tab title="Build from scratch">
+    Before starting, review the [workflows guide](/guides/workflows) to understand the general setup process.
+
+    In [Console](https://console.invopop.com), create a new workflow and choose [Empty Party workflow](https://console.invopop.com/redirect/workflows/new?template=empty-party) as the base. Then name the workflow with a descriptive label such as "KSeF Register Party (Receive)".
+
+    The new workflow will need to perform these steps:
+
+    1. **Set state** - To `Processing`
+    2. **Register party in KSeF (Poland)** - Registers the party with KSeF and generates a registration link. Configure with your chosen environment (test, demo, or production).
+    3. **Wait for KSeF certificate upload** - Waits for the supplier to generate and upload their KSeF certificate (automatically skipped in test mode)
+    4. **Subscribe to periodic KSeF sync** - Uses the [Cron app](/apps/cron) to schedule periodic execution of the sync workflow. Configure with the sync workflow and your preferred interval.
     5. **Set state** - To `Registered`
 
     Finally, in the **Error handling** area, add the **Set state** action and select `Error`.
@@ -457,7 +523,11 @@ The invoice will be validated, converted to FA(3) XML format, and sent to KSeF. 
 
 ### Import received invoices
 
-Once you've configured the import, sync, and registration workflows, the [Cron app](/apps/cron) automatically triggers the sync workflow at the interval configured in the registration workflow's **Subscribe to periodic import** step. Here is how it works:
+<Note>
+  This section only applies if you configured the **send & receive** setup. If you only need to send invoices, you can skip this section entirely.
+</Note>
+
+Once you've configured the import, sync, and registration (receive) workflows, the [Cron app](/apps/cron) automatically triggers the sync workflow at the interval configured in the registration workflow's **Subscribe to periodic KSeF sync** step. Here is how it works:
 
 1. **Cron scheduling**: The [Cron app](/apps/cron) creates a job for the sync workflow at each configured interval, passing the time window (`from` and `upto`) to process
 2. **Sync workflow**: The sync workflow queries KSeF for all invoices received within the time window
@@ -466,7 +536,7 @@ Once you've configured the import, sync, and registration workflows, the [Cron a
 5. **Organization**: Imported invoices are automatically placed in the configured folder (typically "Invoices · Expenses") with a `Registered` state
 
 <Info>
-  Each party is subscribed to periodic imports during registration. To use a different interval for a specific party, adjust the **Subscribe to periodic import** step settings in the registration workflow before running it. To skip automatic imports for a party, remove the cron subscription step before running it.
+  Each party is subscribed to periodic imports during registration when using the **receive** registration workflow. To use a different interval for a specific party, adjust the **Subscribe to periodic KSeF sync** step settings in the registration workflow before running it.
 </Info>
 
 #### Manual import

--- a/guides/pl-ksef.mdx
+++ b/guides/pl-ksef.mdx
@@ -38,7 +38,7 @@ The table below summarizes which components are needed for each use case:
 | Send invoice workflow | ✓ | ✓ |
 | Import invoice workflow | — | ✓ |
 | Sync invoices workflow | — | ✓ |
-| Registration workflow | Send | Receive |
+| Registration workflow | [Send](#send-only) | [Send & receive](#send--receive) |
 
 
 


### PR DESCRIPTION
## Summary

- Adds a clear distinction between **send only** and **send & receive** use cases in the KSeF Poland guide, with a summary table showing which components (apps, workflows, registration template) are needed for each
- Marks Cron app, import workflow, and sync workflow setup steps as "receive only" so send-only users know they can skip them
- Splits the party registration workflow section into two sub-sections with separate templates: `pl-register` (send) and `pl-register-receive` (send & receive, includes Cron subscription)

## Test plan

- [x] Verify the guide renders correctly in Mintlify (summary table, Info callouts, tabs for both registration templates)
- [x] Confirm the `pl-register-receive` template link resolves correctly in the Console
- [x] Check that anchor links in the introduction (#import-received-invoices) work

🤖 Generated with [Claude Code](https://claude.com/claude-code)