### PR TITLE
docs(fr): note non-established taxable persons e-reporting postponement

### DIFF
--- a/compliance/france.mdx
+++ b/compliance/france.mdx
@@ -88,7 +88,7 @@ Stripe and Chargebee integrations let merchants and ERPs issue compliant invoice
 
 For e-reporting use cases, PAs aggregate transaction and payment data and submit periodic reports to the PPF on a cadence tied to the party's VAT regime.
 
-E-reporting becomes mandatory on the same dates as e-invoicing issuance: 1 Sept 2026 for large and medium-sized companies, 1 Sept 2027 for all businesses.
+E-reporting becomes mandatory on the same dates as e-invoicing issuance: 1 Sept 2026 for large and medium-sized companies, 1 Sept 2027 for all businesses. Non-established taxable persons are an exception: their obligation to e-report acquisitions is postponed to 1 September 2027 regardless of the size of the business.
 
 <AccordionGroup>
   <Accordion title="PPF (Portail Public de Facturation)">
@@ -227,10 +227,11 @@ E-reporting becomes mandatory on the same dates as e-invoicing issuance: 1 Sept 
     * **1 September 2026**:
       - All businesses must be able to receive e-invoices
       - Large and medium-sized companies must issue e-invoices
-      - E-reporting becomes mandatory for these companies
+      - E-reporting of issued transactions (B2C sales and cross-border B2B) becomes mandatory for these companies
     * **1 September 2027**:
       - All remaining businesses (small and micro-businesses) must issue e-invoices
-      - E-reporting becomes mandatory for all businesses
+      - E-reporting of issued transactions becomes mandatory for all businesses
+      - Non-established taxable persons must start e-reporting of acquisitions, regardless of business size (postponed from 1 September 2026)
 
     The implementation has been delayed multiple times to ensure businesses and platforms are adequately prepared.
   </Accordion>

--- a/timelines/france.mdx
+++ b/timelines/france.mdx
@@ -40,7 +40,11 @@ Current and upcoming regulation for France.
 
 <Update label="1 Sept 2026" tags={["B2B", "E-reporting"]}>
   **B2B e-invoicing and e-reporting for large and medium-sized companies**<br />
-  All businesses must be able to receive e-invoices. Large and medium-sized companies (more than 250 employees and exceeding either €50 million in turnover or €43 million in balance sheet) must issue e-invoices. E-reporting becomes mandatory for these companies.
+  All businesses must be able to receive e-invoices. Large and medium-sized companies (more than 250 employees and exceeding either €50 million in turnover or €43 million in balance sheet) must issue e-invoices. E-reporting of issued transactions (B2C sales and cross-border B2B) becomes mandatory for these companies.
+
+  <Note>
+    Non-established taxable persons are exempt from this e-reporting obligation until 1 September 2027.
+  </Note>
 
   | System        | Description  | Invopop Coverage |
   |---------------|---------------|---------------|
@@ -50,7 +54,12 @@ Current and upcoming regulation for France.
 
 <Update label="1 Sept 2027" tags={["B2B", "E-reporting"]}>
   **B2B e-invoicing and e-reporting for all businesses**<br />
-  All remaining businesses (small and micro-businesses) must issue e-invoices. E-reporting becomes mandatory for all businesses.
+  All remaining businesses (small and micro-businesses) must issue e-invoices. E-reporting of issued transactions (B2C sales and cross-border B2B) becomes mandatory for all businesses.
+</Update>
+
+<Update label="1 Sept 2027" tags={["E-reporting"]}>
+  **E-reporting of acquisitions for non-established taxable persons**<br />
+  Non-established taxable persons must start e-reporting of acquisitions, regardless of the size of the business. This obligation is postponed from 1 September 2026 so that it applies to all non-established taxable persons on the same date.
 </Update>
 
 


### PR DESCRIPTION
## Linear
Closes: APP-559

## Summary
- Add a dedicated **1 Sept 2027** entry in the France timeline for the e-reporting of acquisitions obligation that applies to non-established taxable persons (postponed from 1 Sept 2026, regardless of business size).
- Reword the existing 1 Sept 2026 and 1 Sept 2027 B2B e-reporting entries to specify they cover **issued** transactions (B2C sales and cross-border B2B), so the acquisitions-side obligation reads as a clearly distinct item.
- Add a small `<Note>` under the 1 Sept 2026 entry signposting the exemption until 1 Sept 2027.
- Mirror the same changes in `compliance/france.mdx` under the "Implementation timeline" accordion and the E-reporting section narrative.

## Test plan
- [ ] `mint dev` — confirm the France timeline page renders the new entry and the existing entries unchanged in structure.
- [ ] Confirm the `<Note>` block under 1 Sept 2026 displays correctly.
- [ ] Open `/compliance/france` and verify the "Implementation timeline" accordion shows the new bullet under 1 Sept 2027 and that the E-reporting section narrative reflects the exception.
- [ ] `mint broken-links` — no new broken references.

🤖 Generated with [Claude Code](https://claude.com/claude-code)