### PR TITLE
docs(fr): explain opening and signing the PA agreement form

### DIFF
--- a/guides/fr-pa-registration.mdx
+++ b/guides/fr-pa-registration.mdx
@@ -31,7 +31,7 @@ The Annuaire requires every entry to be receive-capable, so there is no send-onl
     Moves the silo entry into a visible "in progress" state so operator dashboards reflect that registration is underway.
   </Step>
   <Step title="Wait for French agreement upload">
-    Pauses until the signed agreement is uploaded and accepted (`gov-fr.agreement.wait.approval`).
+    Pauses until the signed agreement is uploaded and accepted (`gov-fr.agreement.wait.approval`). This is a **manual gate** — the party stays in <Badge color="yellow">processing</Badge> and the workflow does not advance until someone opens the agreement form and signs it. See [Complete the agreement](#complete-the-agreement) below.
   </Step>
   <Step title="Set State → completed">
     Marks the agreement step as completed before the directory and Peppol registrations run.
@@ -58,6 +58,30 @@ The Annuaire requires every entry to be receive-capable, so there is no send-onl
     <RegisterWorkflow />
   </Tab>
 </Tabs>
+
+## Complete the agreement
+
+After the workflow reaches **Wait for French agreement upload**, the party sits in <Badge color="yellow">processing</Badge> until the PA mandate is signed. **This step is manual and required** — the party cannot be accepted, registered in the Annuaire, or published on Peppol until it is done.
+
+The agreement form is surfaced as a link on the party itself:
+
+<Steps>
+  <Step title="Open the party entry">
+    In Console, open the party (silo entry) that the register workflow is running on.
+  </Step>
+  <Step title="Go to the Meta tab">
+    Open the **Meta** tab. The **Sign agreement for France** step publishes an agreement link there (meta key `approval-link`).
+  </Step>
+  <Step title="Open and sign the agreement form">
+    Click the link to open the French PA agreement form. Review the mandate that authorises Invopop to act as the party's Plateforme Agréée, sign it, and submit.
+  </Step>
+</Steps>
+
+Once the signed agreement is submitted and accepted, **Wait for French agreement upload** resolves and the workflow continues to the directory and Peppol registration steps, ending in <Badge color="purple">registered</Badge>.
+
+<Note>
+  If you don't open the Meta tab and sign the agreement, the party stays in <Badge color="yellow">processing</Badge> indefinitely — it is never automatically accepted.
+</Note>
 
 ## Unregistration
 

--- a/guides/fr-pa-registration.mdx
+++ b/guides/fr-pa-registration.mdx
@@ -63,6 +63,8 @@ The Annuaire requires every entry to be receive-capable, so there is no send-onl
 
 After the workflow reaches **Wait for French agreement upload**, the party sits in <Badge color="yellow">processing</Badge> until the PA mandate is signed. **This step is manual and required** — the party cannot be accepted, registered in the Annuaire, or published on Peppol until it is done.
 
+### Sign in Console
+
 The agreement form is surfaced as a link on the party itself:
 
 <Steps>
@@ -77,7 +79,23 @@ The agreement form is surfaced as a link on the party itself:
   </Step>
 </Steps>
 
-Once the signed agreement is submitted and accepted, **Wait for French agreement upload** resolves and the workflow continues to the directory and Peppol registration steps, ending in <Badge color="purple">registered</Badge>.
+### Sign through the API
+
+You can also complete the agreement programmatically — useful when you embed the onboarding in your own product instead of sending the signer to the Invopop form. Once the workflow has paused at **Wait for French agreement upload**:
+
+  1. [Download the unsigned agreement PDF](/api-ref/apps/gov-fr/agreement-fetch) `GET /apps/gov-fr/v1/entry/{silo_entry_id}/agreement`<br />
+    The mandate PDF is generated from the party's data for the signer to review and sign.
+
+  2. [Upload the signed agreement](/api-ref/apps/gov-fr/agreement-upload) `POST /apps/gov-fr/v1/entry/{silo_entry_id}/agreement`<br />
+    Send the signed PDF together with the signature method: `esignature` for an electronic (PAdES) signature, or `identity` for a handwritten one.
+
+  3. [Upload identity images](/api-ref/apps/gov-fr/identity-upload) `POST /apps/gov-fr/v1/entry/{silo_entry_id}/identity`<br />
+    Only required when the signature method is `identity`. Upload one image per view: `front` and `back` for an ID card, or `page` for a passport.
+
+  4. [Confirm the submission](/api-ref/apps/gov-fr/confirm) `POST /apps/gov-fr/v1/entry/{silo_entry_id}/confirm`<br />
+    Marks the submission as complete and wakes the waiting workflow task.
+
+Whichever way the agreement is signed, once it is submitted and accepted, **Wait for French agreement upload** resolves and the workflow continues to the directory and Peppol registration steps, ending in <Badge color="purple">registered</Badge>.
 
 <Note>
   If you don't open the Meta tab and sign the agreement, the party stays in <Badge color="yellow">processing</Badge> indefinitely — it is never automatically accepted.


### PR DESCRIPTION
## What

The France PA registration guide (`/guides/fr-pa-registration`) listed the register workflow steps but never explained what to do when the workflow pauses at **Wait for French agreement upload**. Operators had no way of knowing there is a form to open and sign before the party can be accepted.

## Changes

- Flag the **Wait for French agreement upload** step as a manual gate (party stays in `processing` until signed).
- Add a **Complete the agreement** section: open the party entry → **Meta** tab → click the agreement link (`approval-link`) → review and sign the PA mandate. Once submitted and accepted, the workflow continues to directory + Peppol registration and ends in `registered`.
- Add a **Sign through the API** subsection: the four-call sequence (fetch agreement PDF → upload signed PDF → upload identity images if hand-signed → confirm) linking to the existing `api-ref/apps/gov-fr` pages, mirroring the SII supplier guide.
- Add a note that, without signing, the party is never automatically accepted.

Text-only for now — a screenshot of the Meta link can be added later (the KSeF guide has an analogous one).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
