### PR TITLE
docs(es): document AEAT tax ID lookup endpoint

### DIFF
--- a/api-ref/apps/gov-es/lookup.mdx
+++ b/api-ref/apps/gov-es/lookup.mdx
@@ -1,0 +1,6 @@
+---
+title: "Verify tax ID"
+openapi: "POST /apps/gov-es/v1/lookup"
+---
+
+Verify a Spanish tax ID (NIF/CIF) against the AEAT census without going through the registration flow. The response always reports whether AEAT identified the tax ID; set `correct` to `true` to also receive the official name registered with AEAT when the tax ID is identified.

--- a/apps/spain.mdx
+++ b/apps/spain.mdx
@@ -367,6 +367,7 @@ import FAQ from '/snippets/faqs/es/composers/app-spain.mdx';
 
 		The following API Endpoints are available when you enable this app:
 
+		* [Verify Tax ID](/api-ref/apps/gov-es/lookup)
 		* [Generate Agreement PDF](/api-ref/apps/gov-es/agreement-fetch)
 		* [Upload Agreement PDF](/api-ref/apps/gov-es/agreement-upload)
 		* [Upload Identity Image](/api-ref/apps/gov-es/identity-upload)

--- a/docs.json
+++ b/docs.json
@@ -628,7 +628,8 @@
 									"api-ref/apps/gov-es/agreement-fetch",
 									"api-ref/apps/gov-es/agreement-upload",
 									"api-ref/apps/gov-es/identity-upload",
-									"api-ref/apps/gov-es/confirm"
+									"api-ref/apps/gov-es/confirm",
+									"api-ref/apps/gov-es/lookup"
 								]
 							},
 							{

--- a/openapi/apps/gov-es_v1.yaml
+++ b/openapi/apps/gov-es_v1.yaml
@@ -163,6 +163,88 @@ paths:
       responses:
         "202":
           description: "No content"
+  /apps/gov-es/v1/lookup:
+    post:
+      x-mint:
+        mcp:
+          enabled: true
+          name: verify-gov-es-tax-id
+          description: Verify a Spanish tax ID (NIF/CIF) against the AEAT census.
+      description: |-
+        Verify a Spanish tax ID (NIF/CIF) against the AEAT census. The endpoint
+        always reports whether AEAT identified the tax ID. When `correct` is
+        `true` and the tax ID is identified, the official name registered with
+        AEAT is also returned.
+
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                tax_id:
+                  description: Spanish tax ID (NIF/CIF) to verify against AEAT.
+                  type: string
+                  example: "B98602031"
+                name:
+                  description: |-
+                    Name to check against the tax ID. For individuals AEAT
+                    verifies that the name matches the tax ID on record; for
+                    companies the name is not required to confirm the tax ID
+                    exists.
+                  type: string
+                  example: "Provide One SL"
+                correct:
+                  description: |-
+                    When `true` and the tax ID is identified, the response also
+                    includes the official `name` as registered with AEAT.
+                  type: boolean
+                  default: false
+              required: ["tax_id"]
+      responses:
+        "200":
+          description: The verification completed and the result is reported in the body.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  identified:
+                    description: Whether AEAT identified the tax ID.
+                    type: boolean
+                  name:
+                    description: |-
+                      Official name registered with AEAT. Only present when
+                      `correct` was `true` in the request and the tax ID was
+                      identified.
+                    type: string
+        "400":
+          description: Bad Request - The request body could not be parsed or `tax_id` was empty.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    description: Details of the error.
+        "422":
+          description: Unprocessable Entity - The tax ID could not be verified (invalid or unverifiable input).
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    description: Details of the error.
+        "500":
+          description: Internal Server Error - The upstream AEAT lookup failed.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    description: Details of the error.
   /apps/gov-es/v1/entry/{silo_entry_id}/{system}/confirm:
     post:
       description: Confirm that the upload process has completed.


### PR DESCRIPTION
## Summary

Documents the new `POST /apps/gov-es/v1/lookup` endpoint added to the `gov-es` service (commits `39f378e` + `5680530`). It verifies a Spanish tax ID (NIF/CIF) against the AEAT census synchronously — unlike the existing gateway task flow, it works on a bare tax ID + name rather than a full GOBL envelope and does not touch a silo entry.

## Changes

- **`openapi/apps/gov-es_v1.yaml`** — add the `POST /apps/gov-es/v1/lookup` operation. Request body: `tax_id` (required), `name` (optional), `correct` (bool, default `false`). Responses mirror the controller's status mapping: `200` (`identified`, plus official `name` when `correct=true` and identified), `400` (bad/empty body), `422` (unverifiable tax ID), `500` (AEAT upstream failure). Includes an `x-mint` MCP block for tool discoverability.
- **`api-ref/apps/gov-es/lookup.mdx`** — new thin wrapper page ("Verify tax ID").
- **`docs.json`** — register the page under the Spain API Reference group.
- **`apps/spain.mdx`** — link the endpoint from the **API Endpoints** tab.

## Notes

- Verification runs against the **live AEAT environment only**, so a real verification requires a production-accepted certificate.
- `correct=false` returns just `{identified}`; `correct=true` adds the official `{name}` only when the tax ID is identified.

## Validation

- `mint openapi-check openapi/apps/gov-es_v1.yaml` → valid.
- `docs.json` → valid JSON.

🤖 Generated with [Claude Code](https://claude.com/claude-code)