### PR TITLE
docs(fr): add Flow 10 payment examples to France app

### DIFF
--- a/apps/france.mdx
+++ b/apps/france.mdx
@@ -8,12 +8,13 @@ mode: wide
 import PaSendInvoiceWorkflow from '/snippets/workflows/fr/fr-pa-send-invoice.mdx';
 import PaReceiveInvoiceWorkflow from '/snippets/workflows/fr/fr-pa-receive-invoice.mdx';
 import PaRegisterWorkflow from '/snippets/workflows/fr/fr-pa-register.mdx';
-import PaDeregisterWorkflow from '/snippets/workflows/fr/fr-pa-deregister.mdx';
+import PaDeregisterWorkflow from '/snippets/workflows/fr/fr-pa-unregister.mdx';
 import PaSendStatusWorkflow from '/snippets/workflows/fr/fr-pa-send-status.mdx';
 import FacturxWorkflow from '/snippets/workflows/fr/facturx-invoice.mdx';
 import PeppolAccordion from '/snippets/invoices/fr/peppol-accordion.mdx';
 import FacturxAccordion from '/snippets/invoices/fr/facturx-accordion.mdx';
 import PaAccordion from '/snippets/invoices/fr/pa-accordion.mdx';
+import PaymentsAccordion from '/snippets/payments/fr/accordion.mdx';
 import Supplier from '/snippets/suppliers/fr/company.mdx';
 import FranceResources from '/snippets/tables/france-resources.mdx';
 import FAQ from '/snippets/faqs/fr/composers/app-france.mdx';
@@ -186,6 +187,9 @@ import FAQ from '/snippets/faqs/fr/composers/app-france.mdx';
 
 		<FacturxAccordion />
 
+		E-reporting (Flow 10) example payments
+
+		<PaymentsAccordion />
 
 		Copy and paste these documents into the [GOBL builder](https://build.gobl.org) in order to preview and verify them.
 	</Tab>

--- a/snippets/payments/fr/accordion.mdx
+++ b/snippets/payments/fr/accordion.mdx
@@ -5,16 +5,16 @@ import IntlEU from '/snippets/payments/fr/intl-eu.mdx';
 
 <AccordionGroup>
 
-	<Accordion title="Domestic B2C payment (Flow 10.4)">
+	<Accordion title="Domestic B2C payment">
 
-		A cashed-in receipt from a domestic B2C transaction. Flow 10.4 aggregates by `(date, currency)` and is rate-agnostic at the bucket level, so the tax breakdown lives directly on each line rather than on a referenced invoice.
+		A cashed-in receipt from a domestic B2C transaction. Domestic B2C payments aggregate by `(date, currency)` and are rate-agnostic at the bucket level, so the tax breakdown lives directly on each line rather than on a referenced invoice.
 
 		Notice:
 
 		- `type` is `receipt` and `method.key` `credit-transfer` records how the money was received,
-		- no `customer` is set — Flow 10.4 doesn't need counterparty identification,
-		- `lines[i].document` is omitted on purpose: a line without a `document` reference is what classifies the payment as B2C (10.4); a line with one would route it to intl B2B (10.2) instead,
-		- `lines[i].tax.categories[...].rates[...]` carries the VAT base/percent/amount directly so the bucket's `<TaxPercent>` / `<Amount>` come out right in the report.
+		- no `customer` is set — domestic B2C payments don't need counterparty identification,
+		- `lines[i].document` is omitted on purpose: a line without a `document` reference is what classifies the payment as domestic B2C; a line with one would route it to international B2B instead,
+		- `lines[i].tax.categories[...].rates[...]` carries the VAT base, percent and amount directly on each line, since domestic B2C buckets aggregate by `(date, currency)` and don't reference an underlying invoice.
 
 		<CodeGroup>
 			<B2CMin />
@@ -22,16 +22,15 @@ import IntlEU from '/snippets/payments/fr/intl-eu.mdx';
 		</CodeGroup>
 	</Accordion>
 
-	<Accordion title="Intl B2B payment (Flow 10.2)">
+	<Accordion title="International B2B payment">
 
-		A cross-border B2B payment settling a previously issued invoice — here, Bistrot Lyon SAS cashing in from German customer Müller GmbH. Flow 10.2 reports per-payment detail and requires the counterparty identification plus a link to the underlying invoice.
+		A cross-border B2B payment settling a previously issued invoice — here, Bistrot Lyon SAS cashing in from German customer Müller GmbH. International B2B payments report per-payment detail and require the counterparty identification plus a link to the underlying invoice.
 
 		Notice:
 
 		- `customer` is populated with the foreign counterparty (DE tax ID),
-		- `lines[i].document` references the invoice being settled by `code` and `issue_date` — this is both how `gov-fr.reporting.record` classifies the payment as 10.2 and how GOBL allocates the cashed amount across the original invoice's tax rates,
-		- if the referenced invoice had mixed VAT rates and this payment only partially settles it, GOBL splits the cash proportionally across rates at calculation time — you don't write that math,
-		- TT-95 / TT-99 amounts in the resulting Flux 10.2 XML come straight out of that allocation, in EUR (FX-converted from the payment currency if different).
+		- `lines[i].document` references the invoice being settled by `code` and `issue_date` — this is both how `gov-fr.reporting.record` classifies the payment as international B2B and how GOBL allocates the cashed amount across the original invoice's tax rates,
+		- if the referenced invoice had mixed VAT rates and this payment only partially settles it, GOBL splits the cash proportionally across rates at calculation time — you don't write that math.
 
 		<CodeGroup>
 			<IntlEUMin />

--- a/snippets/payments/fr/accordion.mdx
+++ b/snippets/payments/fr/accordion.mdx
@@ -1,0 +1,42 @@
+import B2CMin from '/snippets/payments/fr/b2c.min.mdx';
+import B2C from '/snippets/payments/fr/b2c.mdx';
+import IntlEUMin from '/snippets/payments/fr/intl-eu.min.mdx';
+import IntlEU from '/snippets/payments/fr/intl-eu.mdx';
+
+<AccordionGroup>
+
+	<Accordion title="Domestic B2C payment (Flow 10.4)">
+
+		A cashed-in receipt from a domestic B2C transaction. Flow 10.4 aggregates by `(date, currency)` and is rate-agnostic at the bucket level, so the tax breakdown lives directly on each line rather than on a referenced invoice.
+
+		Notice:
+
+		- `type` is `receipt` and `method.key` `credit-transfer` records how the money was received,
+		- no `customer` is set — Flow 10.4 doesn't need counterparty identification,
+		- `lines[i].document` is omitted on purpose: a line without a `document` reference is what classifies the payment as B2C (10.4); a line with one would route it to intl B2B (10.2) instead,
+		- `lines[i].tax.categories[...].rates[...]` carries the VAT base/percent/amount directly so the bucket's `<TaxPercent>` / `<Amount>` come out right in the report.
+
+		<CodeGroup>
+			<B2CMin />
+			<B2C />
+		</CodeGroup>
+	</Accordion>
+
+	<Accordion title="Intl B2B payment (Flow 10.2)">
+
+		A cross-border B2B payment settling a previously issued invoice — here, Bistrot Lyon SAS cashing in from German customer Müller GmbH. Flow 10.2 reports per-payment detail and requires the counterparty identification plus a link to the underlying invoice.
+
+		Notice:
+
+		- `customer` is populated with the foreign counterparty (DE tax ID),
+		- `lines[i].document` references the invoice being settled by `code` and `issue_date` — this is both how `gov-fr.reporting.record` classifies the payment as 10.2 and how GOBL allocates the cashed amount across the original invoice's tax rates,
+		- if the referenced invoice had mixed VAT rates and this payment only partially settles it, GOBL splits the cash proportionally across rates at calculation time — you don't write that math,
+		- TT-95 / TT-99 amounts in the resulting Flux 10.2 XML come straight out of that allocation, in EUR (FX-converted from the payment currency if different).
+
+		<CodeGroup>
+			<IntlEUMin />
+			<IntlEU />
+		</CodeGroup>
+	</Accordion>
+
+</AccordionGroup>

--- a/snippets/payments/fr/b2c.mdx
+++ b/snippets/payments/fr/b2c.mdx
@@ -1,0 +1,51 @@
+```json Built version
+{
+	"$schema": "https://gobl.org/draft-0/bill/payment",
+	"$regime": "FR",
+	"type": "receipt",
+	"method": {
+		"key": "credit-transfer"
+	},
+	"series": "B",
+	"code": "PAY-B2C-001",
+	"issue_date": "2026-04-15",
+	"value_date": "2026-04-15",
+	"currency": "EUR",
+	"supplier": {
+		"name": "Bistrot Lyon SAS",
+		"tax_id": {
+			"country": "FR",
+			"code": "50522465228"
+		},
+		"addresses": [
+			{
+				"country": "FR"
+			}
+		]
+	},
+	"lines": [
+		{
+			"i": 1,
+			"amount": "600.00",
+			"tax": {
+				"categories": [
+					{
+						"code": "VAT",
+						"rates": [
+							{
+								"key": "standard",
+								"base": "500.00",
+								"percent": "20%",
+								"amount": "100.00"
+							}
+						],
+						"amount": "100.00"
+					}
+				],
+				"sum": "100.00"
+			}
+		}
+	],
+	"total": "600.00"
+}
+```

--- a/snippets/payments/fr/b2c.min.mdx
+++ b/snippets/payments/fr/b2c.min.mdx
@@ -1,0 +1,51 @@
+```json FR B2C Payment (minimal)
+{
+	"$schema": "https://gobl.org/draft-0/bill/payment",
+	"$regime": "FR",
+	"type": "receipt",
+	"method": {
+		"key": "credit-transfer"
+	},
+	"series": "B",
+	"code": "PAY-B2C-001",
+	"issue_date": "2026-04-15",
+	"value_date": "2026-04-15",
+	"currency": "EUR",
+	"supplier": {
+		"name": "Bistrot Lyon SAS",
+		"tax_id": {
+			"country": "FR",
+			"code": "50522465228"
+		},
+		"addresses": [
+			{
+				"country": "FR"
+			}
+		]
+	},
+	"lines": [
+		{
+			"i": 1,
+			"amount": "600.00",
+			"tax": {
+				"categories": [
+					{
+						"code": "VAT",
+						"rates": [
+							{
+								"key": "standard",
+								"base": "500.00",
+								"percent": "20%",
+								"amount": "100.00"
+							}
+						],
+						"amount": "100.00"
+					}
+				],
+				"sum": "100.00"
+			}
+		}
+	],
+	"total": "600.00"
+}
+```

--- a/snippets/payments/fr/intl-eu.mdx
+++ b/snippets/payments/fr/intl-eu.mdx
@@ -1,0 +1,69 @@
+```json Built version
+{
+	"$schema": "https://gobl.org/draft-0/bill/payment",
+	"$regime": "FR",
+	"type": "receipt",
+	"method": {
+		"key": "credit-transfer"
+	},
+	"series": "B",
+	"code": "PAY-DE-001",
+	"issue_date": "2026-04-20",
+	"value_date": "2026-04-20",
+	"currency": "EUR",
+	"supplier": {
+		"name": "Bistrot Lyon SAS",
+		"tax_id": {
+			"country": "FR",
+			"code": "50522465228"
+		},
+		"addresses": [
+			{
+				"country": "FR"
+			}
+		]
+	},
+	"customer": {
+		"name": "Müller GmbH",
+		"tax_id": {
+			"country": "DE",
+			"code": "136695976"
+		},
+		"addresses": [
+			{
+				"country": "DE"
+			}
+		]
+	},
+	"lines": [
+		{
+			"i": 1,
+			"document": {
+				"type": "standard",
+				"issue_date": "2026-04-20",
+				"series": "B",
+				"code": "INTL-DE-APR-001"
+			},
+			"amount": "2400.00",
+			"tax": {
+				"categories": [
+					{
+						"code": "VAT",
+						"rates": [
+							{
+								"key": "standard",
+								"base": "2000.00",
+								"percent": "20%",
+								"amount": "400.00"
+							}
+						],
+						"amount": "400.00"
+					}
+				],
+				"sum": "400.00"
+			}
+		}
+	],
+	"total": "2400.00"
+}
+```

--- a/snippets/payments/fr/intl-eu.min.mdx
+++ b/snippets/payments/fr/intl-eu.min.mdx
@@ -1,0 +1,69 @@
+```json FR Intl B2B Payment (minimal)
+{
+	"$schema": "https://gobl.org/draft-0/bill/payment",
+	"$regime": "FR",
+	"type": "receipt",
+	"method": {
+		"key": "credit-transfer"
+	},
+	"series": "B",
+	"code": "PAY-DE-001",
+	"issue_date": "2026-04-20",
+	"value_date": "2026-04-20",
+	"currency": "EUR",
+	"supplier": {
+		"name": "Bistrot Lyon SAS",
+		"tax_id": {
+			"country": "FR",
+			"code": "50522465228"
+		},
+		"addresses": [
+			{
+				"country": "FR"
+			}
+		]
+	},
+	"customer": {
+		"name": "Müller GmbH",
+		"tax_id": {
+			"country": "DE",
+			"code": "136695976"
+		},
+		"addresses": [
+			{
+				"country": "DE"
+			}
+		]
+	},
+	"lines": [
+		{
+			"i": 1,
+			"document": {
+				"type": "standard",
+				"series": "B",
+				"code": "INTL-DE-APR-001",
+				"issue_date": "2026-04-20"
+			},
+			"amount": "2400.00",
+			"tax": {
+				"categories": [
+					{
+						"code": "VAT",
+						"rates": [
+							{
+								"key": "standard",
+								"base": "2000.00",
+								"percent": "20%",
+								"amount": "400.00"
+							}
+						],
+						"amount": "400.00"
+					}
+				],
+				"sum": "400.00"
+			}
+		}
+	],
+	"total": "2400.00"
+}
+```


### PR DESCRIPTION
## Summary

- Adds two GOBL payment snippet pairs under `snippets/payments/fr/` — a domestic B2C receipt (Flow 10.4) and an intl B2B receipt FR→DE (Flow 10.2), ported from the operator-guide fixtures in `docs.reporting/fixtures/payments/`.
- New `snippets/payments/fr/accordion.mdx` wraps both with notes on how the record action classifies payments (presence/absence of `lines[i].document`) and how GOBL splits the cashed amount across the referenced invoice's tax rates.
- Wires the accordion into the `apps/france.mdx` **Documents** tab next to the existing PA / Peppol / Factur-X invoice accordions.
- Fixes a pre-existing broken import in `apps/france.mdx` — `fr-pa-deregister.mdx` → `fr-pa-unregister.mdx` (the file had been renamed without updating the import; surfaced as a `mintlify dev` warning).

Closes [APP-540](https://linear.app/invopop/issue/APP-540).

## Test plan

- [ ] `mintlify dev` runs without the previous "Could not find file `fr-pa-deregister.mdx`" warning
- [ ] France app **Documents** tab renders the new "E-reporting (Flow 10) example payments" section with both accordions
- [ ] Each accordion shows the minimal and built tabs (no empty `<CodeGroup>`)
- [ ] `./gobl-build.sh` re-run still produces no errors on the two new `.min.mdx` files

🤖 Generated with [Claude Code](https://claude.com/claude-code)