### PR TITLE
Add France PA and cross-border invoice examples

### DIFF
--- a/apps/france.mdx
+++ b/apps/france.mdx
@@ -13,6 +13,7 @@ import PaSendStatusWorkflow from '/snippets/workflows/fr/fr-pa-send-status.mdx';
 import FacturxWorkflow from '/snippets/workflows/fr/facturx-invoice.mdx';
 import PeppolAccordion from '/snippets/invoices/fr/peppol-accordion.mdx';
 import FacturxAccordion from '/snippets/invoices/fr/facturx-accordion.mdx';
+import PaAccordion from '/snippets/invoices/fr/pa-accordion.mdx';
 import Supplier from '/snippets/suppliers/fr/company.mdx';
 import FranceResources from '/snippets/tables/france-resources.mdx';
 import FAQ from '/snippets/faqs/fr/composers/app-france.mdx';
@@ -173,7 +174,11 @@ import FAQ from '/snippets/faqs/fr/composers/app-france.mdx';
 			</Accordion>
 		</AccordionGroup>
 
-		Plateforme Agréée example invoices
+		Plateforme Agréée (Flow 2) example invoices
+
+		<PaAccordion />
+
+		Peppol-only example invoices
 
 		<PeppolAccordion />
 

--- a/guides/fr-pa-invoicing.mdx
+++ b/guides/fr-pa-invoicing.mdx
@@ -7,6 +7,7 @@ description: Send and receive B2B invoices over Peppol with automatic PPF report
 import FranceResources from '/snippets/tables/france-resources.mdx';
 import SendInvoiceWorkflow from '/snippets/workflows/fr/fr-pa-send-invoice.mdx';
 import ReceiveInvoiceWorkflow from '/snippets/workflows/fr/fr-pa-receive-invoice.mdx';
+import PaAccordion from '/snippets/invoices/fr/pa-accordion.mdx';
 import FAQ from '/snippets/faqs/fr/composers/guide-pa-invoicing.mdx';
 
 <Note>
@@ -113,6 +114,12 @@ The receive workflow detects the inbound format, imports it into a GOBL document
     <ReceiveInvoiceWorkflow />
   </Tab>
 </Tabs>
+
+## Example invoices
+
+Each example below pairs a hand-authored minimal GOBL invoice with the built version produced by `gobl build`. Paste either into the [GOBL builder](https://build.gobl.org) to preview the document, or use the minimal version as a starting point for your own integration.
+
+<PaAccordion />
 
 ## FAQ
 

--- a/snippets/invoices/fr/chorus-pro-accordion.mdx
+++ b/snippets/invoices/fr/chorus-pro-accordion.mdx
@@ -1,5 +1,7 @@
 import B2GInvoice from '/snippets/invoices/fr/chorus-pro-b2g.min.mdx';
 import B2GInvoiceBuilt from '/snippets/invoices/fr/chorus-pro-b2g.mdx';
+import CrossBorderMin from '/snippets/invoices/fr/chorus-pro-cross-border.min.mdx';
+import CrossBorder from '/snippets/invoices/fr/chorus-pro-cross-border.mdx';
 
 <AccordionGroup>
 	<Accordion title="Chorus Pro B2G Invoice">
@@ -20,6 +22,22 @@ import B2GInvoiceBuilt from '/snippets/invoices/fr/chorus-pro-b2g.mdx';
 		<CodeGroup>
 			<B2GInvoice />
 			<B2GInvoiceBuilt />
+		</CodeGroup>
+	</Accordion>
+
+	<Accordion title="Chorus Pro cross-border invoice (DE → FR)">
+
+		A non-French supplier invoicing a French public sector entity through Chorus Pro. Chorus Pro accepts foreign suppliers — the customer's SIRET is what anchors the document to the right administration.
+
+		Notice:
+
+		- the supplier carries a DE tax ID and address, while the customer keeps its `SIRET` identity,
+		- the `fr-choruspro-v1` add-on still applies — Chorus Pro routing rules are driven by the receiver, not the issuer,
+		- VAT is reported as standard French VAT because the place of supply is France; cross-border reverse-charge cases would set the line tax accordingly.
+
+		<CodeGroup>
+			<CrossBorderMin />
+			<CrossBorder />
 		</CodeGroup>
 	</Accordion>
 </AccordionGroup>

--- a/snippets/invoices/fr/chorus-pro-cross-border.mdx
+++ b/snippets/invoices/fr/chorus-pro-cross-border.mdx
@@ -1,0 +1,141 @@
+```json Built version
+{
+	"$schema": "https://gobl.org/draft-0/bill/invoice",
+	"$regime": "FR",
+	"$addons": [
+		"eu-en16931-v2017",
+		"fr-choruspro-v1"
+	],
+	"type": "standard",
+	"series": "SAMPLE",
+	"code": "001",
+	"issue_date": "2022-02-01",
+	"currency": "EUR",
+	"tax": {
+		"ext": {
+			"fr-choruspro-framework": "A1",
+			"untdid-document-type": "380"
+		}
+	},
+	"supplier": {
+		"name": "Provide One Inc.",
+		"tax_id": {
+			"country": "DE",
+			"code": "111111125"
+		},
+		"addresses": [
+			{
+				"num": "42",
+				"street": "Berliner Strasse",
+				"locality": "Berlin",
+				"code": "10117",
+				"country": "DE"
+			}
+		],
+		"emails": [
+			{
+				"addr": "billing@example.com"
+			}
+		],
+		"ext": {
+			"fr-choruspro-scheme": "2"
+		}
+	},
+	"customer": {
+		"name": "Sample Public Entity",
+		"tax_id": {
+			"country": "FR",
+			"code": "44732829320"
+		},
+		"identities": [
+			{
+				"type": "SIRET",
+				"code": "73282932012345",
+				"ext": {
+					"iso-scheme-id": "0009"
+				}
+			}
+		],
+		"addresses": [
+			{
+				"num": "1",
+				"street": "Rue Sundacsakn",
+				"locality": "Saint-Germain-En-Laye",
+				"code": "75050",
+				"country": "FR"
+			}
+		],
+		"emails": [
+			{
+				"addr": "email@sample.com"
+			}
+		],
+		"ext": {
+			"fr-choruspro-scheme": "1"
+		}
+	},
+	"lines": [
+		{
+			"i": 1,
+			"quantity": "20",
+			"item": {
+				"name": "Development services",
+				"price": "90.00",
+				"unit": "h"
+			},
+			"sum": "1800.00",
+			"discounts": [
+				{
+					"reason": "Special discount",
+					"percent": "10%",
+					"amount": "180.00"
+				}
+			],
+			"taxes": [
+				{
+					"cat": "VAT",
+					"key": "standard",
+					"rate": "general",
+					"percent": "20%",
+					"ext": {
+						"untdid-tax-category": "S"
+					}
+				}
+			],
+			"total": "1620.00"
+		}
+	],
+	"payment": {
+		"terms": {
+			"notes": "Please pay within 10 days"
+		}
+	},
+	"totals": {
+		"sum": "1620.00",
+		"total": "1620.00",
+		"taxes": {
+			"categories": [
+				{
+					"code": "VAT",
+					"rates": [
+						{
+							"key": "standard",
+							"ext": {
+								"untdid-tax-category": "S"
+							},
+							"base": "1620.00",
+							"percent": "20%",
+							"amount": "324.00"
+						}
+					],
+					"amount": "324.00"
+				}
+			],
+			"sum": "324.00"
+		},
+		"tax": "324.00",
+		"total_with_tax": "1944.00",
+		"payable": "1944.00"
+	}
+}
+```

--- a/snippets/invoices/fr/chorus-pro-cross-border.min.mdx
+++ b/snippets/invoices/fr/chorus-pro-cross-border.min.mdx
@@ -1,0 +1,89 @@
+```json Chorus Pro Cross-Border Invoice (DE → FR)
+{
+    "$schema": "https://gobl.org/draft-0/bill/invoice",
+    "$regime": "FR",
+    "$addons": [
+        "fr-choruspro-v1"
+    ],
+    "type": "standard",
+    "series": "SAMPLE",
+    "code": "001",
+    "issue_date": "2022-02-01",
+    "currency": "EUR",
+    "supplier": {
+        "name": "Provide One Inc.",
+        "tax_id": {
+            "country": "DE",
+            "code": "111111125"
+        },
+        "addresses": [
+            {
+                "num": "42",
+                "street": "Berliner Strasse",
+                "locality": "Berlin",
+                "code": "10117",
+                "country": "DE"
+            }
+        ],
+        "emails": [
+            {
+                "addr": "billing@example.com"
+            }
+        ]
+    },
+    "customer": {
+        "name": "Sample Public Entity",
+        "tax_id": {
+            "country": "FR",
+            "code": "732829320"
+        },
+        "identities": [
+            {
+                "type": "SIRET",
+                "code": "73282932012345"
+            }
+        ],
+        "addresses": [
+            {
+                "num": "1",
+                "street": "Rue Sundacsakn",
+                "locality": "Saint-Germain-En-Laye",
+                "code": "75050",
+                "country": "FR"
+            }
+        ],
+        "emails": [
+            {
+                "addr": "email@sample.com"
+            }
+        ]
+    },
+    "lines": [
+        {
+            "quantity": "20",
+            "item": {
+                "name": "Development services",
+                "price": "90.00",
+                "unit": "h"
+            },
+            "discounts": [
+                {
+                    "percent": "10%",
+                    "reason": "Special discount"
+                }
+            ],
+            "taxes": [
+                {
+                    "cat": "VAT",
+                    "rate": "standard"
+                }
+            ]
+        }
+    ],
+    "payment": {
+        "terms": {
+            "detail": "Please pay within 10 days"
+        }
+    }
+}
+```

--- a/snippets/invoices/fr/pa-accordion.mdx
+++ b/snippets/invoices/fr/pa-accordion.mdx
@@ -1,0 +1,75 @@
+import B2BMin from '/snippets/invoices/fr/pa-b2b.min.mdx';
+import B2B from '/snippets/invoices/fr/pa-b2b.mdx';
+import CreditNoteMin from '/snippets/invoices/fr/pa-credit-note.min.mdx';
+import CreditNote from '/snippets/invoices/fr/pa-credit-note.mdx';
+import AdvanceMin from '/snippets/invoices/fr/pa-advance.min.mdx';
+import Advance from '/snippets/invoices/fr/pa-advance.mdx';
+import InternationalMin from '/snippets/invoices/fr/pa-b2b-international.min.mdx';
+import International from '/snippets/invoices/fr/pa-b2b-international.mdx';
+
+<AccordionGroup>
+
+	<Accordion title="PA B2B invoice (domestic)">
+
+		A regulated B2B invoice between two French parties, both registered in the Annuaire. The [`fr-ctc-flow2-v1`](https://docs.gobl.org/addons/fr-ctc-flow2-v1) add-on drives validation for the PA e-invoicing flow.
+
+		Notice:
+
+		- both parties carry a `SIREN` identity with `iso-scheme-id` `0002` and a `peppol` inbox under scheme `0225` so the workflow can route via Peppol,
+		- `fr-ctc-billing-mode` `B7` marks this as a standard B2B invoice; `untdid-document-type` `380` confirms the commercial invoice type,
+		- the `payment`, `payment-method`, and `payment-term` notes carry the French legal-mention text (penalty clauses, late-payment terms, early-payment discount), each tagged with the appropriate UNTDID 4451 subject code,
+		- `ordering.code` records the customer's purchase order reference.
+
+		<CodeGroup>
+			<B2BMin />
+			<B2B />
+		</CodeGroup>
+	</Accordion>
+
+	<Accordion title="PA B2B credit note">
+
+		A credit note that partially cancels a previously issued PA invoice. The `preceding` array references the original invoice by series, code, and issue date.
+
+		Notice:
+
+		- `type` is `credit-note` and `untdid-document-type` is `381` (commercial credit note),
+		- the `preceding` block makes the link to the original invoice explicit — required for PA matching at the PPF.
+
+		<CodeGroup>
+			<CreditNoteMin />
+			<CreditNote />
+		</CodeGroup>
+	</Accordion>
+
+	<Accordion title="PA B2B advance payment invoice">
+
+		An advance (down-payment) invoice — used when a payment is collected before the final goods or services are delivered.
+
+		Notice:
+
+		- `fr-ctc-billing-mode` is `B1` (advance / down payment) and `untdid-document-type` is `386`,
+		- the final invoice issued at delivery normally references this advance to net it off the total.
+
+		<CodeGroup>
+			<AdvanceMin />
+			<Advance />
+		</CodeGroup>
+	</Accordion>
+
+	<Accordion title="PA cross-border B2B invoice (FR → DE)">
+
+		A French supplier invoicing a customer in another EU member state. Cross-border B2B is **not** transmitted via the PA e-invoicing flow — it falls under [e-reporting](/guides/fr-pa-reporting) instead — but the same GOBL document is used as the source of truth for both.
+
+		Notice:
+
+		- the customer carries a DE tax ID and a generic email inbox rather than a Peppol address,
+		- VAT is `exempt` with the `untdid-tax-category` `K` and `cef-vatex` `VATEX-EU-IC` to mark the intra-community supply,
+		- once the [`fr-ctc-flow10-v1`](https://docs.gobl.org/addons/fr-ctc-flow10-v1) add-on is released, this document will additionally feed the periodic e-report to the PPF.
+
+		<CodeGroup>
+			<InternationalMin />
+			<International />
+		</CodeGroup>
+	</Accordion>
+
+</AccordionGroup>

--- a/snippets/invoices/fr/pa-advance.mdx
+++ b/snippets/invoices/fr/pa-advance.mdx
@@ -1,0 +1,189 @@
+```json Built version
+{
+	"$schema": "https://gobl.org/draft-0/bill/invoice",
+	"$regime": "FR",
+	"$addons": [
+		"eu-en16931-v2017",
+		"fr-ctc-flow2-v1"
+	],
+	"type": "standard",
+	"series": "FAC",
+	"code": "2024-AV-001",
+	"issue_date": "2024-06-01",
+	"currency": "EUR",
+	"tax": {
+		"rounding": "currency",
+		"ext": {
+			"fr-ctc-billing-mode": "B1",
+			"untdid-document-type": "380"
+		}
+	},
+	"supplier": {
+		"name": "Fournisseur Example SARL",
+		"tax_id": {
+			"country": "FR",
+			"code": "44732829320"
+		},
+		"identities": [
+			{
+				"scope": "legal",
+				"type": "SIREN",
+				"code": "732829320",
+				"ext": {
+					"iso-scheme-id": "0002"
+				}
+			}
+		],
+		"inboxes": [
+			{
+				"key": "peppol",
+				"scheme": "0225",
+				"code": "732829320"
+			}
+		],
+		"addresses": [
+			{
+				"num": "123",
+				"street": "Rue de la Paix",
+				"locality": "Paris",
+				"code": "75001",
+				"country": "FR"
+			}
+		],
+		"emails": [
+			{
+				"addr": "facturation@fournisseur.fr"
+			}
+		]
+	},
+	"customer": {
+		"name": "Client Example SAS",
+		"tax_id": {
+			"country": "FR",
+			"code": "39356000000"
+		},
+		"identities": [
+			{
+				"scope": "legal",
+				"type": "SIREN",
+				"code": "356000000",
+				"ext": {
+					"iso-scheme-id": "0002"
+				}
+			}
+		],
+		"inboxes": [
+			{
+				"key": "peppol",
+				"scheme": "0225",
+				"code": "356000000"
+			}
+		],
+		"addresses": [
+			{
+				"num": "456",
+				"street": "Avenue des Champs-Elysees",
+				"locality": "Paris",
+				"code": "75008",
+				"country": "FR"
+			}
+		],
+		"emails": [
+			{
+				"addr": "comptabilite@client.fr"
+			}
+		]
+	},
+	"lines": [
+		{
+			"i": 1,
+			"quantity": "1",
+			"item": {
+				"name": "Acompte - Projet de developpement",
+				"price": "5000.00",
+				"unit": "one"
+			},
+			"sum": "5000.00",
+			"taxes": [
+				{
+					"cat": "VAT",
+					"key": "standard",
+					"rate": "general",
+					"percent": "20%",
+					"ext": {
+						"untdid-tax-category": "S"
+					}
+				}
+			],
+			"total": "5000.00"
+		}
+	],
+	"payment": {
+		"terms": {
+			"notes": "Paiement immediat"
+		},
+		"instructions": {
+			"key": "credit-transfer",
+			"credit_transfer": [
+				{
+					"iban": "FR7630006000011234567890189",
+					"name": "Fournisseur Example SARL"
+				}
+			],
+			"ext": {
+				"untdid-payment-means": "30"
+			}
+		}
+	},
+	"totals": {
+		"sum": "5000.00",
+		"total": "5000.00",
+		"taxes": {
+			"categories": [
+				{
+					"code": "VAT",
+					"rates": [
+						{
+							"key": "standard",
+							"ext": {
+								"untdid-tax-category": "S"
+							},
+							"base": "5000.00",
+							"percent": "20%",
+							"amount": "1000.00"
+						}
+					],
+					"amount": "1000.00"
+				}
+			],
+			"sum": "1000.00"
+		},
+		"tax": "1000.00",
+		"total_with_tax": "6000.00",
+		"payable": "6000.00"
+	},
+	"notes": [
+		{
+			"key": "payment",
+			"text": "Une penalite fixe de 40 EUR sera appliquee en cas de retard de paiement.",
+			"ext": {
+				"untdid-text-subject": "PMT"
+			}
+		},
+		{
+			"key": "payment-method",
+			"text": "Des penalites de retard s'appliquent conformement a nos conditions generales de vente.",
+			"ext": {
+				"untdid-text-subject": "PMD"
+			}
+		},
+		{
+			"key": "payment-term",
+			"text": "Aucun escompte n'est offert pour paiement anticipe.",
+			"ext": {
+				"untdid-text-subject": "AAB"
+			}
+		}
+	]
+}
+```

--- a/snippets/invoices/fr/pa-advance.min.mdx
+++ b/snippets/invoices/fr/pa-advance.min.mdx
@@ -1,0 +1,146 @@
+```json PA B2B Advance Payment Invoice
+{
+    "$schema": "https://gobl.org/draft-0/bill/invoice",
+    "$regime": "FR",
+    "$addons": [
+        "fr-ctc-flow2-v1"
+    ],
+    "type": "standard",
+    "series": "FAC",
+    "code": "2024-AV-001",
+    "issue_date": "2024-06-01",
+    "currency": "EUR",
+    "tax": {
+        "ext": {
+            "fr-ctc-billing-mode": "B1",
+            "untdid-document-type": "386"
+        }
+    },
+    "supplier": {
+        "name": "Fournisseur Example SARL",
+        "tax_id": {
+            "country": "FR",
+            "code": "732829320"
+        },
+        "identities": [
+            {
+                "type": "SIREN",
+                "code": "732829320",
+                "ext": {
+                    "iso-scheme-id": "0002"
+                }
+            }
+        ],
+        "inboxes": [
+            {
+                "key": "peppol",
+                "scheme": "0225",
+                "code": "732829320"
+            }
+        ],
+        "addresses": [
+            {
+                "num": "123",
+                "street": "Rue de la Paix",
+                "locality": "Paris",
+                "code": "75001",
+                "country": "FR"
+            }
+        ],
+        "emails": [
+            {
+                "addr": "facturation@fournisseur.fr"
+            }
+        ]
+    },
+    "customer": {
+        "name": "Client Example SAS",
+        "tax_id": {
+            "country": "FR",
+            "code": "356000000"
+        },
+        "identities": [
+            {
+                "type": "SIREN",
+                "code": "356000000",
+                "ext": {
+                    "iso-scheme-id": "0002"
+                }
+            }
+        ],
+        "inboxes": [
+            {
+                "key": "peppol",
+                "scheme": "0225",
+                "code": "356000000"
+            }
+        ],
+        "addresses": [
+            {
+                "num": "456",
+                "street": "Avenue des Champs-Elysees",
+                "locality": "Paris",
+                "code": "75008",
+                "country": "FR"
+            }
+        ],
+        "emails": [
+            {
+                "addr": "comptabilite@client.fr"
+            }
+        ]
+    },
+    "lines": [
+        {
+            "quantity": "1",
+            "item": {
+                "name": "Acompte - Projet de developpement",
+                "price": "5000.00"
+            },
+            "taxes": [
+                {
+                    "cat": "VAT",
+                    "rate": "standard"
+                }
+            ]
+        }
+    ],
+    "notes": [
+        {
+            "key": "payment",
+            "text": "Une penalite fixe de 40 EUR sera appliquee en cas de retard de paiement.",
+            "ext": {
+                "untdid-text-subject": "PMT"
+            }
+        },
+        {
+            "key": "payment-method",
+            "text": "Des penalites de retard s'appliquent conformement a nos conditions generales de vente.",
+            "ext": {
+                "untdid-text-subject": "PMD"
+            }
+        },
+        {
+            "key": "payment-term",
+            "text": "Aucun escompte n'est offert pour paiement anticipe.",
+            "ext": {
+                "untdid-text-subject": "AAB"
+            }
+        }
+    ],
+    "payment": {
+        "instructions": {
+            "key": "credit-transfer",
+            "credit_transfer": [
+                {
+                    "iban": "FR7630006000011234567890189",
+                    "name": "Fournisseur Example SARL"
+                }
+            ]
+        },
+        "terms": {
+            "detail": "Paiement immediat"
+        }
+    }
+}
+```

--- a/snippets/invoices/fr/pa-b2b-international.mdx
+++ b/snippets/invoices/fr/pa-b2b-international.mdx
@@ -1,0 +1,176 @@
+```json Built version
+{
+	"$schema": "https://gobl.org/draft-0/bill/invoice",
+	"$regime": "FR",
+	"$addons": [
+		"eu-en16931-v2017",
+		"fr-ctc-flow2-v1"
+	],
+	"type": "standard",
+	"series": "FAC",
+	"code": "2024-INT-001",
+	"issue_date": "2024-06-15",
+	"currency": "EUR",
+	"tax": {
+		"rounding": "currency",
+		"ext": {
+			"fr-ctc-billing-mode": "B7",
+			"untdid-document-type": "380"
+		}
+	},
+	"supplier": {
+		"name": "Fournisseur France SARL",
+		"tax_id": {
+			"country": "FR",
+			"code": "44732829320"
+		},
+		"identities": [
+			{
+				"scope": "legal",
+				"type": "SIREN",
+				"code": "732829320",
+				"ext": {
+					"iso-scheme-id": "0002"
+				}
+			}
+		],
+		"inboxes": [
+			{
+				"key": "peppol",
+				"scheme": "0225",
+				"code": "732829320"
+			}
+		],
+		"addresses": [
+			{
+				"num": "123",
+				"street": "Rue de la Paix",
+				"locality": "Paris",
+				"code": "75001",
+				"country": "FR"
+			}
+		],
+		"emails": [
+			{
+				"addr": "facturation@fournisseur.fr"
+			}
+		]
+	},
+	"customer": {
+		"name": "Kunde Deutschland GmbH",
+		"tax_id": {
+			"country": "DE",
+			"code": "111111125"
+		},
+		"inboxes": [
+			{
+				"email": "buchhaltung@kunde.de"
+			}
+		],
+		"addresses": [
+			{
+				"num": "10",
+				"street": "Berliner Strasse",
+				"locality": "Berlin",
+				"code": "10117",
+				"country": "DE"
+			}
+		],
+		"emails": [
+			{
+				"addr": "buchhaltung@kunde.de"
+			}
+		]
+	},
+	"lines": [
+		{
+			"i": 1,
+			"quantity": "5",
+			"item": {
+				"name": "Consulting services",
+				"price": "200.00",
+				"unit": "h"
+			},
+			"sum": "1000.00",
+			"taxes": [
+				{
+					"cat": "VAT",
+					"key": "exempt",
+					"ext": {
+						"cef-vatex": "VATEX-EU-IC",
+						"untdid-tax-category": "E"
+					}
+				}
+			],
+			"total": "1000.00"
+		}
+	],
+	"payment": {
+		"terms": {
+			"notes": "Payment within 30 days"
+		},
+		"instructions": {
+			"key": "credit-transfer",
+			"credit_transfer": [
+				{
+					"iban": "FR7630006000011234567890189",
+					"name": "Fournisseur France SARL"
+				}
+			],
+			"ext": {
+				"untdid-payment-means": "30"
+			}
+		}
+	},
+	"totals": {
+		"sum": "1000.00",
+		"total": "1000.00",
+		"taxes": {
+			"categories": [
+				{
+					"code": "VAT",
+					"rates": [
+						{
+							"key": "exempt",
+							"ext": {
+								"cef-vatex": "VATEX-EU-IC",
+								"untdid-tax-category": "E"
+							},
+							"base": "1000.00",
+							"amount": "0.00"
+						}
+					],
+					"amount": "0.00"
+				}
+			],
+			"sum": "0.00"
+		},
+		"tax": "0.00",
+		"total_with_tax": "1000.00",
+		"payable": "1000.00"
+	},
+	"notes": [
+		{
+			"key": "payment",
+			"text": "A fixed penalty of 40 EUR will apply to any late payment.",
+			"ext": {
+				"untdid-text-subject": "PMT"
+			}
+		},
+		{
+			"key": "payment-method",
+			"text": "Late payment penalties apply as per our general terms of sale.",
+			"ext": {
+				"untdid-text-subject": "PMD"
+			}
+		},
+		{
+			"key": "payment-term",
+			"text": "No discount offered for early payment.",
+			"ext": {
+				"untdid-text-subject": "AAB"
+			}
+		}
+	]
+}
+```

--- a/snippets/invoices/fr/pa-b2b-international.min.mdx
+++ b/snippets/invoices/fr/pa-b2b-international.min.mdx
@@ -1,0 +1,140 @@
+```json PA Cross-Border B2B Invoice (FR → DE)
+{
+    "$schema": "https://gobl.org/draft-0/bill/invoice",
+    "$regime": "FR",
+    "$addons": [
+        "fr-ctc-flow2-v1"
+    ],
+    "type": "standard",
+    "series": "FAC",
+    "code": "2024-INT-001",
+    "issue_date": "2024-06-15",
+    "currency": "EUR",
+    "tax": {
+        "ext": {
+            "fr-ctc-billing-mode": "B7",
+            "untdid-document-type": "380"
+        }
+    },
+    "supplier": {
+        "name": "Fournisseur France SARL",
+        "tax_id": {
+            "country": "FR",
+            "code": "732829320"
+        },
+        "identities": [
+            {
+                "type": "SIREN",
+                "code": "732829320",
+                "ext": {
+                    "iso-scheme-id": "0002"
+                }
+            }
+        ],
+        "inboxes": [
+            {
+                "key": "peppol",
+                "scheme": "0225",
+                "code": "732829320"
+            }
+        ],
+        "addresses": [
+            {
+                "num": "123",
+                "street": "Rue de la Paix",
+                "locality": "Paris",
+                "code": "75001",
+                "country": "FR"
+            }
+        ],
+        "emails": [
+            {
+                "addr": "facturation@fournisseur.fr"
+            }
+        ]
+    },
+    "customer": {
+        "name": "Kunde Deutschland GmbH",
+        "tax_id": {
+            "country": "DE",
+            "code": "111111125"
+        },
+        "inboxes": [
+            {
+                "email": "buchhaltung@kunde.de"
+            }
+        ],
+        "addresses": [
+            {
+                "num": "10",
+                "street": "Berliner Strasse",
+                "locality": "Berlin",
+                "code": "10117",
+                "country": "DE"
+            }
+        ],
+        "emails": [
+            {
+                "addr": "buchhaltung@kunde.de"
+            }
+        ]
+    },
+    "lines": [
+        {
+            "quantity": "5",
+            "item": {
+                "name": "Consulting services",
+                "price": "200.00",
+                "unit": "h"
+            },
+            "taxes": [
+                {
+                    "cat": "VAT",
+                    "rate": "exempt",
+                    "ext": {
+                        "untdid-tax-category": "K",
+                        "cef-vatex": "VATEX-EU-IC"
+                    }
+                }
+            ]
+        }
+    ],
+    "notes": [
+        {
+            "key": "payment",
+            "text": "A fixed penalty of 40 EUR will apply to any late payment.",
+            "ext": {
+                "untdid-text-subject": "PMT"
+            }
+        },
+        {
+            "key": "payment-method",
+            "text": "Late payment penalties apply as per our general terms of sale.",
+            "ext": {
+                "untdid-text-subject": "PMD"
+            }
+        },
+        {
+            "key": "payment-term",
+            "text": "No discount offered for early payment.",
+            "ext": {
+                "untdid-text-subject": "AAB"
+            }
+        }
+    ],
+    "payment": {
+        "instructions": {
+            "key": "credit-transfer",
+            "credit_transfer": [
+                {
+                    "iban": "FR7630006000011234567890189",
+                    "name": "Fournisseur France SARL"
+                }
+            ]
+        },
+        "terms": {
+            "detail": "Payment within 30 days"
+        }
+    }
+}
+```

--- a/snippets/invoices/fr/pa-b2b.mdx
+++ b/snippets/invoices/fr/pa-b2b.mdx
@@ -1,0 +1,209 @@
+```json Built version
+{
+	"$schema": "https://gobl.org/draft-0/bill/invoice",
+	"$regime": "FR",
+	"$addons": [
+		"eu-en16931-v2017",
+		"fr-ctc-flow2-v1"
+	],
+	"type": "standard",
+	"series": "FAC",
+	"code": "2024-00001",
+	"issue_date": "2024-06-13",
+	"currency": "EUR",
+	"tax": {
+		"rounding": "currency",
+		"ext": {
+			"fr-ctc-billing-mode": "B7",
+			"untdid-document-type": "380"
+		}
+	},
+	"supplier": {
+		"name": "Fournisseur Example SARL",
+		"tax_id": {
+			"country": "FR",
+			"code": "44732829320"
+		},
+		"identities": [
+			{
+				"scope": "legal",
+				"type": "SIREN",
+				"code": "732829320",
+				"ext": {
+					"iso-scheme-id": "0002"
+				}
+			}
+		],
+		"inboxes": [
+			{
+				"key": "peppol",
+				"scheme": "0225",
+				"code": "732829320"
+			}
+		],
+		"addresses": [
+			{
+				"num": "123",
+				"street": "Rue de la Paix",
+				"locality": "Paris",
+				"code": "75001",
+				"country": "FR"
+			}
+		],
+		"emails": [
+			{
+				"addr": "facturation@fournisseur.fr"
+			}
+		],
+		"telephones": [
+			{
+				"num": "+33100200300"
+			}
+		]
+	},
+	"customer": {
+		"name": "Client Example SAS",
+		"tax_id": {
+			"country": "FR",
+			"code": "39356000000"
+		},
+		"identities": [
+			{
+				"scope": "legal",
+				"type": "SIREN",
+				"code": "356000000",
+				"ext": {
+					"iso-scheme-id": "0002"
+				}
+			}
+		],
+		"inboxes": [
+			{
+				"key": "peppol",
+				"scheme": "0225",
+				"code": "356000000"
+			}
+		],
+		"addresses": [
+			{
+				"num": "456",
+				"street": "Avenue des Champs-Elysees",
+				"locality": "Paris",
+				"code": "75008",
+				"country": "FR"
+			}
+		],
+		"emails": [
+			{
+				"addr": "comptabilite@client.fr"
+			}
+		],
+		"telephones": [
+			{
+				"num": "+33100200400"
+			}
+		]
+	},
+	"lines": [
+		{
+			"i": 1,
+			"quantity": "10",
+			"item": {
+				"name": "Services de conseil",
+				"price": "100.00",
+				"unit": "h"
+			},
+			"sum": "1000.00",
+			"discounts": [
+				{
+					"reason": "Remise fidelite",
+					"percent": "10%",
+					"amount": "100.00"
+				}
+			],
+			"taxes": [
+				{
+					"cat": "VAT",
+					"key": "standard",
+					"rate": "general",
+					"percent": "20%",
+					"ext": {
+						"untdid-tax-category": "S"
+					}
+				}
+			],
+			"total": "900.00"
+		}
+	],
+	"ordering": {
+		"code": "PO-2024-001"
+	},
+	"payment": {
+		"terms": {
+			"notes": "Paiement a 30 jours"
+		},
+		"instructions": {
+			"key": "credit-transfer",
+			"credit_transfer": [
+				{
+					"iban": "FR7630006000011234567890189",
+					"name": "Fournisseur Example SARL"
+				}
+			],
+			"ext": {
+				"untdid-payment-means": "30"
+			}
+		}
+	},
+	"totals": {
+		"sum": "900.00",
+		"total": "900.00",
+		"taxes": {
+			"categories": [
+				{
+					"code": "VAT",
+					"rates": [
+						{
+							"key": "standard",
+							"ext": {
+								"untdid-tax-category": "S"
+							},
+							"base": "900.00",
+							"percent": "20%",
+							"amount": "180.00"
+						}
+					],
+					"amount": "180.00"
+				}
+			],
+			"sum": "180.00"
+		},
+		"tax": "180.00",
+		"total_with_tax": "1080.00",
+		"payable": "1080.00"
+	},
+	"notes": [
+		{
+			"key": "payment",
+			"text": "Une penalite fixe de 40 EUR sera appliquee en cas de retard de paiement.",
+			"ext": {
+				"untdid-text-subject": "PMT"
+			}
+		},
+		{
+			"key": "payment-method",
+			"text": "Des penalites de retard s'appliquent conformement a nos conditions generales de vente.",
+			"ext": {
+				"untdid-text-subject": "PMD"
+			}
+		},
+		{
+			"key": "payment-term",
+			"text": "Aucun escompte n'est offert pour paiement anticipe.",
+			"ext": {
+				"untdid-text-subject": "AAB"
+			}
+		}
+	]
+}
+```

--- a/snippets/invoices/fr/pa-b2b.min.mdx
+++ b/snippets/invoices/fr/pa-b2b.min.mdx
@@ -1,0 +1,166 @@
+```json PA B2B Invoice
+{
+    "$schema": "https://gobl.org/draft-0/bill/invoice",
+    "$regime": "FR",
+    "$addons": [
+        "fr-ctc-flow2-v1"
+    ],
+    "type": "standard",
+    "series": "FAC",
+    "code": "2024-00001",
+    "issue_date": "2024-06-13",
+    "currency": "EUR",
+    "tax": {
+        "ext": {
+            "fr-ctc-billing-mode": "B7",
+            "untdid-document-type": "380"
+        }
+    },
+    "supplier": {
+        "name": "Fournisseur Example SARL",
+        "tax_id": {
+            "country": "FR",
+            "code": "732829320"
+        },
+        "identities": [
+            {
+                "type": "SIREN",
+                "code": "732829320",
+                "ext": {
+                    "iso-scheme-id": "0002"
+                }
+            }
+        ],
+        "inboxes": [
+            {
+                "key": "peppol",
+                "scheme": "0225",
+                "code": "732829320"
+            }
+        ],
+        "addresses": [
+            {
+                "num": "123",
+                "street": "Rue de la Paix",
+                "locality": "Paris",
+                "code": "75001",
+                "country": "FR"
+            }
+        ],
+        "emails": [
+            {
+                "addr": "facturation@fournisseur.fr"
+            }
+        ],
+        "telephones": [
+            {
+                "num": "+33100200300"
+            }
+        ]
+    },
+    "customer": {
+        "name": "Client Example SAS",
+        "tax_id": {
+            "country": "FR",
+            "code": "356000000"
+        },
+        "identities": [
+            {
+                "type": "SIREN",
+                "code": "356000000",
+                "ext": {
+                    "iso-scheme-id": "0002"
+                }
+            }
+        ],
+        "inboxes": [
+            {
+                "key": "peppol",
+                "scheme": "0225",
+                "code": "356000000"
+            }
+        ],
+        "addresses": [
+            {
+                "num": "456",
+                "street": "Avenue des Champs-Elysees",
+                "locality": "Paris",
+                "code": "75008",
+                "country": "FR"
+            }
+        ],
+        "emails": [
+            {
+                "addr": "comptabilite@client.fr"
+            }
+        ],
+        "telephones": [
+            {
+                "num": "+33100200400"
+            }
+        ]
+    },
+    "lines": [
+        {
+            "quantity": "10",
+            "item": {
+                "name": "Services de conseil",
+                "price": "100.00",
+                "unit": "h"
+            },
+            "discounts": [
+                {
+                    "percent": "10%",
+                    "reason": "Remise fidelite"
+                }
+            ],
+            "taxes": [
+                {
+                    "cat": "VAT",
+                    "rate": "standard"
+                }
+            ]
+        }
+    ],
+    "ordering": {
+        "code": "PO-2024-001"
+    },
+    "notes": [
+        {
+            "key": "payment",
+            "text": "Une penalite fixe de 40 EUR sera appliquee en cas de retard de paiement.",
+            "ext": {
+                "untdid-text-subject": "PMT"
+            }
+        },
+        {
+            "key": "payment-method",
+            "text": "Des penalites de retard s'appliquent conformement a nos conditions generales de vente.",
+            "ext": {
+                "untdid-text-subject": "PMD"
+            }
+        },
+        {
+            "key": "payment-term",
+            "text": "Aucun escompte n'est offert pour paiement anticipe.",
+            "ext": {
+                "untdid-text-subject": "AAB"
+            }
+        }
+    ],
+    "payment": {
+        "instructions": {
+            "key": "credit-transfer",
+            "credit_transfer": [
+                {
+                    "iban": "FR7630006000011234567890189",
+                    "name": "Fournisseur Example SARL"
+                }
+            ]
+        },
+        "terms": {
+            "detail": "Paiement a 30 jours"
+        }
+    }
+}
+```

--- a/snippets/invoices/fr/pa-credit-note.mdx
+++ b/snippets/invoices/fr/pa-credit-note.mdx
@@ -1,0 +1,194 @@
+```json Built version
+{
+	"$schema": "https://gobl.org/draft-0/bill/invoice",
+	"$regime": "FR",
+	"$addons": [
+		"eu-en16931-v2017",
+		"fr-ctc-flow2-v1"
+	],
+	"type": "credit-note",
+	"series": "AV",
+	"code": "2024-001",
+	"issue_date": "2024-06-20",
+	"currency": "EUR",
+	"preceding": [
+		{
+			"type": "standard",
+			"issue_date": "2024-06-13",
+			"series": "FAC",
+			"code": "2024-001"
+		}
+	],
+	"tax": {
+		"rounding": "currency",
+		"ext": {
+			"fr-ctc-billing-mode": "B7",
+			"untdid-document-type": "381"
+		}
+	},
+	"supplier": {
+		"name": "Fournisseur Example SARL",
+		"tax_id": {
+			"country": "FR",
+			"code": "44732829320"
+		},
+		"identities": [
+			{
+				"scope": "legal",
+				"type": "SIREN",
+				"code": "732829320",
+				"ext": {
+					"iso-scheme-id": "0002"
+				}
+			}
+		],
+		"inboxes": [
+			{
+				"key": "peppol",
+				"scheme": "0225",
+				"code": "732829320"
+			}
+		],
+		"addresses": [
+			{
+				"num": "123",
+				"street": "Rue de la Paix",
+				"locality": "Paris",
+				"code": "75001",
+				"country": "FR"
+			}
+		],
+		"emails": [
+			{
+				"addr": "facturation@fournisseur.fr"
+			}
+		]
+	},
+	"customer": {
+		"name": "Client Example SAS",
+		"tax_id": {
+			"country": "FR",
+			"code": "39356000000"
+		},
+		"identities": [
+			{
+				"scope": "legal",
+				"type": "SIREN",
+				"code": "356000000",
+				"ext": {
+					"iso-scheme-id": "0002"
+				}
+			}
+		],
+		"inboxes": [
+			{
+				"key": "peppol",
+				"scheme": "0225",
+				"code": "356000000"
+			}
+		],
+		"addresses": [
+			{
+				"num": "456",
+				"street": "Avenue des Champs-Elysees",
+				"locality": "Paris",
+				"code": "75008",
+				"country": "FR"
+			}
+		],
+		"emails": [
+			{
+				"addr": "comptabilite@client.fr"
+			}
+		]
+	},
+	"lines": [
+		{
+			"i": 1,
+			"quantity": "2",
+			"item": {
+				"name": "Services de conseil - Annulation partielle",
+				"price": "100.00",
+				"unit": "h"
+			},
+			"sum": "200.00",
+			"taxes": [
+				{
+					"cat": "VAT",
+					"key": "standard",
+					"rate": "general",
+					"percent": "20%",
+					"ext": {
+						"untdid-tax-category": "S"
+					}
+				}
+			],
+			"total": "200.00"
+		}
+	],
+	"payment": {
+		"instructions": {
+			"key": "credit-transfer",
+			"credit_transfer": [
+				{
+					"iban": "FR7630006000011234567890189",
+					"name": "Fournisseur Example SARL"
+				}
+			],
+			"ext": {
+				"untdid-payment-means": "30"
+			}
+		}
+	},
+	"totals": {
+		"sum": "200.00",
+		"total": "200.00",
+		"taxes": {
+			"categories": [
+				{
+					"code": "VAT",
+					"rates": [
+						{
+							"key": "standard",
+							"ext": {
+								"untdid-tax-category": "S"
+							},
+							"base": "200.00",
+							"percent": "20%",
+							"amount": "40.00"
+						}
+					],
+					"amount": "40.00"
+				}
+			],
+			"sum": "40.00"
+		},
+		"tax": "40.00",
+		"total_with_tax": "240.00",
+		"payable": "240.00"
+	},
+	"notes": [
+		{
+			"key": "payment",
+			"text": "Une penalite fixe de 40 EUR sera appliquee en cas de retard de paiement.",
+			"ext": {
+				"untdid-text-subject": "PMT"
+			}
+		},
+		{
+			"key": "payment-method",
+			"text": "Des penalites de retard s'appliquent conformement a nos conditions generales de vente.",
+			"ext": {
+				"untdid-text-subject": "PMD"
+			}
+		},
+		{
+			"key": "payment-term",
+			"text": "Aucun escompte n'est offert pour paiement anticipe.",
+			"ext": {
+				"untdid-text-subject": "AAB"
+			}
+		}
+	]
+}
+```

--- a/snippets/invoices/fr/pa-credit-note.min.mdx
+++ b/snippets/invoices/fr/pa-credit-note.min.mdx
@@ -1,0 +1,152 @@
+```json PA B2B Credit Note
+{
+    "$schema": "https://gobl.org/draft-0/bill/invoice",
+    "$regime": "FR",
+    "$addons": [
+        "fr-ctc-flow2-v1"
+    ],
+    "type": "credit-note",
+    "series": "AV",
+    "code": "2024-001",
+    "issue_date": "2024-06-20",
+    "currency": "EUR",
+    "tax": {
+        "ext": {
+            "fr-ctc-billing-mode": "B7",
+            "untdid-document-type": "381"
+        }
+    },
+    "preceding": [
+        {
+            "type": "standard",
+            "series": "FAC",
+            "code": "2024-001",
+            "issue_date": "2024-06-13"
+        }
+    ],
+    "supplier": {
+        "name": "Fournisseur Example SARL",
+        "tax_id": {
+            "country": "FR",
+            "code": "732829320"
+        },
+        "identities": [
+            {
+                "type": "SIREN",
+                "code": "732829320",
+                "ext": {
+                    "iso-scheme-id": "0002"
+                }
+            }
+        ],
+        "inboxes": [
+            {
+                "key": "peppol",
+                "scheme": "0225",
+                "code": "732829320"
+            }
+        ],
+        "addresses": [
+            {
+                "num": "123",
+                "street": "Rue de la Paix",
+                "locality": "Paris",
+                "code": "75001",
+                "country": "FR"
+            }
+        ],
+        "emails": [
+            {
+                "addr": "facturation@fournisseur.fr"
+            }
+        ]
+    },
+    "customer": {
+        "name": "Client Example SAS",
+        "tax_id": {
+            "country": "FR",
+            "code": "356000000"
+        },
+        "identities": [
+            {
+                "type": "SIREN",
+                "code": "356000000",
+                "ext": {
+                    "iso-scheme-id": "0002"
+                }
+            }
+        ],
+        "inboxes": [
+            {
+                "key": "peppol",
+                "scheme": "0225",
+                "code": "356000000"
+            }
+        ],
+        "addresses": [
+            {
+                "num": "456",
+                "street": "Avenue des Champs-Elysees",
+                "locality": "Paris",
+                "code": "75008",
+                "country": "FR"
+            }
+        ],
+        "emails": [
+            {
+                "addr": "comptabilite@client.fr"
+            }
+        ]
+    },
+    "lines": [
+        {
+            "quantity": "2",
+            "item": {
+                "name": "Services de conseil - Annulation partielle",
+                "price": "100.00",
+                "unit": "h"
+            },
+            "taxes": [
+                {
+                    "cat": "VAT",
+                    "rate": "standard"
+                }
+            ]
+        }
+    ],
+    "notes": [
+        {
+            "key": "payment",
+            "text": "Une penalite fixe de 40 EUR sera appliquee en cas de retard de paiement.",
+            "ext": {
+                "untdid-text-subject": "PMT"
+            }
+        },
+        {
+            "key": "payment-method",
+            "text": "Des penalites de retard s'appliquent conformement a nos conditions generales de vente.",
+            "ext": {
+                "untdid-text-subject": "PMD"
+            }
+        },
+        {
+            "key": "payment-term",
+            "text": "Aucun escompte n'est offert pour paiement anticipe.",
+            "ext": {
+                "untdid-text-subject": "AAB"
+            }
+        }
+    ],
+    "payment": {
+        "instructions": {
+            "key": "credit-transfer",
+            "credit_transfer": [
+                {
+                    "iban": "FR7630006000011234567890189",
+                    "name": "Fournisseur Example SARL"
+                }
+            ]
+        }
+    }
+}
+```


### PR DESCRIPTION
## Summary

- Pulls five new GOBL invoice examples from `../gobl/examples/fr/` into `snippets/invoices/fr/`, covering the four main France PA (Flow 2) shapes plus a cross-border Chorus Pro case.
- Adds a new `pa-accordion` snippet that groups the PA examples with explanatory copy, wired into the France app's Documents tab and the `fr-pa-invoicing` guide.
- Adds the cross-border Chorus Pro example to the existing `chorus-pro-accordion`, so it surfaces automatically on the Chorus Pro app page and the `fr-chorus-pro` guide.

## New examples

| Snippet | Source | What it shows |
|---|---|---|
| `pa-b2b` | `invoice-fr-fr-ctc-b2b.yaml` | Standard PA Flow 2 domestic B2B invoice |
| `pa-credit-note` | `invoice-fr-fr-ctc-credit-note.yaml` | Credit note with a `preceding` reference |
| `pa-advance` | `invoice-fr-fr-ctc-advance.yaml` | Advance / down-payment invoice (`B1` / UNTDID `386`) |
| `pa-b2b-international` | `invoice-fr-de-ctc-b2bint.yaml` | Cross-border FR → DE intra-community invoice |
| `chorus-pro-cross-border` | `invoice-de-fr-choruspro.yaml` | Non-French supplier invoicing a French public entity |

## Skipped as duplicates

- `invoice-fr-fr-choruspro.yaml` — already covered by `chorus-pro-b2g`.
- `invoice-fr-fr-facturx.yaml` — already covered by `facturx-b2b`.
- `invoice-fr-fr.yaml` — plain invoice with no FR add-on; doesn't fit the feature-per-snippet pattern.

## Reviewer notes

- Built `.mdx` files were produced via `gobl build` from the GOBL repo's `main`, which is ahead of the globally installed `gobl` CLI (the `payment-method` / `payment-term` note keys are recent). May be worth bumping the team's `gobl` install before the next `gobl-build.sh` run.
- `mint broken-links` is clean.

## Test plan

- [ ] `mint dev` — verify the Documents tab on the France app renders the new PA accordion alongside Peppol and Factur-X.
- [ ] Browse to `/guides/fr-pa-invoicing` and confirm the new Example invoices section renders with all four PA accordions expanding correctly.
- [ ] Confirm the Chorus Pro pages (`/apps/choruspro-france` Documents tab and `/guides/fr-chorus-pro`) show the new cross-border accordion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)