### PR TITLE
Add IEET (Catalonia tourist tax) example to VeriFactu and SII

### DIFF
--- a/snippets/invoices/es/accordion.mdx
+++ b/snippets/invoices/es/accordion.mdx
@@ -18,6 +18,8 @@ import CreditNoteInvoice from '/snippets/invoices/es/verifactu-credit-note.mdx';
 import CreditNoteInvoiceMin from '/snippets/invoices/es/verifactu-credit-note.min.mdx';
 import CorrectiveInvoice from '/snippets/invoices/es/verifactu-corrective.mdx';
 import ReplacementInvoiceMin from '/snippets/invoices/es/verifactu-replacement.min.mdx';
+import IEETInvoice from '/snippets/invoices/es/verifactu-ieet.mdx';
+import IEETInvoiceMin from '/snippets/invoices/es/verifactu-ieet.min.mdx';
 
 
 <AccordionGroup>
@@ -163,6 +165,21 @@ import ReplacementInvoiceMin from '/snippets/invoices/es/verifactu-replacement.m
 
   <Accordion title="Replacement invoice (factura de canje)">
     <ReplacementInvoiceMin />
+  </Accordion>
+
+  <Accordion title="B2C Hotel + IEET (Catalonia tourist tax)">
+    The Catalan tourist tax (IEET, *Impost sobre les Estades en Establiments Turístics*) is a regional tax administered by the Agència Tributària de Catalunya — not the AEAT — so it is **not** classified as a tax in the VERI\*FACTU record. Hotels declare it directly to the Generalitat through the quarterly Modelo 950.
+
+    Model the IEET as a document-level [`charge`](https://docs.gobl.org/draft-0/bill/invoice#charge) with `key: "tax"`. This keeps it outside the VAT base (Art. 35 of Llei 5/2017 requires it to be shown separately from the consideration) and lets it flow into the invoice's `ImporteTotal` for VERI\*FACTU without being reported as a tax category.
+
+    <Note>
+      Do not model the IEET as a `VAT` tax line — it is a fixed amount per night, not a percentage, and should not be reported to the AEAT. The `reason` field on the charge is what appears on the guest's invoice, so include the establishment type, location, nights, and rate for a clear breakdown.
+    </Note>
+
+    <CodeGroup>
+      <IEETInvoiceMin />
+      <IEETInvoice />
+    </CodeGroup>
   </Accordion>
 
 </AccordionGroup>

--- a/snippets/invoices/es/sii-accordion.mdx
+++ b/snippets/invoices/es/sii-accordion.mdx
@@ -14,6 +14,8 @@ import B2BExemptE1InvoiceMin from '/snippets/invoices/es/sii-exempt-E1.min.mdx';
 import B2BExemptE1Invoice from '/snippets/invoices/es/sii-exempt-E1.mdx';
 import B2COneStopShopInvoiceMin from '/snippets/invoices/es/sii-b2c-oss.min.mdx';
 import B2COneStopShopInvoice from '/snippets/invoices/es/sii-b2c-oss.mdx';
+import IEETInvoiceMin from '/snippets/invoices/es/sii-ieet.min.mdx';
+import IEETInvoice from '/snippets/invoices/es/sii-ieet.mdx';
 
 <AccordionGroup>
 	<Accordion title="B2C Standard Invoice">
@@ -184,6 +186,24 @@ import B2COneStopShopInvoice from '/snippets/invoices/es/sii-b2c-oss.mdx';
 		<CodeGroup>
 			<B2COneStopShopInvoiceMin />
 			<B2COneStopShopInvoice />
+		</CodeGroup>
+	</Accordion>
+
+	<Accordion title="B2C Hotel + IEET (Catalonia tourist tax)">
+
+		The Catalan tourist tax (IEET, *Impost sobre les Estades en Establiments Turístics*) is a regional tax administered by the Agència Tributària de Catalunya — not the AEAT — so it is **not** reported as a tax to SII. Hotels declare it directly to the Generalitat through the quarterly Modelo 950.
+
+		Notice:
+
+		- model the IEET as a document-level [`charge`](https://docs.gobl.org/draft-0/bill/invoice#charge) with `key: "tax"`, which keeps it out of the VAT base while still appearing as a separate line on the guest's invoice as required by Art. 35 of Llei 5/2017,
+		- do not model the IEET as a `VAT` tax line — it is a fixed amount per night, not a percentage, and the AEAT does not collect it,
+		- the `reason` field on the charge is what the guest sees on the invoice; include the establishment type, location, nights, and rate so the breakdown is unambiguous,
+		- accommodation is invoiced with reduced VAT (10%) on the room base; the IEET charge is added on top of `total_with_tax` to produce `payable`,
+		- the quarterly Modelo 950 to the Generalitat is independent of individual invoices, but structuring the IEET as a typed charge lets hotels query their GOBL invoices for the data they need to file it.
+
+		<CodeGroup>
+			<IEETInvoiceMin />
+			<IEETInvoice />
 		</CodeGroup>
 	</Accordion>
 </AccordionGroup>

--- a/snippets/invoices/es/sii-ieet.mdx
+++ b/snippets/invoices/es/sii-ieet.mdx
@@ -1,0 +1,95 @@
+```json Built version
+{
+	"$schema": "https://gobl.org/draft-0/bill/invoice",
+	"$regime": "ES",
+	"$addons": [
+		"es-sii-v1"
+	],
+	"$tags": [
+		"simplified"
+	],
+	"type": "standard",
+	"series": "SAMPLE",
+	"issue_date": "2026-05-06",
+	"currency": "EUR",
+	"tax": {
+		"ext": {
+			"es-sii-doc-type": "F2"
+		}
+	},
+	"supplier": {
+		"name": "Hotel Barcelona Example SL",
+		"tax_id": {
+			"country": "ES",
+			"code": "B85905495"
+		},
+		"addresses": [
+			{
+				"locality": "Barcelona",
+				"code": "08001",
+				"country": "ES"
+			}
+		]
+	},
+	"lines": [
+		{
+			"i": 1,
+			"quantity": "3",
+			"item": {
+				"name": "Double room — 3 nights",
+				"price": "180.00",
+				"unit": "day"
+			},
+			"sum": "540.00",
+			"taxes": [
+				{
+					"cat": "VAT",
+					"key": "standard",
+					"rate": "reduced",
+					"percent": "10.0%",
+					"ext": {
+						"es-sii-regime": "01"
+					}
+				}
+			],
+			"total": "540.00"
+		}
+	],
+	"charges": [
+		{
+			"i": 1,
+			"key": "tax",
+			"reason": "IEET — Hotel 4★, Barcelona city — 3 nights × 1 guest × €3.40",
+			"amount": "10.20"
+		}
+	],
+	"totals": {
+		"sum": "540.00",
+		"charge": "10.20",
+		"total": "550.20",
+		"taxes": {
+			"categories": [
+				{
+					"code": "VAT",
+					"rates": [
+						{
+							"key": "standard",
+							"ext": {
+								"es-sii-regime": "01"
+							},
+							"base": "540.00",
+							"percent": "10.0%",
+							"amount": "54.00"
+						}
+					],
+					"amount": "54.00"
+				}
+			],
+			"sum": "54.00"
+		},
+		"tax": "54.00",
+		"total_with_tax": "604.20",
+		"payable": "604.20"
+	}
+}
+```

--- a/snippets/invoices/es/sii-ieet.min.mdx
+++ b/snippets/invoices/es/sii-ieet.min.mdx
@@ -1,0 +1,50 @@
+```json B2C Hotel + IEET (Catalonia tourist tax)
+{
+  "$schema": "https://gobl.org/draft-0/bill/invoice",
+  "$addons": [
+    "es-sii-v1"
+  ],
+  "$tags": [
+    "simplified"
+  ],
+  "series": "SAMPLE",
+  "issue_date": "2026-05-06",
+  "supplier": {
+    "name": "Hotel Barcelona Example SL",
+    "tax_id": {
+      "country": "ES",
+      "code": "B85905495"
+    },
+    "addresses": [
+      {
+        "locality": "Barcelona",
+        "code": "08001",
+        "country": "ES"
+      }
+    ]
+  },
+  "lines": [
+    {
+      "quantity": "3",
+      "item": {
+        "name": "Double room — 3 nights",
+        "price": "180.00",
+        "unit": "day"
+      },
+      "taxes": [
+        {
+          "cat": "VAT",
+          "rate": "reduced"
+        }
+      ]
+    }
+  ],
+  "charges": [
+    {
+      "key": "tax",
+      "reason": "IEET — Hotel 4★, Barcelona city — 3 nights × 1 guest × €3.40",
+      "amount": "10.20"
+    }
+  ]
+}
+```

--- a/snippets/invoices/es/verifactu-ieet.mdx
+++ b/snippets/invoices/es/verifactu-ieet.mdx
@@ -1,0 +1,106 @@
+```json Built version
+{
+	"$schema": "https://gobl.org/draft-0/bill/invoice",
+	"$regime": "ES",
+	"$addons": [
+		"es-verifactu-v1"
+	],
+	"$tags": [
+		"simplified"
+	],
+	"type": "standard",
+	"series": "SAMPLE",
+	"issue_date": "2026-05-06",
+	"currency": "EUR",
+	"tax": {
+		"ext": {
+			"es-verifactu-doc-type": "F2"
+		}
+	},
+	"supplier": {
+		"name": "Hotel Barcelona Example SL",
+		"tax_id": {
+			"country": "ES",
+			"code": "B85905495"
+		},
+		"addresses": [
+			{
+				"locality": "Barcelona",
+				"code": "08001",
+				"country": "ES"
+			}
+		]
+	},
+	"customer": {
+		"name": "John Smith",
+		"addresses": [
+			{
+				"locality": "London",
+				"country": "GB"
+			}
+		]
+	},
+	"lines": [
+		{
+			"i": 1,
+			"quantity": "3",
+			"item": {
+				"name": "Double room — 3 nights",
+				"price": "180.00",
+				"unit": "day"
+			},
+			"sum": "540.00",
+			"taxes": [
+				{
+					"cat": "VAT",
+					"key": "standard",
+					"rate": "reduced",
+					"percent": "10.0%",
+					"ext": {
+						"es-verifactu-op-class": "S1",
+						"es-verifactu-regime": "01"
+					}
+				}
+			],
+			"total": "540.00"
+		}
+	],
+	"charges": [
+		{
+			"i": 1,
+			"key": "tax",
+			"reason": "IEET — Hotel 4★, Barcelona city — 3 nights × 1 guest × €3.40",
+			"amount": "10.20"
+		}
+	],
+	"totals": {
+		"sum": "540.00",
+		"charge": "10.20",
+		"total": "550.20",
+		"taxes": {
+			"categories": [
+				{
+					"code": "VAT",
+					"rates": [
+						{
+							"key": "standard",
+							"ext": {
+								"es-verifactu-op-class": "S1",
+								"es-verifactu-regime": "01"
+							},
+							"base": "540.00",
+							"percent": "10.0%",
+							"amount": "54.00"
+						}
+					],
+					"amount": "54.00"
+				}
+			],
+			"sum": "54.00"
+		},
+		"tax": "54.00",
+		"total_with_tax": "604.20",
+		"payable": "604.20"
+	}
+}
+```

--- a/snippets/invoices/es/verifactu-ieet.min.mdx
+++ b/snippets/invoices/es/verifactu-ieet.min.mdx
@@ -1,0 +1,59 @@
+```json B2C Hotel + IEET (Catalonia tourist tax)
+{
+  "$schema": "https://gobl.org/draft-0/bill/invoice",
+  "$addons": [
+    "es-verifactu-v1"
+  ],
+  "$tags": [
+    "simplified"
+  ],
+  "series": "SAMPLE",
+  "issue_date": "2026-05-06",
+  "supplier": {
+    "name": "Hotel Barcelona Example SL",
+    "tax_id": {
+      "country": "ES",
+      "code": "B85905495"
+    },
+    "addresses": [
+      {
+        "locality": "Barcelona",
+        "code": "08001",
+        "country": "ES"
+      }
+    ]
+  },
+  "customer": {
+    "name": "John Smith",
+    "addresses": [
+      {
+        "locality": "London",
+        "country": "GB"
+      }
+    ]
+  },
+  "lines": [
+    {
+      "quantity": "3",
+      "item": {
+        "name": "Double room — 3 nights",
+        "price": "180.00",
+        "unit": "day"
+      },
+      "taxes": [
+        {
+          "cat": "VAT",
+          "rate": "reduced"
+        }
+      ]
+    }
+  ],
+  "charges": [
+    {
+      "key": "tax",
+      "reason": "IEET — Hotel 4★, Barcelona city — 3 nights × 1 guest × €3.40",
+      "amount": "10.20"
+    }
+  ]
+}
+```


### PR DESCRIPTION
## Summary

Documents how to model the Catalan tourist tax (IEET, *Impost sobre les Estades en Establiments Turístics*) on Spanish invoices, prompted by a customer support thread.

The IEET is administered by the Agència Tributària de Catalunya — not the AEAT — and is declared via the quarterly Modelo 950, so it should **not** be reported as a tax in VERI*FACTU or SII records. The recommended GOBL pattern is a document-level `charge` with `key: "tax"`, which:

- keeps the IEET outside the VAT base (Art. 35 of Llei 5/2017 requires it to be shown separately from the consideration),
- flows into `ImporteTotal` without being classified as a tax category,
- renders as a separate concept on the guest's invoice via the `reason` field.

A new "B2C Hotel + IEET (Catalonia tourist tax)" accordion is added to both the VeriFactu and SII example accordions, with min and built versions generated by `gobl build` (3 nights × €180 room + reduced VAT 10% + €10.20 IEET → €604.20 payable).

## Files

- `snippets/invoices/es/verifactu-ieet.min.mdx` + `verifactu-ieet.mdx`
- `snippets/invoices/es/sii-ieet.min.mdx` + `sii-ieet.mdx`
- Wired into `accordion.mdx` and `sii-accordion.mdx`

## Notes for reviewers

- The SII version omits the `customer` block because SII validation requires a `tax_id` or `es-sii-identity-type` identity on any customer, and the example tourist has neither. The existing `sii-b2c.min.mdx` snippet handles this the same way. The VeriFactu version keeps the named non-resident guest from the original support thread.
- Built `.mdx` files were produced by `gobl-build.sh` (`gobl build` on the corresponding `.min.mdx`).

## Test plan

- [ ] Render the VeriFactu app/guide pages and confirm the new accordion appears with both min and built tabs
- [ ] Render the SII guide page and confirm the same
- [ ] Verify `gobl build` still succeeds on both `.min.mdx` files

🤖 Generated with [Claude Code](https://claude.com/claude-code)