### PR TITLE
France flow2 docs and reordering

### DIFF
--- a/compliance/france.mdx
+++ b/compliance/france.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Invoicing compliance in France"
 sidebarTitle: "Compliance"
-description: "France's mandatory e-invoicing requirements, Peppol and ChorusPro implementation, and e-reporting obligations for B2B and B2G transactions"
+description: "France's mandatory e-invoicing and e-reporting framework — Plateforme Agréée model, Annuaire, PPF, ChorusPro, and the September 2026 mandate."
 ---
 
 import FranceResources from '/snippets/tables/france-resources.mdx';
@@ -14,85 +14,83 @@ import FranceResources from '/snippets/tables/france-resources.mdx';
 
 ## Executive summary
 
-France operates a mandatory e-invoicing system through the **Peppol network**, where businesses connect through certified **Plateforme Agréée (PA)** platforms. The system uses a **centralized model** where each PA looks up the buyer in the state **Annuaire** directory and routes invoices to the buyer's PA over Peppol. In parallel, the PA submits the mandated e-invoice and e-report dataset to the government **data concentrator**, where the state stores VAT data for each transaction.
+France's B2B e-invoicing reform runs on a **five-corner model**: businesses connect through a certified **Plateforme Agréée (PA)**, which routes each invoice over the Peppol network to the buyer's PA, while the PA also forwards the mandated dataset to the **PPF** (_Portail Public de Facturation_) — the government data concentrator that stores VAT data per transaction. PAs look up routing through the **Annuaire**, France's national directory of e-invoicing endpoints.
 
-France's e-invoicing system encompasses different models for different transaction types. **B2G e-invoicing** has been mandatory since 2020, with all suppliers invoicing French public entities required to submit electronic invoices through **ChorusPro**, a government-provided platform that accepts multiple e-invoicing formats based on EN 16931 with Chorus Pro extensions. **B2B e-invoicing** is being rolled out in phases: a voluntary pilot phase in 2025, followed by mandatory acceptance for all businesses and mandatory issuance for large and medium-sized companies in September 2026, with full mandatory issuance for all businesses by September 2027. B2C invoicing is not required under the new e-invoicing mandate.
+Different transaction types follow different rules:
 
-France handles e-reporting through approved **PA (Plateforme Agréé)** platforms as part of its electronic invoicing reform, creating a "five corner model" where e-reporting is integrated into the e-invoicing process. The system relies on the Peppol network infrastructure with additional French-specific requirements, and e-reporting becomes mandatory alongside e-invoicing in September 2026 for large and medium-sized companies, and September 2027 for all businesses.
+- **B2G** has been mandatory since 2020 via [ChorusPro](#choruspro).
+- **B2B** is being rolled out in phases: voluntary pilot in 2025, mandatory **receive** for everyone plus mandatory **issuance** for large and medium-sized companies on 1 September 2026, mandatory issuance for all businesses on 1 September 2027.
+- **B2C** is exempt from e-invoicing but is subject to **e-reporting** to the PPF.
+- **Cross-border B2B** is also out of scope for e-invoicing and reported via e-reporting.
 
-Invopop is an officially approved PA platform (Plateforme Agréé) by the French tax administration and provides coverage for French invoicing through the **Peppol** and **ChorusPro France** apps. The platform also offers integrations with Stripe and Chargebee, enabling businesses to issue compliant invoices directly from their merchant or ERP platforms while automatically handling the complex PA routing and data concentrator submission process.
+Invopop is an [officially approved Plateforme Agréée](https://www.impots.gouv.fr/je-consulte-la-liste-des-plateformes-agreees) under the DGFiP mandate. Coverage:
 
-## E-invoicing in France
+| | App / Guide |
+|---|---|
+| B2G via ChorusPro | [ChorusPro France](/apps/choruspro-france) · [Chorus Pro guide](/guides/fr-chorus-pro) |
+| B2B PA — registration, invoicing, status | [PA guide](/guides/fr-pa) |
+| B2C and cross-border e-reporting | [PA reporting guide](/guides/fr-pa-reporting) (in development) |
 
-France runs on the Peppol network. Businesses connect through a certified **Plateforme Agréée** (PA). For each invoice, the PA looks up the buyer in the state **Annuaire** and routes the document to the buyer's PA over Peppol. In paralell, the PA submits the mandated e-invoice/e-report dataset to the government **data concentrator**, where the state stores the VAT data for each transaction.
+Stripe and Chargebee integrations let merchants and ERPs issue compliant invoices with the PA routing handled automatically.
+
+## E-invoicing
 
 <AccordionGroup>
-  <Accordion title="Peppol (B2B, B2G)">
-    <Warning>
-    B2B e-invoicing will be rolled out in phases:
-    - **2025**: Pilot phase
-    - **September 2026**: All businesses must accept e-invoices; large and medium-sized companies must issue e-invoices
-    - **September 2027**: All businesses must issue e-invoices
-    </Warning>
-
-    Though France has not explicitly mandated the use of the Peppol network, it is the default infrastructure for e-invoicing in France.
+  <Accordion title="Plateforme Agréée (B2B)">
+    Each business connects through a certified PA. The PA looks up the buyer in the Annuaire and routes the invoice over Peppol to the buyer's PA, while forwarding a simplified **F1 invoice** to the PPF as the fifth corner.
 
     |            |             |
     |------------|-------------|
-    | **Models** | B2G |
-    | **Status** | Mandatory |
-    | **Format** | UBL 2.0, UBL, CII, CPP, FacturX, PES, PDF, Peppol BIS |
-    | **Infrastructure** | Peppol |
-    | **Model** | Centralized |
-    | **Scope & Deadline** | Mandatory for all businesses invoicing public authorities since 2020 |
-    | **Agency** | [Direction Générale des Finances Publiques](https://www.economie.gouv.fr/dgfip) (DGFIP) |
-    | **Invopop support** | Yes |
+    | **Models** | B2B |
+    | **Status** | Mandatory (phased — see below) |
+    | **Format** | UBL (Peppol France CIUS), CII, Factur-X (PDF/A-3 with embedded CII) |
+    | **Infrastructure** | Peppol + Annuaire + PPF |
+    | **Model** | Five-corner |
+    | **Scope & deadline** | 1 Sept 2026: all businesses must receive; large and medium-sized companies must issue. 1 Sept 2027: all businesses must issue. |
+    | **Agency** | [Direction Générale des Finances Publiques](https://www.economie.gouv.fr/dgfip) (DGFiP) |
+    | **Invopop support** | [PA guide](/guides/fr-pa) |
 
     <Columns cols="2">
       <Card title="Peppol" size="20" icon="https://assets.invopop.com/apps/peppol/icon.svg" href="/apps/peppol" horizontal>Get covered →</Card>
+      <Card title="PA guide" size="20" icon="book" href="/guides/fr-pa" horizontal>Get covered →</Card>
     </Columns>
-
   </Accordion>
 
   <Accordion title="ChorusPro (B2G)">
-    B2G e-invoicing has been mandatory in France since 2020. All suppliers invoicing French public entities must submit electronic invoices through ChorusPro, a mandatory service provided by the French government for invoicing French public institutions. The platform allows businesses to upload invoices in multiple e-invoicing formats and track them throughout the French public administration process.
+    B2G e-invoicing has been mandatory in France since 2020. All suppliers invoicing French public entities submit electronic invoices through ChorusPro.
 
     |            |             |
     |------------|-------------|
     | **Models** | B2G |
-    | **Format** | EN 16931 with Chorus Pro extensions |
+    | **Status** | Mandatory since 2020 |
+    | **Format** | EN 16931 with ChorusPro extensions (CII) |
     | **Infrastructure** | [ChorusPro](https://portail.chorus-pro.gouv.fr/) |
     | **Model** | Centralized |
-    | **Scope & Deadline** | Mandatory for all businesses invoicing public authorities since 2020 |
-    | **Agency** | [Direction Générale des Finances Publiques](https://www.economie.gouv.fr/dgfip) (DGFIP) |
-    | **Invopop support** | [ChorusPro France App](/apps/choruspro-france) |
+    | **Agency** | [Direction Générale des Finances Publiques](https://www.economie.gouv.fr/dgfip) (DGFiP) |
+    | **Invopop support** | [Chorus Pro guide](/guides/fr-chorus-pro) |
 
     <Columns cols="2">
       <Card title="Chorus Pro France" size="20" icon="https://assets.invopop.com/apps/chroruspro/icon.svg" href="/apps/choruspro-france" horizontal>Get covered →</Card>
     </Columns>
-
   </Accordion>
 </AccordionGroup>
-
-<Note>B2C invoicing is not required in France under the new e-invoicing mandate.</Note>
 
 ## E-reporting
 
-France handles e-reporting through approved PA (Plateforme Agréé) platforms as part of its electronic invoicing reform. Invopop is an officially approved PA platform, as listed on the French government’s [official list of approved platforms](https://www.impots.gouv.fr/liste-des-plateformes-agreees-immatriculees-sous-reserve).
+E-reporting covers the transactions out of scope for e-invoicing — B2C sales, cross-border B2B, and any flow where one party is not registered in the Annuaire. PAs aggregate transaction and payment data and submit periodic reports to the PPF on a cadence tied to the party's VAT regime.
 
-Invopop is an approved platform (PA) by the French tax administration, meaning we have successfully registered and passed the technical approval process necessary for the registration procedure.
+E-reporting becomes mandatory on the same dates as e-invoicing issuance: 1 Sept 2026 for large and medium-sized companies, 1 Sept 2027 for all businesses.
 
 <AccordionGroup>
   <Accordion title="PPF (Portail Public de Facturation)">
-    The French PA system relies on the Peppol network infrastructure with additional French-specific requirements. This creates a “five corner model” for e-invoicing compliance in which e-reporting is integrated into the e-invoicing process.
-      |                     |                                               |
-      |---------------------|-----------------------------------------------|
-      | **Format**          | Any Peppol France compliant format                                   |
-      | **Scope&#160;&&#160;deadline**| September 1, 2026 for companies with more than 250 employees and exceeding either €50 million in turnover or €43 million in balance sheet, followed by September 1, 2027 for small and micro-businesses | 
-      | **Invopop support**| Coming Q1 2026 |
+    |                     |                                               |
+    |---------------------|-----------------------------------------------|
+    | **Format**          | GOBL with the `fr-ctc-flow10-v1` add-on (under development) |
+    | **Cadence**         | Determined by VAT regime — ten-day, monthly, or bimonthly |
+    | **Scope & deadline**| 1 Sept 2026 for large and medium-sized companies, 1 Sept 2027 for all businesses |
+    | **Invopop support** | In development — see [reporting guide](/guides/fr-pa-reporting) |
   </Accordion>
 </AccordionGroup>
-
 
 ## Regulation
 
@@ -214,15 +212,15 @@ Invopop is an approved platform (PA) by the French tax administration, meaning w
   </Accordion>
 
   <Accordion title="Implementation timeline">
-    France has announced a phased approach to B2B e-invoicing:
+    France's phased rollout for B2B e-invoicing and e-reporting:
 
-    * **2025**: Voluntary pilot phase for businesses to test systems
-    * **September 2026**:
+    * **2025**: Voluntary pilot phase
+    * **1 September 2026**:
       - All businesses must be able to receive e-invoices
       - Large and medium-sized companies must issue e-invoices
       - E-reporting becomes mandatory for these companies
-    * **September 2027**:
-      - All remaining businesses must issue e-invoices
+    * **1 September 2027**:
+      - All remaining businesses (small and micro-businesses) must issue e-invoices
       - E-reporting becomes mandatory for all businesses
 
     The implementation has been delayed multiple times to ensure businesses and platforms are adequately prepared.
@@ -231,7 +229,7 @@ Invopop is an approved platform (PA) by the French tax administration, meaning w
   <Accordion title="Related resources">
     * [France delays mandatory e-invoicing to March 2026](https://www.invopop.com/blog/france-e-invoicing-delayed-march-2026) - 18 September, 2023
     * [Electronic invoicing in France](https://www.invopop.com/blog/electronic-invoicing-in-france) - 14 February, 2023
-    * [Government article in English](https://entreprendre.service-public.gouv.fr/actualites/A15683?lang=en) - 29 August, 2025 
+    * [Government article in English](https://entreprendre.service-public.gouv.fr/actualites/A15683?lang=en) - 29 August, 2025
   </Accordion>
 </AccordionGroup>
 

--- a/docs.json
+++ b/docs.json
@@ -286,7 +286,16 @@
 								"group": "🇫🇷 France",
 								"pages": [
 									"/guides/fr-chorus-pro",
-									"/guides/fr-pa"
+									{
+										"group": "Plateforme Agréée (PA)",
+										"pages": [
+											"/guides/fr-pa",
+											"/guides/fr-pa-registration",
+											"/guides/fr-pa-invoicing",
+											"/guides/fr-pa-status",
+											"/guides/fr-pa-reporting"
+										]
+									}
 								]
 							},
 							"/guides/gr-iapr",
@@ -768,11 +777,35 @@
 
 		{
 			"source": "/guides/countries/fr-facturx",
-			"destination": "/guides/fr-pa#invoice-formats"
+			"destination": "/guides/fr-pa-invoicing#formats"
 		},
 		{
 			"source": "/guides/fr-facturx",
-			"destination": "/guides/fr-pa#invoice-formats"
+			"destination": "/guides/fr-pa-invoicing#formats"
+		},
+		{
+			"source": "/guides/fr-pa#annuaire-registration",
+			"destination": "/guides/fr-pa-registration"
+		},
+		{
+			"source": "/guides/fr-pa#invoice-formats",
+			"destination": "/guides/fr-pa-invoicing#formats"
+		},
+		{
+			"source": "/guides/fr-pa#sending",
+			"destination": "/guides/fr-pa-invoicing#sending"
+		},
+		{
+			"source": "/guides/fr-pa#receiving",
+			"destination": "/guides/fr-pa-invoicing#receiving"
+		},
+		{
+			"source": "/guides/fr-pa#status",
+			"destination": "/guides/fr-pa-status"
+		},
+		{
+			"source": "/guides/fr-pa#reporting",
+			"destination": "/guides/fr-pa-reporting"
 		},
 		{
 			"source": "/guides/countries/de-xrechnung",

--- a/faq/france.mdx
+++ b/faq/france.mdx
@@ -8,15 +8,22 @@ sidebarTitle: "FAQ"
 ## General
 
 <AccordionGroup>
-    <Accordion title="How are credit notes and corrections handled?">
-  E-invoices cannot be deleted or retracted. Instead a credit note or corrected invoice can be sent referencing the original invoice. 
+  <Accordion title="Is Invopop ready for the September 2026 mandate?">
+    Invopop is an [officially approved Plateforme Agréée](https://www.impots.gouv.fr/je-consulte-la-liste-des-plateformes-agreees) under the DGFiP mandate. Registration, invoicing, and lifecycle status are available today; e-reporting (Flow 10) is in active development. See the [PA hub readiness matrix](/guides/fr-pa) for the current state.
+  </Accordion>
+  <Accordion title="What's the difference between e-invoicing and e-reporting?">
+    **E-invoicing** transmits the invoice itself between trading parties via Peppol, with the PPF receiving the regulated dataset as a fifth corner. **E-reporting** is a periodic submission to the PPF covering transactions out of scope for e-invoicing — B2C, cross-border B2B, and any flow where the counterparty is not in the Annuaire.
+  </Accordion>
+  <Accordion title="Do I need to act if I'm B2C-only?">
+    Yes — B2C is exempt from e-invoicing but is subject to e-reporting. From 1 September 2026 (large and medium-sized companies) or 1 September 2027 (all businesses), B2C transactions must be reported periodically to the PPF.
+  </Accordion>
+  <Accordion title="How are credit notes and corrections handled?">
+    E-invoices cannot be deleted or retracted. Instead a credit note or corrected invoice is sent referencing the original.
   </Accordion>
   <Accordion title="How can I view an XML attached to a PDF?">
-    In Factur-X PDFs, the XML file is embedded within the PDF itself. To extract and view it, you can use the `Attachments` section in Adobe Acrobat Reader.
-
-    Alternatively, you can use specialized tools like the [SysTools PDF Extractor](https://www.systoolsgroup.com/pdf/extractor/) to extract the XML file.
+    In Factur-X PDFs, the XML file is embedded within the PDF itself. To extract and view it, use the `Attachments` section in Adobe Acrobat Reader, or a tool like the [SysTools PDF Extractor](https://www.systoolsgroup.com/pdf/extractor/).
   </Accordion>
-</AccordionGroup>  
+</AccordionGroup>
 
 ## E-reporting
 
@@ -24,53 +31,44 @@ sidebarTitle: "FAQ"
   <Accordion title="Do I have to e-report imports?">
     If the supply is taxable under French reverse charge (i.e. VAT is paid on import), the transaction must be e-reported.
   </Accordion>
-  
+
   <Accordion title="When should I e-report payment data?">
     Report payment data only when VAT is due on receipt of payment, such as for services under "cash VAT" (TVA sur les encaissements).
   </Accordion>
-  
-  <Accordion title="Does this apply to foreign businesses without a Fixed Establishment (FE) in France?">
-    E-invoicing does not apply. If the business is liable to French VAT, e-reporting applies to the relevant flows. E-reporting for reverse-charge VAT and intra EU-acquisitions are deferred till 1 September 2027.
-  </Accordion> 
-  
-  <Accordion title="How are credit notes and corrections handled?">
-  E-invoices cannot be deleted or retracted. Instead a credit note or corrected invoice can be sent referencing the original invoice. 
-  </Accordion>
-  <Accordion title="How can I view an XML attached to a PDF?">
-    In Factur-X PDFs, the XML file is embedded within the PDF itself. To extract and view it, you can use the `Attachments` section in Adobe Acrobat Reader.
 
-    Alternatively, you can use specialized tools like the [SysTools PDF Extractor](https://www.systoolsgroup.com/pdf/extractor/) to extract the XML file.
+  <Accordion title="Does this apply to foreign businesses without a Fixed Establishment (FE) in France?">
+    E-invoicing does not apply. If the business is liable to French VAT, e-reporting applies to the relevant flows. E-reporting for reverse-charge VAT and intra-EU acquisitions is deferred until 1 September 2027.
   </Accordion>
 </AccordionGroup>
 
 
-  ## ChorusPro
+## ChorusPro
 
-  <AccordionGroup>
+<AccordionGroup>
   <Accordion title="What invoice formats does Chorus Pro support?">
-  Chorus Pro primarily supports CII format based on EN16931. Invopop currently focuses on CII with plans to add additional formats in the future.
+    Chorus Pro primarily supports CII format based on EN16931. Invopop currently focuses on CII with plans to add additional formats in the future.
   </Accordion>
 
   <Accordion title="Do I need a SIRET number to use Chorus Pro?">
-  French businesses need a SIRET number. Foreign businesses can use their local tax identifier, but should verify acceptance with the receiving French institution.
+    French businesses need a SIRET number. Foreign businesses can use their local tax identifier, but should verify acceptance with the receiving French institution.
   </Accordion>
 
   <Accordion title="Can I modify invoices after sending to Chorus Pro?">
-  Yes, you can modify and resubmit invoices until the receiving institution accepts them. Once accepted, invoices become locked and cannot be modified.
+    Yes, you can modify and resubmit invoices until the receiving institution accepts them. Once accepted, invoices become locked and cannot be modified.
   </Accordion>
 
   <Accordion title="How do I find my invoice in Chorus Pro?">
-  Use your GOBL invoice series and code combined as the invoice identifier in the Chorus Pro portal to locate your submitted invoices.
+    Use your GOBL invoice series and code combined as the invoice identifier in the Chorus Pro portal to locate your submitted invoices.
   </Accordion>
 
   <Accordion title="What happens if my supplier registration fails?">
-  Ensure the supplier has a valid Chorus Pro account and provided correct credentials. Contact support if registration workflow issues persist.
+    Ensure the supplier has a valid Chorus Pro account and provided correct credentials. Contact support if registration workflow issues persist.
   </Accordion>
 
   <Accordion title="Are there file size limits for Chorus Pro invoices?">
-  Chorus Pro has specific file size and format requirements. Invopop handles these automatically when generating CII XML files from your GOBL invoices.
+    Chorus Pro has specific file size and format requirements. Invopop handles these automatically when generating CII XML files from your GOBL invoices.
   </Accordion>
-  </AccordionGroup>
+</AccordionGroup>
 
 <Card title="Participate in our community"
   icon="forumbee"
@@ -80,4 +78,3 @@ sidebarTitle: "FAQ"
 >
   Ask and answer questions about France's regulation →
 </Card>
-

--- a/guides/fr-pa-invoicing.mdx
+++ b/guides/fr-pa-invoicing.mdx
@@ -1,0 +1,116 @@
+---
+title: "France PA — invoicing"
+sidebarTitle: "Invoicing"
+description: Send and receive B2B invoices over Peppol with automatic PPF reporting.
+---
+
+import FranceResources from '/snippets/tables/france-resources.mdx';
+import SendInvoiceWorkflow from '/snippets/workflows/fr/fr-pa-send-invoice.mdx';
+import ReceiveInvoiceWorkflow from '/snippets/workflows/fr/fr-pa-receive-invoice.mdx';
+
+The France PA invoicing flow covers **regulated B2B exchanges** — both parties registered in the Annuaire. The same GOBL document drives both sides: a single invoice with the `fr-ctc-flow2-v1` add-on, generated as the format negotiated with the receiver. On receipt, any of the accepted formats is converted back to that same representation.
+
+For non-regulated traffic — B2C, cross-border, or any flow where one party is not in the Annuaire — use the [reporting flow](/guides/fr-pa-reporting) instead.
+
+## Formats
+
+The PA specification accepts five formats. In practice the three base formats below cover essentially all real-world traffic, and Invopop supports both sending and receiving on all three.
+
+| Format | Notes |
+|---|---|
+| **UBL** | Peppol France CIUS — recommended default. Native Peppol format with the widest receiver support. |
+| **CII** | UN/CEFACT XML, semantically equivalent to UBL. Common in cross-border and industrial contexts. |
+| **Factur-X** | Hybrid PDF/A-3 with embedded CII. Identical to [ZUGFeRD](/guides/de-ubl) and aligned with EN 16931. |
+
+Switching format is a workflow-config change rather than a data-model change — you author and validate one GOBL invoice, and the workflow's generation step produces whichever format the counterparty expects.
+
+## Sending
+
+The send workflow records the invoice for compliance, generates the chosen format, transmits it to the receiver's PA over Peppol, and forwards the F1 copy to the PPF as the fifth corner.
+
+The **Record Invoice** step validates SIRENs and checks both parties against the Annuaire. Invoices where either side is missing are rejected — branch non-regulated traffic into the [reporting flow](/guides/fr-pa-reporting) upstream of this workflow.
+
+### How it works
+
+<Steps>
+  <Step title="Set State → processing">
+    Moves the invoice into a visible "in progress" state for operator dashboards.
+  </Step>
+  <Step title="Add Signature">
+    Locks the GOBL envelope so downstream steps work against an immutable document.
+  </Step>
+  <Step title="Record Invoice">
+    Validates SIRENs, checks both parties against the Annuaire, and stores the invoice in the local PA database.
+  </Step>
+  <Step title="Generate UBL Document">
+    Produces a Peppol France CIUS UBL invoice or credit note. Swap for **Generate CII Document** if the receiver requires CII, or **Generate PDF (Factur-X)** for hybrid PDF.
+  </Step>
+  <Step title="Send Peppol Document">
+    Transmits the generated document to the receiver's PA over the Peppol network.
+  </Step>
+  <Step title="Set State → sent">
+    Marks Peppol delivery as successful.
+  </Step>
+  <Step title="Forward Invoice to PPF">
+    Generates the simplified F1 invoice and forwards it, along with the mandatory `200` _déposée_ status, to the PPF.
+  </Step>
+  <Step title="Set State → completed">
+    Marks the full e-invoicing flow — Peppol delivery and PPF reporting — as complete.
+  </Step>
+</Steps>
+
+### Workflow code
+
+<Tabs>
+  <Tab title="Template">
+    <Card iconType="duotone" title="France PA send invoice workflow" icon="code-branch" href="https://console.invopop.com/redirect/workflows/new?template=fr-fr-pa-send-invoice" cta="Add to my workspace">
+      Records and sends a France-compliant invoice via Peppol and the PPF.
+    </Card>
+  </Tab>
+  <Tab title="Code">
+    Copy and paste into a new [Empty Invoice workflow](https://console.invopop.com/redirect/workflows/new?template=empty-invoice).
+    <SendInvoiceWorkflow />
+  </Tab>
+</Tabs>
+
+## Receiving
+
+The receive workflow detects the inbound format, imports it into a GOBL document, and records it against your registered party. The same workflow handles UBL, CII, and Factur-X — the format-detection branch routes each payload to the correct importer.
+
+### How it works
+
+<Steps>
+  <Step title="Import Peppol Document">
+    Pulls the inbound payload from Peppol and branches on the detected format:
+    - `UBL` → **Import UBL Document** converts the UBL XML to GOBL.
+    - `CII` → **Import UN/CEFACT CII Document** converts the CII XML to GOBL.
+    - `PDF` → **Import PDF (Factur-X)** extracts the embedded CII and converts it to GOBL.
+  </Step>
+  <Step title="Set Folder → expenses">
+    Files the invoice under the `Invoices · Expenses` folder so it lands in the right place for accounting workflows.
+  </Step>
+  <Step title="Record Invoice">
+    Validates SIRENs, resolves your registered party as the customer (or supplier in self-billing flows), and guards against duplicate processing.
+  </Step>
+  <Step title="Set State → registered">
+    Marks the incoming invoice as successfully received.
+  </Step>
+</Steps>
+
+### Workflow code
+
+<Tabs>
+  <Tab title="Template">
+    <Card iconType="duotone" title="France PA receive invoice workflow" icon="code-branch" href="https://console.invopop.com/redirect/workflows/new?template=fr-fr-pa-receive-invoice" cta="Add to my workspace">
+      Imports an incoming Peppol invoice (UBL, CII, or Factur-X) and records it.
+    </Card>
+  </Tab>
+  <Tab title="Code">
+    Copy and paste into a new [Empty Invoice workflow](https://console.invopop.com/redirect/workflows/new?template=empty-invoice).
+    <ReceiveInvoiceWorkflow />
+  </Tab>
+</Tabs>
+
+---
+
+<FranceResources />

--- a/guides/fr-pa-registration.mdx
+++ b/guides/fr-pa-registration.mdx
@@ -1,0 +1,86 @@
+---
+title: "France PA — registration"
+sidebarTitle: "Registration"
+description: Register a party in the French Annuaire and on the Peppol network.
+---
+
+import FranceResources from '/snippets/tables/france-resources.mdx';
+import RegisterWorkflow from '/snippets/workflows/fr/fr-pa-register.mdx';
+import DeregisterWorkflow from '/snippets/workflows/fr/fr-pa-deregister.mdx';
+
+Each party — a SIREN — is registered once. The workflow signs the contract, records the party in the Annuaire, opens a reporting register, and publishes the party on the Peppol network. After it completes, the party can both send and receive invoices and is ready to start recording transactions for reporting.
+
+The Annuaire requires every entry to be receive-capable, so there is no send-only option. Internally the workflow extends the standard [Peppol registration](/guides/peppol) with a French Annuaire step and the reporting register.
+
+## How it works
+
+<Steps>
+  <Step title="Sign Contract">
+    Kicks off the contract signature flow with the party. The job pauses here until the party returns the signed agreement.
+  </Step>
+  <Step title="Set State → processing">
+    Moves the silo entry into a visible "in progress" state so operator dashboards reflect that registration is underway.
+  </Step>
+  <Step title="Wait for Approval">
+    Pauses until Invopop's KYC review of the signed contract clears.
+  </Step>
+  <Step title="Register in Annuaire">
+    Submits the party's SIREN to the French national directory so other PAs can route invoices to it.
+  </Step>
+  <Step title="Register Reporter">
+    Opens a reporting record keyed by SIREN and stores the cadence chosen during onboarding. See [reporting](/guides/fr-pa-reporting#registration) for the cadence options.
+  </Step>
+  <Step title="Register Peppol Party">
+    Publishes the party in SMP/SML with the `france` document group, enabling Peppol-level routing for sending and receiving.
+  </Step>
+  <Step title="Set State → registered">
+    Marks the party as fully onboarded.
+  </Step>
+</Steps>
+
+## Workflow code
+
+<Tabs>
+  <Tab title="Template">
+    <Card iconType="duotone" title="France PA register party workflow" icon="code-branch" href="https://console.invopop.com/redirect/workflows/new?template=fr-fr-pa-register" cta="Add to my workspace">
+      Registers a party in the Annuaire, on the Peppol network, and as a reporter.
+    </Card>
+  </Tab>
+  <Tab title="Code">
+    Copy and paste into a new [Empty Party workflow](https://console.invopop.com/redirect/workflows/new?template=empty-party).
+    <RegisterWorkflow />
+  </Tab>
+</Tabs>
+
+## Deregistration
+
+When a party stops trading or moves to another platform, run a deregistration workflow. The two steps remove the party from the Annuaire and close out its reporting register.
+
+<Steps>
+  <Step title="Disable in Annuaire">
+    Removes the inbox from the French directory and disables the party on Peppol so no further invoices are routed to it.
+  </Step>
+  <Step title="Disable Reporter">
+    Closes the reporting register so no more periodic reports are generated for this SIREN.
+  </Step>
+</Steps>
+
+<Note>
+  Deregistration does not delete historical reports already submitted to the PPF.
+</Note>
+
+<Tabs>
+  <Tab title="Template">
+    <Card iconType="duotone" title="France PA deregister party workflow" icon="code-branch" href="https://console.invopop.com/redirect/workflows/new?template=fr-fr-pa-deregister" cta="Add to my workspace">
+      Removes a party from the Annuaire and stops periodic reporting.
+    </Card>
+  </Tab>
+  <Tab title="Code">
+    Copy and paste into a new [Empty Party workflow](https://console.invopop.com/redirect/workflows/new?template=empty-party).
+    <DeregisterWorkflow />
+  </Tab>
+</Tabs>
+
+---
+
+<FranceResources />

--- a/guides/fr-pa-reporting.mdx
+++ b/guides/fr-pa-reporting.mdx
@@ -1,0 +1,66 @@
+---
+title: "France PA — e-reporting"
+sidebarTitle: "Reporting"
+description: Periodic e-reporting (Flow 10) of B2C and non-regulated B2B transactions to the PPF.
+---
+
+import FranceResources from '/snippets/tables/france-resources.mdx';
+
+<Warning>
+  E-reporting is **in development**. The `fr-ctc-flow10-v1` GOBL add-on is not yet released and the actions below are subject to change. Do not build production flows on this guide yet — track the [hub readiness matrix](/guides/fr-pa) for updates.
+</Warning>
+
+E-reporting covers transactions that are out of scope for regulated e-invoicing — B2C sales, foreign B2B (cross-border), and any flow where one party is not registered in the Annuaire. Instead of routing each invoice individually, you record it locally and Invopop submits an aggregated report to the PPF on a fixed cadence.
+
+Reports use the `fr-ctc-flow10-v1` add-on, distinct from the `fr-ctc-flow2-v1` add-on used for e-invoicing. Both invoice and payment data are reported.
+
+## Registration
+
+Reporting is registered at the **SIREN level** as part of the [party registration workflow](/guides/fr-pa-registration). The registration step captures two things and reuses them for every report submitted afterwards:
+
+1. **The SIREN.** Invopop opens an internal record keyed by SIREN. Every invoice and payment recorded later is attached to and aggregated under this record.
+2. **The reporting cadence.** Invoice and payment data have separate schedules, and the cadence is determined by the party's VAT regime — pick the one that matches.
+
+### Cadence — invoice and transaction data
+
+| VAT regime | Period | Submit to PPF |
+|---|---|---|
+| Monthly Actual | Ten-day periods (1–10, 11–20, 21–end) | 10 days after each period |
+| Quarterly Actual | Monthly | 10th of the following month |
+| Simplified VAT | Monthly | Between 25th and 30th of the following month |
+| Non-Established Taxpayer | Bimonthly | Between 25th and 30th of the following month |
+
+### Cadence — payment data
+
+| VAT regime | Period | Submit to PPF |
+|---|---|---|
+| Monthly Actual | Monthly | 10th of the following month |
+| Quarterly Actual | Monthly | 10th of the following month |
+| Simplified VAT | Monthly | Between 25th and 30th of the following month |
+| Non-Established Taxpayer | Bimonthly | Between 25th and 30th of the following month |
+
+## Recording
+
+Send each invoice or payment through a **recording workflow**. The single `Record for Reporting` step stores the document against the registered SIREN and queues it for the next periodic report. B2C sales and foreign B2B transactions both go through the same step — only the invoice context differs.
+
+```mermaid
+flowchart LR
+    I[Invoice or payment] --> R[Record for Reporting]
+```
+
+## Periodic submission
+
+A second workflow generates and submits the report. It is triggered automatically by the cadence chosen at registration — if recorded data exists for the period when the cadence fires, Invopop builds the report and sends it to the PPF without any manual intervention.
+
+```mermaid
+flowchart LR
+    G[Generate Report] --> S[Send Report to PPF]
+```
+
+## Corrective reports
+
+When a previously submitted period needs to change — a wrong amount, a missing transaction, an invoice that should not have been included — trigger a corrective report. It runs the same `Generate Report` and `Send Report to PPF` steps but is scoped to the period being amended rather than the current one.
+
+---
+
+<FranceResources />

--- a/guides/fr-pa-status.mdx
+++ b/guides/fr-pa-status.mdx
@@ -1,0 +1,218 @@
+---
+title: "France PA — lifecycle status"
+sidebarTitle: "Status"
+description: Send and receive lifecycle status updates (CDAR) for B2B invoices.
+---
+
+import FranceResources from '/snippets/tables/france-resources.mdx';
+import SendStatusWorkflow from '/snippets/workflows/fr/fr-pa-send-status.mdx';
+
+<Warning>
+  Status is moving to a first-class GOBL document. Today it is a CDAR XML attached to the originating invoice; the next iteration makes it a standalone document with its own schema. Workflow steps and job arguments will change before the September 2026 mandate.
+</Warning>
+
+France requires lifecycle status updates on B2B national invoices to be reported to the PPF. Two statuses are your responsibility to send — `212` Encaissée (paid) and `210` Refusée (refused). The other two mandatory codes (`200` Déposée and `213` Rejetée) are emitted automatically by Invopop, so you do not need a workflow for them.
+
+## Sending
+
+A status workflow records the status against the originating invoice, generates a CDAR XML payload, transmits it to the counterparty's PA over Peppol, and — for the two mandatory statuses — forwards a copy to the PPF.
+
+### How it works
+
+<Steps>
+  <Step title="Record Status">
+    Stores the status against the originating invoice in the local PA database. The `status_code` and `reason_code` come from the workflow config or from job arguments at runtime.
+  </Step>
+  <Step title="Generate CDAR">
+    Uses the CII app to produce a CDAR XML envelope from the recorded status.
+  </Step>
+  <Step title="Send Peppol Document">
+    Transmits the CDAR to the counterparty's PA over the Peppol network.
+  </Step>
+  <Step title="Forward Status to PPF">
+    For the two mandatory statuses (`210` and `212`), forwards the CDAR to the PPF. Non-mandatory statuses skip this step.
+  </Step>
+</Steps>
+
+### Job arguments
+
+Pass status details as job arguments to use one workflow for multiple status types. Arguments take priority over workflow config.
+
+| Argument | Description |
+|---|---|
+| `code` | Status code (`200`–`213`). |
+| `reason-code` | Reason code (e.g. `MONTANTTOTAL_ERR`). Defaults by status code if omitted. |
+| `reason-text` | Optional free-text explanation. |
+
+```json
+{
+  "args": {
+    "code": "210",
+    "reason-code": "DOUBLON",
+    "reason-text": "Duplicate invoice already processed"
+  }
+}
+```
+
+<Info>
+  Use one workflow per mandatory status (paid, refused) with the code pre-configured, rather than a single generic workflow. Keeps runbooks simple.
+</Info>
+
+### Workflow code
+
+The example below is configured for `207` (En litige) with reason `MONTANTTOTAL_ERR`. Override `status_code` / `reason_code` per workflow or via job arguments.
+
+<Tabs>
+  <Tab title="Template">
+    <Card iconType="duotone" title="France PA send status workflow" icon="code-branch" href="https://console.invopop.com/redirect/workflows/new?template=fr-fr-pa-send-status" cta="Add to my workspace">
+      Generates and forwards a CDAR status update via Peppol and the PPF.
+    </Card>
+  </Tab>
+  <Tab title="Code">
+    Copy and paste into a new [Empty Invoice workflow](https://console.invopop.com/redirect/workflows/new?template=empty-invoice).
+    <SendStatusWorkflow />
+  </Tab>
+</Tabs>
+
+## Receiving
+
+Incoming statuses arrive over the same Peppol transport as invoices. Peppol's format detection identifies them as CDAR, the CII app imports them into GOBL, and the result is recorded against the originating invoice.
+
+<Steps>
+  <Step title="Import Peppol Document">
+    Receives the inbound Peppol payload and detects that it is a CDAR status update rather than an invoice.
+  </Step>
+  <Step title="Import UN/CEFACT CII Document">
+    Converts the CDAR XML into a GOBL representation.
+  </Step>
+  <Step title="Record Status">
+    Files the status under the originating invoice in the local PA database.
+  </Step>
+</Steps>
+
+## Deriving a status from an invoice
+
+The **Build Status from Invoice** step creates a new silo entry with a status payload pre-filled from an existing invoice. The new entry can then trigger the **Send status** workflow. Use this when the events that drive a status — payment captured, dispute raised — live alongside invoices in your system, and you want to avoid building a CDAR payload from scratch.
+
+```mermaid
+flowchart LR
+    I[Invoice] --> B[Build Status from Invoice]
+    B -->|new silo entry| N[Create Job]
+    N -..-> S[Send status workflow]
+```
+
+## Status codes
+
+| Code | French | English | Mandatory to PPF |
+|---|---|---|---|
+| `200` | Déposée | Deposited | Yes (automatic) |
+| `205` | Approuvée | Accepted | No |
+| `206` | Partiellement approuvée | Partially Approved | No |
+| `207` | En litige | Disputed | No |
+| `208` | Suspendue | Suspended | No |
+| `209` | Complétée | Completed | No |
+| `210` | Refusée | Refused by buyer | Yes (manual) |
+| `211` | Paiement transmis | Payment transmitted | No |
+| `212` | Encaissée | Cashed/Paid | Yes (manual) |
+| `213` | Rejetée | Rejected by platform | Yes (automatic) |
+
+## Reason codes
+
+Each status accepts specific reason codes. Statuses not listed (`205`, `209`, `211`, `212`) do not require one. Defaults are applied when `reason-code` is omitted.
+
+| Status | Reason code | Description | Default |
+|---|---|---|---|
+| `200` Déposée | `NON_TRANSMISE` | Destinataire non connecté | ✓ |
+| `206` Partiellement approuvée | `AUTRE` | Autre | ✓ |
+| `206` Partiellement approuvée | `TX_TVA_ERR` | Taux de TVA erroné | |
+| `206` Partiellement approuvée | `MONTANTTOTAL_ERR` | Montant total erroné | |
+| `206` Partiellement approuvée | `CALCUL_ERR` | Erreur de calcul de la facture | |
+| `206` Partiellement approuvée | `NON_CONFORME` | Mention légale manquante | |
+| `206` Partiellement approuvée | `DOUBLON` | Facture en doublon | |
+| `206` Partiellement approuvée | `DEST_ERR` | Erreur de destinataire | |
+| `206` Partiellement approuvée | `TRANSAC_INC` | Transaction inconnue | |
+| `206` Partiellement approuvée | `EMMET_INC` | Émetteur inconnu | |
+| `206` Partiellement approuvée | `CONTRAT_TERM` | Contrat terminé | |
+| `206` Partiellement approuvée | `DOUBLE_FACT` | Double facture | |
+| `206` Partiellement approuvée | `CMD_ERR` | N° de commande incorrect ou manquant | |
+| `206` Partiellement approuvée | `ADR_ERR` | Adresse de facturation électronique erronée | |
+| `206` Partiellement approuvée | `SIRET_ERR` | SIRET erroné ou absent | |
+| `206` Partiellement approuvée | `CODE_ROUTAGE_ERR` | CODE_ROUTAGE absent ou erroné | |
+| `206` Partiellement approuvée | `REF_CT_ABSENT` | Référence contractuelle nécessaire | |
+| `206` Partiellement approuvée | `REF_ERR` | Référence incorrecte | |
+| `206` Partiellement approuvée | `PU_ERR` | Prix unitaires incorrects | |
+| `206` Partiellement approuvée | `REM_ERR` | Remise erronée | |
+| `206` Partiellement approuvée | `QTE_ERR` | Quantité facturée incorrecte | |
+| `206` Partiellement approuvée | `ART_ERR` | Article facturé incorrect | |
+| `206` Partiellement approuvée | `MODPAI_ERR` | Modalités de paiement incorrectes | |
+| `206` Partiellement approuvée | `QUALITE_ERR` | Qualité d'article livré incorrecte | |
+| `206` Partiellement approuvée | `LIVR_INCOMP` | Problème de livraison | |
+| `207` En litige | `AUTRE` | Autre | ✓ |
+| `207` En litige | `TX_TVA_ERR` | Taux de TVA erroné | |
+| `207` En litige | `MONTANTTOTAL_ERR` | Montant total erroné | |
+| `207` En litige | `CALCUL_ERR` | Erreur de calcul de la facture | |
+| `207` En litige | `NON_CONFORME` | Mention légale manquante | |
+| `207` En litige | `DOUBLON` | Facture en doublon | |
+| `207` En litige | `DEST_ERR` | Erreur de destinataire | |
+| `207` En litige | `TRANSAC_INC` | Transaction inconnue | |
+| `207` En litige | `EMMET_INC` | Émetteur inconnu | |
+| `207` En litige | `CONTRAT_TERM` | Contrat terminé | |
+| `207` En litige | `DOUBLE_FACT` | Double facture | |
+| `207` En litige | `CMD_ERR` | N° de commande incorrect ou manquant | |
+| `208` Suspendue | `JUSTIF_ABS` | Justificatif absent ou insuffisant | ✓ |
+| `208` Suspendue | `SIRET_ERR` | SIRET erroné ou absent | |
+| `208` Suspendue | `CODE_ROUTAGE_ERR` | CODE_ROUTAGE absent ou erroné | |
+| `208` Suspendue | `REF_CT_ABSENT` | Référence contractuelle nécessaire | |
+| `208` Suspendue | `REF_ERR` | Référence incorrecte | |
+| `208` Suspendue | `CMD_ERR` | N° de commande incorrect ou manquant | |
+| `208` Suspendue | `ADR_ERR` | Adresse de facturation électronique erronée | |
+| `210` Refusée | `TRANSAC_INC` | Transaction inconnue | ✓ |
+| `210` Refusée | `COORD_BANC_ERR` | Erreur de coordonnées bancaires | |
+| `210` Refusée | `TX_TVA_ERR` | Taux de TVA erroné | |
+| `210` Refusée | `MONTANTTOTAL_ERR` | Montant total erroné | |
+| `210` Refusée | `CALCUL_ERR` | Erreur de calcul de la facture | |
+| `210` Refusée | `NON_CONFORME` | Mention légale manquante | |
+| `210` Refusée | `DOUBLON` | Facture en doublon | |
+| `210` Refusée | `DEST_ERR` | Erreur de destinataire | |
+| `210` Refusée | `EMMET_INC` | Émetteur inconnu | |
+| `210` Refusée | `CONTRAT_TERM` | Contrat terminé | |
+| `210` Refusée | `DOUBLE_FACT` | Double facture | |
+| `210` Refusée | `CMD_ERR` | N° de commande incorrect ou manquant | |
+| `210` Refusée | `ADR_ERR` | Adresse de facturation électronique erronée | |
+| `210` Refusée | `SIRET_ERR` | SIRET erroné ou absent | |
+| `210` Refusée | `CODE_ROUTAGE_ERR` | CODE_ROUTAGE absent ou erroné | |
+| `210` Refusée | `REF_CT_ABSENT` | Référence contractuelle nécessaire | |
+| `210` Refusée | `REF_ERR` | Référence incorrecte | |
+| `210` Refusée | `PU_ERR` | Prix unitaires incorrects | |
+| `210` Refusée | `REM_ERR` | Remise erronée | |
+| `210` Refusée | `QTE_ERR` | Quantité facturée incorrecte | |
+| `210` Refusée | `ART_ERR` | Article facturé incorrect | |
+| `210` Refusée | `MODPAI_ERR` | Modalités de paiement incorrectes | |
+| `210` Refusée | `QUALITE_ERR` | Qualité d'article livré incorrecte | |
+| `210` Refusée | `LIVR_INCOMP` | Problème de livraison | |
+| `213` Rejetée | `REJ_SEMAN` | Rejet pour erreur sémantique | ✓ |
+| `213` Rejetée | `REJ_UNI` | Rejet sur contrôle unicité | |
+| `213` Rejetée | `REJ_COH` | Rejet sur contrôle cohérence de données | |
+| `213` Rejetée | `REJ_ADR` | Rejet sur contrôle d'adressage | |
+| `213` Rejetée | `REJ_CONT_B2G` | Rejet sur contrôles métier B2G | |
+| `213` Rejetée | `REJ_REF_PJ` | Rejet sur référence de PJ | |
+| `213` Rejetée | `REJ_ASS_PJ` | Rejet sur erreur d'association de la PJ | |
+| `213` Rejetée | `IRR_VIDE_F` | Contrôle de non vide sur les fichiers du flux | |
+| `213` Rejetée | `IRR_TYPE_F` | Contrôle de type et extension des fichiers | |
+| `213` Rejetée | `IRR_SYNTAX` | Contrôle syntaxique des fichiers du flux | |
+| `213` Rejetée | `IRR_TAILLE_PJ` | Contrôle de taille des PJ | |
+| `213` Rejetée | `IRR_NOM_PJ` | Contrôle du nom des PJ | |
+| `213` Rejetée | `IRR_VID_PJ` | Contrôle de PJ non vide | |
+| `213` Rejetée | `IRR_EXT_DOC` | Contrôle de l'extension des PJ | |
+| `213` Rejetée | `IRR_TAILLE_F` | Contrôle de taille max des fichiers | |
+| `213` Rejetée | `IRR_ANTIVIRUS` | Contrôle anti-virus | |
+| `213` Rejetée | `DEST_INC` | Destinataire inconnu | |
+| `213` Rejetée | `ADR_ERR` | Adresse de facturation électronique erronée | |
+| `213` Rejetée | `DOUBLON` | Facture en doublon | |
+| `213` Rejetée | `CALCUL_ERR` | Erreur de calcul de la facture | |
+| `213` Rejetée | `TX_TVA_ERR` | Taux de TVA erroné | |
+| `213` Rejetée | `MONTANTTOTAL_ERR` | Montant total erroné | |
+
+---
+
+<FranceResources />

--- a/guides/fr-pa.mdx
+++ b/guides/fr-pa.mdx
@@ -1,461 +1,64 @@
 ---
-title: "PA (Plateforme Agréée) Guide"
-sidebarTitle: "Plateforme Agréée (PA)"
-description: Send compliant e-invoices through France's PA system via Peppol and PPF
+title: "PA (Plateforme Agréée) guide"
+sidebarTitle: "Overview"
+description: France's PA system — concepts, readiness, and links to the four implementation guides.
 ---
 
 import FranceResources from '/snippets/tables/france-resources.mdx';
-import RegisterWorkflow from '/snippets/workflows/fr/fr-pa-register.mdx';
-import ReceiveInvoiceWorkflow from '/snippets/workflows/fr/fr-pa-receive-invoice.mdx';
-import SendInvoiceWorkflow from '/snippets/workflows/fr/fr-pa-send-invoice.mdx';
-import SendStatusWorkflow from '/snippets/workflows/fr/fr-pa-send-status.mdx';
 
-## Introduction
+Invopop is an [officially approved Plateforme Agréée](https://www.impots.gouv.fr/je-consulte-la-liste-des-plateformes-agreees) (PA) under the DGFiP mandate. This page is the entry point to the four France PA implementation guides — [registration](/guides/fr-pa-registration), [invoicing](/guides/fr-pa-invoicing), [status](/guides/fr-pa-status), and [reporting](/guides/fr-pa-reporting).
+
+## Prerequisites
+
+- An Invopop workspace with the **Peppol** and **France** apps enabled.
+- French company details, including SIREN/SIRET.
+- A clear view of your invoicing flows (B2B, B2C, domestic, cross-border) — this drives which sub-guides apply.
 
 <Warning>
-  The workflow steps and API used in this guide are subject to change. We are actively working on new approaches to event handling for a more global use case. The examples here are functional and can be used today, but expect updates before the September 2026 mandate.
+  The France PA implementation is on a moving target. Action names, GOBL add-ons, and workflow shapes will keep changing until the September 2026 mandate. Each sub-guide flags its own readiness — see the matrix below.
 </Warning>
 
-France handles e-invoicing through approved PA (_Plateforme Agréée_) platforms as part of its electronic invoicing reform. Invopop is an officially approved PA platform, as listed on the [French government's official list of approved platforms](https://www.impots.gouv.fr/je-consulte-la-liste-des-plateformes-agreees).
+## Readiness
 
-Invopop is _Plateforme Agréée_ (Approved Platform) by the French tax administration, meaning we have successfully provided all necessary documentation for the registration procedure and passed the technical compliance verification.
+| Capability | Status | Notes |
+|---|---|---|
+| Annuaire registration | <Badge color="green">Available</Badge> | Self-serve KYC in development |
+| Send invoices (UBL, CII, Factur-X) | <Badge color="green">Available</Badge> | API may change before Sept 2026 |
+| Receive invoices | <Badge color="green">Available</Badge> | API may change before Sept 2026 |
+| Lifecycle status | <Badge color="blue">Beta</Badge> | Moving to a first-class GOBL document |
+| E-reporting (Flow 10) | <Badge color="yellow">In development</Badge> | `fr-ctc-flow10-v1` add-on not yet released |
 
-### Prerequisites
-
-To use the France PA integration, you will need:
-
-- **Invopop workspace** with the Peppol and France apps enabled.
-- **French company registration details** including SIREN/SIRET numbers.
-- **Understanding of your invoicing flows** (B2B, B2C, domestic, cross-border) to plan registration and reporting requirements.
-- **Business processes for status updates** to implement the mandatory lifecycle status workflow.
-
-## Key Concepts
+## Key concepts
 
 | | |
 |------|------------|
-| **Annuaire** | The French e-invoicing directory where parties must be registered to participate in regulated e-invoicing flows. Not to be confused with the Peppol Directory. |
-| **PPF** | Portail Public de Facturation — the French government system that receives mandatory invoice data and lifecycle updates. Invopop handles all communications with the PPF automatically. |
-| **Regulated Flow** | An invoice exchange where both the sender and receiver are registered in the Directory. These follow the complete French e-invoicing process including Peppol transmission and PPF reporting. |
-| **Non-Regulated Flow** | An invoice exchange where only one party is registered in the Directory. Invoices are stored for e-reporting to the PPF but may not be transmitted via Peppol. |
-| **E-Reporting** | Periodic reporting to the PPF covering non-regulated flows and B2C transactions.|
-| **CDAR** | Cross Domain Acknowledgement and Response. The format used for lifecycle status updates ("cycle de vie") in France, communicated between parties and to the PPF. |
-| **Fifth Corner** | The tax authority in the Peppol exchange model. Corners 1–4 are sender, sender's PA, receiver's PA, and receiver; the fifth corner is the tax authority that receives a copy of the invoice for regulated flows. In France this is the PPF. |
-| **F1 Invoice** | Simplified UBL format used to forward the invoice to the fifth corner (the tax authority, i.e. the PPF) for regulated flows. Part of e-invoicing, not e-reporting. Generated automatically by Invopop. |
-
-## E-Invoicing
-
-### Annuaire registration
-
-The _annuaire_ is France's national directory of e-invoicing endpoints. It records every registered company and their PA (Invopop, in this case), so that the tax administration knows how to route regulated e-invoicing flows.
-
-Registering in the annuare enables parties (companies) to send and receive invoices in France. Behind the scenes, it extends the standard [Peppol registration workflow](/guides/peppol) with one additional French-specific step to register the party in the Annuaire.
-
-<Note>
-  Peppol registration in France always enables **both sending and receiving**. Once a party is listed in the Annuaire, it must be reachable to receive invoices. There is no send-only option.
-</Note>
-
-#### How it works
-
-1. **Register Party for Approval** — submits the party details for Invopop review.
-2. **Set state to Processing** — marks the party as awaiting approval.
-3. **Wait for Approval** — pauses until the party passes the approval check.
-4. **Register Party** — registers the party in the French Directory (`gov-fr.party.register`). This is the France-specific step added on top of the base Peppol flow.
-5. **Register Peppol Party** — registers the party on the Peppol network with the `france` document group, enabled for sending and receiving via SMP/SML/Peppol.
-6. **Set state to Registered** — marks the party as fully onboarded.
-
-<Info>
-  If you want to understand the base Peppol onboarding this workflow is built on, see the [Peppol registration guide](/guides/peppol). The France PA workflow is the same flow plus the **Register Party (France)** step before the Peppol registration step.
-</Info>
-
-#### Workflow code
-
-<Tabs>
-  <Tab title="Template">
-    <Card iconType="duotone" title="France PA register party workflow" icon="code-branch" href="https://console.invopop.com/redirect/workflows/new?template=fr-fr-pa-register" cta="Add to my workspace">
-      Registers a party in the Annuaire and on the Peppol network for sending and receiving invoices.
-    </Card>
-  </Tab>
-  <Tab title="Code">
-    Copy and paste into a new [Empty Party workflow](https://console.invopop.com/redirect/workflows/new?template=empty-party) code view.
-    <RegisterWorkflow />
-  </Tab>
-</Tabs>
-
-### Invoice formats
-
-The French PA specification lists five accepted invoice formats. UBL and CII each have a base version and an extended version (adding extra fields for French-specific requirements), and Factur-X rounds out the list. In practice, the three base formats cover essentially all real-world exchanges, and Invopop supports sending _and_ receiving all three:
-
-| Format | Description |
-|---|---|
-| **UBL** | XML invoice based on the Peppol France CIUS. The default format used across the Peppol network and the one we recommend for all outgoing flows. An extended UBL variant also exists but is rarely needed. |
-| **CII** | UN/CEFACT Cross Industry Invoice — another XML format, semantically equivalent to UBL and required by some counterparties (particularly in cross-border and automotive/industrial contexts). An extended CII variant is also accepted. |
-| **Factur-X** | Hybrid PDF/A-3 with an embedded CII XML payload. Human-readable on top, machine-readable underneath. Common with buyers who want a visual invoice alongside the structured data. Factur-X is a joint Franco-German standard (identical to [ZUGFeRD](/guides/de-ubl)) aligned with the European Norm EN 16931. |
-
-<Info>
-  **We recommend sending as UBL.** It's the native Peppol France CIUS format, has the widest receiver support, and is the cleanest to validate. Choose CII or Factur-X only when a specific counterparty requires it.
-</Info>
-
-The underlying invoice is always the **same GOBL document with the `fr-ctc-flow2-v1` add-on**. The format is only an addition at the end of the workflow — switching format is a configuration change, not a data-model change. That means:
-
-- You author and validate one GOBL invoice.
-- The workflow's generation step produces the chosen format (UBL, CII, or Factur-X).
-- Incoming invoices in any of the three formats are converted back into the same GOBL representation for you to consume.
-
-### Sending
-
-#### Invoices
-
-<Warning>
-  The workflow steps below are subject to change. We are working on new methods of handling events for a more global use case. This example is functional today, but expect refinements before the September 2026 mandate.
-</Warning>
-
-The sending workflow records the invoice for France PA compliance, transmits it via Peppol, and then forwards it to the PPF.
-
-<Note>
-  This workflow is for **B2B regulated flows**. The `gov-fr.invoice.record` step validates this up-front and will reject the invoice if it doesn't meet the criteria (e.g. if the receiver is not registered in the Annuaire).
-
-  For mixed traffic, run a Annuaire lookup step and `if-else` statements earlier in the workflow and branch non-regulated invoices into the periodic e-reporting path instead.
-</Note>
-
-##### How it works
-
-1. **Set state to Processing** — marks the job as in progress.
-2. **Sign the envelope** — locks the GOBL document against further modification.
-3. **Record Invoice** — validates SIRENs, checks both parties against the Annuaire, and records the invoice.
-4. **Generate UBL Document** — produces a Peppol France CIUS–compliant UBL invoice or credit note.
-5. **Send via Peppol** — transmits the invoice to the receiver's PA platform over the Peppol network.
-6. **Set state to Sent** — marks successful Peppol delivery.
-7. **Forward to PPF** — sends the F1 invoice and the mandatory _déposée_ (deposited) status to the PPF (the fifth corner).
-8. **Set state to Completed** — marks full completion including PPF reporting.
-
-##### Workflow code
-
-<Tabs>
-  <Tab title="Template">
-    <Card iconType="duotone" title="France PA send invoice workflow" icon="code-branch" href="https://console.invopop.com/redirect/workflows/new?template=fr-fr-pa-send-invoice" cta="Add to my workspace">
-      Records and sends a France-compliant invoice via Peppol and the PPF.
-    </Card>
-  </Tab>
-  <Tab title="Code">
-    Copy and paste into a new [Empty Invoice workflow](https://console.invopop.com/redirect/workflows/new?template=empty-invoice) code view.
-    <SendInvoiceWorkflow />
-  </Tab>
-</Tabs>
-
-#### Status
-
-<Warning>
-  **Status is moving to a first-class GOBL document.** Today a status update is a CDAR XML attached to the originating invoice; we are designing a dedicated GOBL document so lifecycle statuses become standalone documents with their own schema. The workflow below is functional and safe to use now — expect the steps and job arguments to change once the new GOBL status document is released.
-</Warning>
-
-France requires mandatory lifecycle status updates to be reported to the PPF for B2B national invoices. You must implement workflows for the two statuses that are your responsibility:
-
-| Status | Code | Trigger |
-|---|---|---|
-| **Encaissée** (cashed/paid) | `212` | Invoice has been paid |
-| **Refusée** (refused by buyer) | `210` | Buyer refuses the invoice (business rejection) |
-
-The following statuses are handled **automatically** by Invopop and do not require a workflow:
-
-| Status | Code | When |
-|---|---|---|
-| **Déposée** (deposited) | `200` | Sent automatically when the invoice is created |
-| **Rejetée** (rejected by platform) | `213` | Sent automatically on processing failure |
-
-You can also send additional non-mandatory statuses (e.g. `205` Approuvée, `207` En litige) for lifecycle tracking. The status workflow below handles all of these.
-
-##### How it works
-
-1. **Generate Status (France)** — creates a CDAR document with the specified status code and reason code. The `status_code`, `reason_code`, and optional `reason_text` are configured per workflow or passed as job arguments.
-2. **Send via Peppol** — transmits the CDAR to the counterparty over Peppol.
-3. **Forward to PPF** — for mandatory statuses (`210`, `212`), sends the notification to the PPF in the required format.
-
-##### Using job arguments
-
-Instead of hardcoding the status in the workflow configuration, you can pass the status details as **job arguments** when creating the job. Arguments take priority over the workflow's configured values, so you can use a single workflow for multiple status types.
-
-The supported arguments are:
-
-| Argument | Description |
-|---|---|
-| `code` | Status code (`200`–`213`). Overrides `status_code` in the workflow config. |
-| `reason-code` | Reason code (e.g. `MONTANTTOTAL_ERR`). Overrides `reason_code` in the workflow config. If omitted, a default reason code is applied based on the status code. |
-| `reason-text` | Optional free-text explanation. Overrides `reason_text` in the workflow config. |
-
-For example, to trigger a _Refusée_ (refused) status using a workflow that is configured with a different default:
-
-```json
-{
-  "args": {
-    "code": "210",
-    "reason-code": "DOUBLON",
-    "reason-text": "Duplicate invoice already processed"
-  }
-}
-```
-
-This approach is useful when you want a single status workflow that can handle multiple status types dynamically, driven by your business logic.
-
-##### Workflow code
-
-The example below is configured for status `207` (En litige / Disputed) with reason code `MONTANTTOTAL_ERR`. Change `status_code` and `reason_code` to match your use case, or override them at runtime using job arguments as described above.
-
-<Tabs>
-  <Tab title="Template">
-    <Card iconType="duotone" title="France PA send status workflow" icon="code-branch" href="https://console.invopop.com/redirect/workflows/new?template=fr-fr-pa-send-status" cta="Add to my workspace">
-      Generates and forwards a lifecycle status update (CDAR) via Peppol and the PPF.
-    </Card>
-  </Tab>
-  <Tab title="Code">
-    Copy and paste into a new [Empty Invoice workflow](https://console.invopop.com/redirect/workflows/new?template=empty-invoice) code view.
-    <SendStatusWorkflow />
-  </Tab>
-</Tabs>
-
-<Info>
-  We recommend creating a separate workflow for each mandatory status type (paid, refused) with the appropriate code pre-configured, rather than a single generic workflow. This keeps your operational runbooks simple and reduces the risk of sending the wrong code.
-</Info>
-
-##### Available status codes
-
-| Code | French | English | Mandatory to PPF |
-|---|---|---|---|
-| `200` | Déposée | Deposited | Yes (automatic) |
-| `205` | Approuvée | Accepted | No |
-| `206` | Partiellement approuvée | Partially Approved | No |
-| `207` | En litige | Disputed | No |
-| `208` | Suspendue | Suspended | No |
-| `209` | Complétée | Completed | No |
-| `210` | Refusée | Refused by buyer | Yes (manual) |
-| `211` | Paiement transmis | Payment transmitted | No |
-| `212` | Encaissée | Cashed/Paid | Yes (manual) |
-| `213` | Rejetée | Rejected by platform | Yes (automatic) |
-
-##### Reason codes by status
-
-Each status code accepts specific reason codes. Statuses not listed below (e.g. `205`, `209`, `211`, `212`) do not require a reason code.
-
-<AccordionGroup>
-  <Accordion title="200 — Déposée (Deposited)">
-    | Reason Code | Description |
-    |---|---|
-    | `NON_TRANSMISE` | Destinataire non connecté |
-
-    Default: `NON_TRANSMISE`
-  </Accordion>
-
-  <Accordion title="206 — Partiellement approuvée (Partially Approved)">
-    | Reason Code | Description |
-    |---|---|
-    | `AUTRE` | Autre |
-    | `TX_TVA_ERR` | Taux de TVA erroné |
-    | `MONTANTTOTAL_ERR` | Montant total erroné |
-    | `CALCUL_ERR` | Erreur de calcul de la facture |
-    | `NON_CONFORME` | Mention légale manquante |
-    | `DOUBLON` | Facture en doublon |
-    | `DEST_ERR` | Erreur de destinataire |
-    | `TRANSAC_INC` | Transaction inconnue |
-    | `EMMET_INC` | Émetteur inconnu |
-    | `CONTRAT_TERM` | Contrat terminé |
-    | `DOUBLE_FACT` | Double facture |
-    | `CMD_ERR` | N° de commande incorrect ou manquant |
-    | `ADR_ERR` | Adresse de facturation électronique erronée |
-    | `SIRET_ERR` | SIRET erroné ou absent |
-    | `CODE_ROUTAGE_ERR` | CODE_ROUTAGE absent ou erroné |
-    | `REF_CT_ABSENT` | Référence contractuelle nécessaire |
-    | `REF_ERR` | Référence incorrecte |
-    | `PU_ERR` | Prix unitaires incorrects |
-    | `REM_ERR` | Remise erronée |
-    | `QTE_ERR` | Quantité facturée incorrecte |
-    | `ART_ERR` | Article facturé incorrect |
-    | `MODPAI_ERR` | Modalités de paiement incorrectes |
-    | `QUALITE_ERR` | Qualité d'article livré incorrecte |
-    | `LIVR_INCOMP` | Problème de livraison |
-
-    Default: `AUTRE`
-  </Accordion>
-
-  <Accordion title="207 — En litige (Disputed)">
-    | Reason Code | Description |
-    |---|---|
-    | `AUTRE` | Autre |
-    | `TX_TVA_ERR` | Taux de TVA erroné |
-    | `MONTANTTOTAL_ERR` | Montant total erroné |
-    | `CALCUL_ERR` | Erreur de calcul de la facture |
-    | `NON_CONFORME` | Mention légale manquante |
-    | `DOUBLON` | Facture en doublon |
-    | `DEST_ERR` | Erreur de destinataire |
-    | `TRANSAC_INC` | Transaction inconnue |
-    | `EMMET_INC` | Émetteur inconnu |
-    | `CONTRAT_TERM` | Contrat terminé |
-    | `DOUBLE_FACT` | Double facture |
-    | `CMD_ERR` | N° de commande incorrect ou manquant |
-
-    Default: `AUTRE`
-  </Accordion>
-
-  <Accordion title="208 — Suspendue (Suspended)">
-    | Reason Code | Description |
-    |---|---|
-    | `JUSTIF_ABS` | Justificatif absent ou insuffisant |
-    | `SIRET_ERR` | SIRET erroné ou absent |
-    | `CODE_ROUTAGE_ERR` | CODE_ROUTAGE absent ou erroné |
-    | `REF_CT_ABSENT` | Référence contractuelle nécessaire |
-    | `REF_ERR` | Référence incorrecte |
-    | `CMD_ERR` | N° de commande incorrect ou manquant |
-    | `ADR_ERR` | Adresse de facturation électronique erronée |
-
-    Default: `JUSTIF_ABS`
-  </Accordion>
-
-  <Accordion title="210 — Refusée (Refused by buyer)">
-    | Reason Code | Description |
-    |---|---|
-    | `COORD_BANC_ERR` | Erreur de coordonnées bancaires |
-    | `TX_TVA_ERR` | Taux de TVA erroné |
-    | `MONTANTTOTAL_ERR` | Montant total erroné |
-    | `CALCUL_ERR` | Erreur de calcul de la facture |
-    | `NON_CONFORME` | Mention légale manquante |
-    | `DOUBLON` | Facture en doublon |
-    | `DEST_ERR` | Erreur de destinataire |
-    | `TRANSAC_INC` | Transaction inconnue |
-    | `EMMET_INC` | Émetteur inconnu |
-    | `CONTRAT_TERM` | Contrat terminé |
-    | `DOUBLE_FACT` | Double facture |
-    | `CMD_ERR` | N° de commande incorrect ou manquant |
-    | `ADR_ERR` | Adresse de facturation électronique erronée |
-    | `SIRET_ERR` | SIRET erroné ou absent |
-    | `CODE_ROUTAGE_ERR` | CODE_ROUTAGE absent ou erroné |
-    | `REF_CT_ABSENT` | Référence contractuelle nécessaire |
-    | `REF_ERR` | Référence incorrecte |
-    | `PU_ERR` | Prix unitaires incorrects |
-    | `REM_ERR` | Remise erronée |
-    | `QTE_ERR` | Quantité facturée incorrecte |
-    | `ART_ERR` | Article facturé incorrect |
-    | `MODPAI_ERR` | Modalités de paiement incorrectes |
-    | `QUALITE_ERR` | Qualité d'article livré incorrecte |
-    | `LIVR_INCOMP` | Problème de livraison |
-
-    Default: `TRANSAC_INC`
-  </Accordion>
-
-  <Accordion title="213 — Rejetée (Rejected by platform)">
-    | Reason Code | Description |
-    |---|---|
-    | `REJ_SEMAN` | Rejet pour erreur sémantique |
-    | `REJ_UNI` | Rejet sur contrôle unicité |
-    | `REJ_COH` | Rejet sur contrôle cohérence de données |
-    | `REJ_ADR` | Rejet sur contrôle d'adressage |
-    | `REJ_CONT_B2G` | Rejet sur contrôles métier B2G |
-    | `REJ_REF_PJ` | Rejet sur référence de PJ |
-    | `REJ_ASS_PJ` | Rejet sur erreur d'association de la PJ |
-    | `IRR_VIDE_F` | Contrôle de non vide sur les fichiers du flux |
-    | `IRR_TYPE_F` | Contrôle de type et extension des fichiers |
-    | `IRR_SYNTAX` | Contrôle syntaxique des fichiers du flux |
-    | `IRR_TAILLE_PJ` | Contrôle de taille des PJ |
-    | `IRR_NOM_PJ` | Contrôle du nom des PJ |
-    | `IRR_VID_PJ` | Contrôle de PJ non vide |
-    | `IRR_EXT_DOC` | Contrôle de l'extension des PJ |
-    | `IRR_TAILLE_F` | Contrôle de taille max des fichiers |
-    | `IRR_ANTIVIRUS` | Contrôle anti-virus |
-    | `DEST_INC` | Destinataire inconnu |
-    | `ADR_ERR` | Adresse de facturation électronique erronée |
-    | `DOUBLON` | Facture en doublon |
-    | `CALCUL_ERR` | Erreur de calcul de la facture |
-    | `TX_TVA_ERR` | Taux de TVA erroné |
-    | `MONTANTTOTAL_ERR` | Montant total erroné |
-
-    Default: `REJ_SEMAN`
-  </Accordion>
-</AccordionGroup>
-
-### Receiving
-
-Incoming invoices and incoming status updates (CDAR) both arrive over the same Peppol transport. The following example shows how invoices are received and processed.
-
-Incoming documents arrive via Peppol in one of the three supported formats (UBL, CII, or Factur-X PDF). The receive workflow branches on the detected format, imports it into the shared GOBL representation, records it against the France PA system as an incoming invoice, and files it in the `Invoices · Expenses` folder.
-
-##### How it works
-
-1. **Import Peppol Document** — receives the inbound Peppol payload and branches on the detected format code:
-   - `UBL` → **Import UBL Document** (`ubl.import`) converts the UBL XML to GOBL.
-   - `CII` → **Import UN/CEFACT CII Document** (`cii.import`) converts the CII XML to GOBL.
-   - `PDF` → **Import PDF (Factur-X)** (`cii.pdf.import`) extracts the embedded CII and converts it to GOBL.
-2. **Set Folder** — files the invoice under `Invoices · Expenses`.
-3. **Record Invoice** — validates SIRENs, checks both parties against the Annuaire, resolves _your_ registered party as the customer (or supplier if self-billed), and guards against duplicates.
-4. **Set state to Registered** — marks the incoming invoice as successfully received.
-
-##### Workflow code
-
-<Tabs>
-  <Tab title="Template">
-    <Card iconType="duotone" title="France PA receive invoice workflow" icon="code-branch" href="https://console.invopop.com/redirect/workflows/new?template=fr-fr-pa-receive-invoice" cta="Add to my workspace">
-      Imports an incoming Peppol invoice (UBL, CII, or Factur-X PDF) and records it against the France PA system.
-    </Card>
-  </Tab>
-  <Tab title="Code">
-    Copy and paste into a new [Empty Invoice workflow](https://console.invopop.com/redirect/workflows/new?template=empty-invoice) code view.
-    <ReceiveInvoiceWorkflow />
-  </Tab>
-</Tabs>
-
-## Reporting
-
-### Registration
-
-Reporting is done at the **SIREN** level, not at the party or invoice level. Before a party can submit any reports, it must be registered for reporting so Invopop has an internal SIREN-keyed record to attach all subsequent reports to.
-
-Registration has two requirements:
-
-1. **Record a SIREN.** Send the party along with its SIREN. Invopop stores an internal record keyed by that SIREN, which all later invoice and payment reports will be attached to and aggregated under for submission to the PPF.
-2. **Select a reporting cadence.** Periodic reporting is submitted on a fixed schedule tied to the party's VAT regime. **Invoice/transaction** data and **payment** data have separate schedules — choose the cadence that matches the party's regime for each.
-
-   The schedules are identical for the Quarterly Actual, Simplified VAT, and Non-Established Taxpayer regimes. Only the **Monthly Actual Regime** differs: invoice/transaction data is reported in ten-day periods, while payments are reported monthly.
-
-   **Invoice and transaction data**
-
-   | VAT Regime | Period | Submit to PPF | PPF → Tax Authorities |
-   |---|---|---|---|
-   | **Monthly Actual Regime** | Ten-day periods: 1st–10th, 11th–20th, 21st–month end | 10 days after the period ends (20th of current month, end of current month, 10th of following month) | 1st ten-day: 21st at 08:00 · 2nd ten-day: 1st of following month at 08:00 · 3rd ten-day: 11th of following month at 08:00 |
-   | **Quarterly Actual Regime** | Monthly | 10th of the following month | 11th of the following month at 08:00 |
-   | **Simplified VAT Taxation Regime** | Monthly | Between the 25th and 30th of the following month | 1st of the second following month at 08:00 |
-   | **Non-Established Taxpayer VAT Regime** | Bimonthly (every two calendar months) | Between the 25th and 30th of the following month | 1st of the second following month at 08:00 |
-
-   **Payment data**
-
-   | VAT Regime | Period | Submit to PPF | PPF → Tax Authorities |
-   |---|---|---|---|
-   | **Monthly Actual Regime** | Monthly | 10th of the following month | 11th of the following month at 08:00 |
-   | **Quarterly Actual Regime** | Monthly | 10th of the following month | 11th of the following month at 08:00 |
-   | **Simplified VAT Taxation Regime** | Monthly | Between the 25th and 30th of the following month | 1st of the second following month at 08:00 |
-   | **Non-Established Taxpayer VAT Regime** | Bimonthly (every two calendar months) | Between the 25th and 30th of the following month | 1st of the second following month at 08:00 |
-
-Once both are in place, the party is ready to report invoices and payments (see the following sections).
-
-<Warning>
-  Invoice and payment reports are GOBL documents that use the **`fr-ctc-flow10-v1`** add-on (distinct from the `fr-ctc-flow2-v1` add-on used for e-invoicing). The Flow 10 add-on is still under development and some fields are not yet finalized — expect breaking changes until it is released.
-</Warning>
-
-#### How reporting works
-
-Once a party is registered, Invopop drives reporting automatically:
-
-- **Automatic regular reports.** For each registered SIREN, Invopop aggregates all invoices and payments sent to the reporting workflow during the current period and submits the report to the PPF on the configured cadence. No manual trigger is required — if the data is there by the deadline, the report goes out.
-- **Corrective reports.** You can also trigger a corrective report to fix an error in a previously submitted report. This is the path to use when, for example, an invoice was reported with a wrong amount (a missing zero, a typo) or the wrong transaction was included, and you need to amend a prior period rather than only adjusting future filings.
-
-Both invoice and payment reporting share this model.
-
-### Report an invoice
-
-To report an invoice, send it to a **reporting workflow**. The workflow stores the invoice against the registered SIREN; Invopop then builds and submits the periodic report to the PPF on the cadence selected at registration, and triggers a corrective report whenever one is needed.
-
-The invoice must use the `fr-ctc-flow10-v1` add-on (Flow 10), which extends the standard GOBL invoice with the fields required for French e-reporting.
-
-### Report a payment
-
-Payment reporting follows the same pattern as invoice reporting: send the payment document to a reporting workflow, Invopop stores it against the registered SIREN, and payment data is included in the periodic (and, when needed, corrective) report at the selected cadence.
-
-Payments also use the `fr-ctc-flow10-v1` add-on.
+| **Annuaire** | France's national directory of e-invoicing endpoints. Records every registered company and its PA so the tax administration can route regulated flows. Distinct from the Peppol Directory. |
+| **PPF** | _Portail Public de Facturation_ — the government data concentrator that receives the mandated invoice and reporting datasets. Invopop handles all PPF traffic. |
+| **Five-corner model** | Sender, sender's PA, receiver's PA, receiver, plus the PPF as the fifth corner. Regulated flows always send a copy to the fifth corner. |
+| **Regulated flow** | Both parties registered in the Annuaire. Routed via Peppol with a parallel submission to the PPF. |
+| **Non-regulated flow** | Only one party registered. Reported periodically to the PPF as e-reporting. |
+| **F1 invoice** | Simplified UBL forwarded to the PPF for regulated flows. Generated automatically. |
+| **CDAR** | _Cross Domain Acknowledgement and Response_. The format used for lifecycle status updates. |
+| **Flow 2 / Flow 10** | DGFiP add-on identifiers. Flow 2 (`fr-ctc-flow2-v1`) covers e-invoicing; Flow 10 (`fr-ctc-flow10-v1`) covers e-reporting. |
+
+## Plateforme Agréée guides
+
+The four sub-guides correspond to the workflows you will wire together. Most of these depend on Invopop's [Peppol](/apps/peppol), [UBL](/apps/oasis-ubl), and [CII](/apps/uncefact-cii) apps for transport and format conversion.
+
+<Columns cols="2">
+  <Card title="Registration" icon="address-book" href="/guides/fr-pa-registration" horizontal>
+    Register and deregister a party in the Annuaire and on Peppol.
+  </Card>
+  <Card title="Invoicing" icon="file-invoice" href="/guides/fr-pa-invoicing" horizontal>
+    Send and receive B2B invoices via Peppol with PPF reporting.
+  </Card>
+  <Card title="Status" icon="signal-bars" href="/guides/fr-pa-status" horizontal>
+    Send, receive, and derive lifecycle status updates (CDAR).
+  </Card>
+  <Card title="Reporting" icon="chart-line" href="/guides/fr-pa-reporting" horizontal>
+    Periodic e-reporting of B2C and non-regulated B2B transactions.
+  </Card>
+</Columns>
 
 ---
 

--- a/snippets/tables/france-resources.mdx
+++ b/snippets/tables/france-resources.mdx
@@ -4,7 +4,7 @@
 |-----------|------------|
 |  Compliance |   <Icon icon="https://assets.invopop.com/flags/fr.svg" /> [Invoicing compliance in France](/compliance/france)<br /> <Icon icon="timeline" /> [Compliance timeline](/timelines/france)|
 |  Apps |  <Icon icon="https://assets.invopop.com/apps/peppol/icon.svg" /> [Peppol](/apps/peppol)<br /><Icon icon="https://assets.invopop.com/apps/chroruspro/icon.svg" /> [ChorusPro France](/apps/choruspro-france) |
-|  Guides | <Icon icon="book" /> [ChorusPro Guide](/guides/fr-chorus-pro)<br /><Icon icon="book" /> [PA Guide](/guides/fr-pa) |
+|  Guides | <Icon icon="book" /> [ChorusPro Guide](/guides/fr-chorus-pro)<br /><Icon icon="book" /> [PA Guide](/guides/fr-pa) — [Registration](/guides/fr-pa-registration) · [Invoicing](/guides/fr-pa-invoicing) · [Status](/guides/fr-pa-status) · [Reporting](/guides/fr-pa-reporting) |
 |  FAQ | <Icon icon="square-question" /> [France FAQ](/faq/france) |
 |  GOBL | <Icon icon="https://assets.invopop.com/icons/gobl.svg" />  [France Tax Regime](https://docs.gobl.org/regimes/fr)<br /> <Icon icon="https://assets.invopop.com/icons/gobl.svg" /> [Chorus Pro Addon](https://docs.gobl.org/addons/fr-choruspro-v1)<br /> <Icon icon="https://assets.invopop.com/icons/gobl.svg" /> [French Factur-X Addon](https://docs.gobl.org/addons/fr-facturx-v1) |
 | GitHub | <Icon icon="github" /> [gobl.xinvoice](https://github.com/invopop/gobl.xinvoice) |

--- a/snippets/workflows/fr/fr-pa-deregister.mdx
+++ b/snippets/workflows/fr/fr-pa-deregister.mdx
@@ -1,0 +1,27 @@
+---
+title: "France PA deregister party workflow"
+description: "Removes a party from the Annuaire and stops periodic reporting"
+countryCode: "fr"
+appId: "gov-fr"
+schema: "org/party"
+---
+```json France PA deregister party workflow
+{
+    "name": "France PA deregister party",
+    "description": "Removes a party from the Annuaire and stops periodic reporting",
+    "schema": "org/party",
+    "steps": [
+        {
+            "id": "1a3c8a10-1e2a-11f1-8bfb-2beaa1df60f0",
+            "name": "Disable in Annuaire",
+            "provider": "directory.disable"
+        },
+        {
+            "id": "1f8a4520-1e2a-11f1-8bfb-2beaa1df60f0",
+            "name": "Disable Reporter",
+            "provider": "reporting.disable"
+        }
+    ],
+    "rescue": []
+}
+```

--- a/snippets/workflows/fr/fr-pa-receive-invoice.mdx
+++ b/snippets/workflows/fr/fr-pa-receive-invoice.mdx
@@ -63,7 +63,7 @@ schema: "bill/invoice"
         {
             "id": "2f4ad890-1e2a-11f1-8bfb-2beaa1df60f0",
             "name": "Record Invoice",
-            "provider": "gov-fr.invoice.record"
+            "provider": "directory.record"
         },
         {
             "id": "dd14a3e0-0fb5-11f0-b078-9fc456829eca",

--- a/snippets/workflows/fr/fr-pa-register.mdx
+++ b/snippets/workflows/fr/fr-pa-register.mdx
@@ -1,6 +1,6 @@
 ---
 title: "France PA register party workflow"
-description: "Registers in the French Directory and Peppol network for sending and receiving invoices"
+description: "Registers in the French Annuaire, Peppol network, and reporting register"
 countryCode: "fr"
 appId: "gov-fr"
 schema: "org/party"
@@ -8,13 +8,13 @@ schema: "org/party"
 ```json France PA register party workflow
 {
     "name": "France PA register party",
-    "description": "Registers in the French Directory and Peppol network for sending and receiving invoices",
+    "description": "Registers in the French Annuaire, Peppol network, and reporting register",
     "schema": "org/party",
     "steps": [
         {
             "id": "0adf46e0-8fdb-11f0-a8fb-61ec9e5a76ba",
-            "name": "Register Party for Approval",
-            "provider": "peppol.register.approval"
+            "name": "Sign Contract",
+            "provider": "contracts.sign"
         },
         {
             "id": "0e44b900-8fdb-11f0-a8fb-61ec9e5a76ba",
@@ -28,12 +28,17 @@ schema: "org/party"
         {
             "id": "12aaf950-8fdb-11f0-a8fb-61ec9e5a76ba",
             "name": "Wait for Approval",
-            "provider": "peppol.wait.approval"
+            "provider": "contracts.wait.approval"
         },
         {
             "id": "d10a4680-1e29-11f1-8bfb-2beaa1df60f0",
-            "name": "Register Party",
-            "provider": "gov-fr.party.register"
+            "name": "Register in Annuaire",
+            "provider": "directory.register"
+        },
+        {
+            "id": "e510a280-1e29-11f1-8bfb-2beaa1df60f0",
+            "name": "Register Reporter",
+            "provider": "reporting.register"
         },
         {
             "id": "7a5a4db0-0fae-11f0-b37b-0be1c251a274",

--- a/snippets/workflows/fr/fr-pa-send-invoice.mdx
+++ b/snippets/workflows/fr/fr-pa-send-invoice.mdx
@@ -27,8 +27,8 @@ schema: "bill/invoice"
         },
         {
             "id": "f1e30fa0-13c9-11f1-98a6-7dfa4cb26122",
-            "name": "Record Invoice (France)",
-            "provider": "gov-fr.invoice.record"
+            "name": "Record Invoice",
+            "provider": "directory.record"
         },
         {
             "id": "1b5850d0-13bf-11f1-bc3b-b99ec414b63d",
@@ -59,7 +59,7 @@ schema: "bill/invoice"
         {
             "id": "e1f6ce90-16eb-11f1-86ba-d13d91b4f398",
             "name": "Forward Invoice to PPF",
-            "provider": "gov-fr.invoice.forward"
+            "provider": "directory.send"
         },
         {
             "id": "80a9d5e0-1a17-11f1-a82f-e740c226ef51",

--- a/snippets/workflows/fr/fr-pa-send-status.mdx
+++ b/snippets/workflows/fr/fr-pa-send-status.mdx
@@ -1,25 +1,34 @@
 ---
 title: "France PA send status workflow"
-description: "Generate and forward a lifecycle status update (CDAR) via Peppol and PPF"
+description: "Record, generate, and forward a lifecycle status update (CDAR) via Peppol and PPF"
 countryCode: "fr"
 appId: "gov-fr"
 schema: "bill/invoice"
 ---
 ```json France PA send status workflow
 {
-    "name": "Send state",
-    "description": "Generate and forward a lifecycle status update (CDAR) via Peppol and PPF",
+    "name": "Send status",
+    "description": "Record, generate, and forward a lifecycle status update (CDAR) via Peppol and PPF",
     "schema": "bill/invoice",
     "steps": [
         {
             "id": "e600d990-16f5-11f1-86ba-d13d91b4f398",
-            "name": "Generate Status (France)",
-            "provider": "gov-fr.status.generate",
-            "summary": "Generate 207 status (MONTANTTOTAL_ERR)",
+            "name": "Record Status",
+            "provider": "directory.record",
+            "summary": "Record 207 status (MONTANTTOTAL_ERR)",
             "config": {
                 "reason_code": "MONTANTTOTAL_ERR",
                 "reason_text": "",
                 "status_code": "207"
+            }
+        },
+        {
+            "id": "e9008990-16f5-11f1-86ba-d13d91b4f398",
+            "name": "Generate CDAR",
+            "provider": "cii.generate",
+            "summary": "Generate CDAR XML",
+            "config": {
+                "doc_type": "cdar"
             }
         },
         {
@@ -30,7 +39,7 @@ schema: "bill/invoice"
         {
             "id": "ef5500c0-16f5-11f1-86ba-d13d91b4f398",
             "name": "Forward Status to PPF",
-            "provider": "gov-fr.status.forward"
+            "provider": "directory.send"
         }
     ],
     "rescue": []

--- a/timelines/france.mdx
+++ b/timelines/france.mdx
@@ -44,7 +44,7 @@ Current and upcoming regulation for France.
 
   | System        | Description  | Invopop Coverage |
   |---------------|---------------|---------------|
-  | [PPF (Portail Public de Facturation)](#ppf) | The French PA system relies on the Peppol network infrastructure with additional French-specific requirements, creating a "five corner model" for e-invoicing compliance | Coming Q1 2026 |
+  | [PPF (Portail Public de Facturation)](#ppf) | The French PA system relies on the Peppol network infrastructure with additional French-specific requirements, creating a "five corner model" for e-invoicing compliance | Available — see [PA guide](/guides/fr-pa) |
 
 </Update>
 


### PR DESCRIPTION
Split the 480-line fr-pa.mdx into a hub overview plus four focused sub-pages (registration, invoicing, status, reporting), each flagged with its own readiness state via Mintlify badges.

Migrated all France PA action references to the new contracts.* / directory.* / reporting.* namespaces in both prose and workflow snippets. Will land alongside the platform-side rename.

Added a new deregistration workflow (snippet + card) and documented derive-status-from-invoice and receive-status flows that were missing before.

Rewrote compliance/france.mdx to fix stale content: PPF support is no longer "Coming Q1 2026", the broken Peppol/B2G accordion is now a proper PA accordion, format list trimmed to UBL/CII/Factur-X, B2C correctly framed as exempt-from-e-invoicing-but-subject-to-e-reporting, five-corner / Annuaire / PPF concepts consolidated, terminology aligned to "PPF".

Updated FAQ with "Is Invopop ready?", "e-invoicing vs e-reporting?", "B2C-only?" entries.

Sidebar grouping under 🇫🇷 France with a nested Plateforme Agréée (PA) subgroup, plus redirects from the old fr-pa#anchor URLs to the new sub-pages.