### PR TITLE
docs: FAQ — receiving invoices at multiple PDPs in France

### DIFF
--- a/snippets/faqs/fr/leaves/pa/receiving.mdx
+++ b/snippets/faqs/fr/leaves/pa/receiving.mdx
@@ -5,3 +5,16 @@
   <Accordion title="What format do received France PA invoices arrive in?">
     UBL, CII, or Factur-X (PDF with embedded CII XML), all conforming to EN 16931 and the French CTC profile. Invopop preserves the original and exposes the GOBL conversion.
   </Accordion>
+
+  <Accordion title="Can I receive invoices at more than one platform (PDP) for the same company?">
+    Yes. A single company can be reachable at several destinations by registering different routing identifiers (electronic addresses) in the Annuaire — one per PDP or inbox. Invoices addressed to a given identifier are delivered to the platform registered against it, so you can route some invoices to Invopop and others to a different PDP (for example a travel-and-expense tool) for the same SIREN.
+
+    The Annuaire supports several address formats that map to increasingly granular destinations within the same company:
+
+    - `SIREN` — the company as a whole.
+    - `SIREN_SIRET` — a specific establishment.
+    - `SIREN_SIRET_ROUTINGCODE` — a site, department, or workflow within an establishment.
+    - `SIREN_SUFFIX` — a custom routing suffix.
+
+    Give each PDP or inbox a distinct identifier and share the matching address with each issuer, so their invoices reach the intended destination. You can [look up an electronic address](/guides/fr-lookup) in the Annuaire to confirm where it currently routes.
+  </Accordion>


### PR DESCRIPTION
## What

Adds a France PA **receiving** FAQ: _"Can I receive invoices at more than one platform (PDP) for the same company?"_

It explains that a single company (SIREN) can be reachable at several destinations by registering different routing identifiers in the Annuaire — one per PDP or inbox — so some invoices can be routed to Invopop and others to a different PDP. It lists the Annuaire electronic-address formats:

- `SIREN` — the company as a whole
- `SIREN_SIRET` — a specific establishment
- `SIREN_SIRET_ROUTINGCODE` — a site, department, or workflow
- `SIREN_SUFFIX` — a custom routing suffix

and links to the [directory lookup guide](/guides/fr-lookup).

## Why

Recurring customer request: people frequently ask whether they can register two inboxes, or receive some invoices in one place and others elsewhere (e.g. a travel-and-expense tool handling hotel invoices while Invopop handles the rest). The original ask came from the travel/expense reception use case, but the answer is general.

## Where

Appended one `<Accordion>` to `snippets/faqs/fr/leaves/pa/receiving.mdx`. No composer changes needed — this leaf is already imported by the France FAQ page (and other PA consumers), so it surfaces automatically under **Receiving questions → PA (Plateforme Agréée)**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)