### PR TITLE
Correct invoice guide fix

### DIFF
--- a/guides/correct-invoice.mdx
+++ b/guides/correct-invoice.mdx
@@ -64,42 +64,60 @@ Let's walk through both.
 
 ## Using the console
 
-  ### Steps
-    1. In the [Console](https://console.invopop.com), click on **Invoices** in the left sidebar.
-    2. Select the invoice you want to correct.
-      <Warning>
-        The invoice must be issued before a correction can be made.
-      </Warning>
-    3. Click on the **Correct** button in the top-right corner. This will open the **Correction** dialog.
+
+
+    In the [Console](https://console.invopop.com), click on **Invoices** in the left sidebar and select the invoice you want to correct.
+
+    <Warning>
+      The invoice must be issued before a correction can be made.
+    </Warning>
+  
+  <Steps>
+
+  <Step title="Open the Correction dialog">
+    Click on the **Correct** button in the top-right corner. This will open the **Correction** dialog.
+
     <Frame>
       <img
-        alt= "Toggle code view"
+        alt="Toggle code view"
         src="/assets/guides/cn-correct-button.gif"
         width="100%"
       />
     </Frame>
-    4. In the Series field, enter the series code for credit note (e.g.,`CN`).
-    5. Under **Type**, select `credit-note` from the dropdown.
-    6. Click the **Correct** button at the bottom right of the dialog.
-    > This will generate the credit note based on the original invoice.
+  </Step>
+
+  <Step title="Enter the series code">
+    In the Series field, enter the series code for credit note (e.g., `CN`).
+  </Step>
+
+  <Step title="Select the type">
+    Under **Type**, select `credit-note` from the dropdown.
+  </Step>
+
+  <Step title="Generate the credit note">
+    Click the **Correct** button at the bottom right of the dialog. This will generate the credit note based on the original invoice.
 
     <Frame>
       <img
-        alt= "Build invoice"
+        alt="Build invoice"
         src="/assets/guides/cn-correct-dialog.gif"
         width="100%"
       />
     </Frame>
+  </Step>
 
-    7. Click the **Save** button in the top-right corner to store the credit note.
-    > You'll be redirected to the *invoice detail* view.
+  <Step title="Save the credit note">
+    Click the **Save** button in the top-right corner to store the credit note. You'll be redirected to the *invoice detail* view.
+
     <Frame>
       <img
-        alt= "Invoice detail"
+        alt="Invoice detail"
         src="/assets/guides/cn-result.png"
         width="100%"
       />
     </Frame>
+  </Step>
+</Steps>
 
     You've just created your first credit note! You can click on Preview to see how it'd look like in a PDF format.
 
@@ -112,7 +130,7 @@ Let's walk through both.
 
     Let's walk through each method:
 
-    ###  1. Upload of a complete credit note
+    ###  Create a complete credit note
 
     This method gives you full control over the credit note. You define everything, from line items and taxes to the original invoice reference.
     It's perfect if you already have the credit note prepared, whether you built it manually or generated it somewhere else. Just upload it directly to Invopop and you're good to go.
@@ -264,7 +282,7 @@ Let's walk through both.
     If everything goes well, you'll get a `200 OK` response along with the JSON for your newly registered credit note.
 
 
-    ### 2. Auto-generate a credit note from an invoice
+    ### Auto-generate a credit note from an invoice
 
     Sending a complete credit note to Invopop is straightforward, as long as you already have the full document ready to go.
 

--- a/guides/correct-invoice.mdx
+++ b/guides/correct-invoice.mdx
@@ -12,10 +12,10 @@ In this tutorial, you will:
 1. Understand what invoice corrections are and when to use them.
 2. Learn about the three main correction types: **credit notes**, **debit notes**, and **corrective invoice**.
 3. Explore different ways to issue a **credit note** to correct an invoice:
-   * **Using the API**:
+   * [Using the API](#using-the-api):
      * Upload a fully defined credit note
      * Auto-generate a credit note from an existing invoice
-   * **Using the Invopop Console** to create the credit note through the interface.
+   * [Using the Console](#using-the-console) to create the credit note through the interface.
 
 ## Understanding Invoice Corrections
 
@@ -66,8 +66,7 @@ There are two ways to do this:
 
 Let's walk through both.
 
-<Tabs>
-  <Tab title="Console">
+## Using the console
 
   ### Steps
     1. In the [Console](https://console.invopop.com), click on **Invoices** in the left sidebar.
@@ -107,9 +106,8 @@ Let's walk through both.
     </Frame>
 
     You've just created your first credit note! You can click on Preview to see how it'd look like in a PDF format.
-  </Tab>
 
-  <Tab title="API">
+  ## Using the API
 
     There are two ways to submit a credit note using the API:
 
@@ -126,7 +124,7 @@ Let's walk through both.
     #### How it works
 
     Use the [Create an Entry](/api-ref/silo/entries/create-an-entry-post) API endpoint with a request body that wraps your credit note in the required structure:
-    - Set the `$schema` field so that it points to https://gobl.org/draft-0/bill/credit-note.
+    - Set the `$schema` field so that it points to https://gobl.org/draft-0/bill/invoice.
     - Set the `type` field accordingly (`credit-note` instead of `standard`).
     - Include a reference to the original invoice you're correcting (known as a *preceding block* in GOBL).
 
@@ -136,8 +134,8 @@ Let's walk through both.
     {
       "content_type": "application/json",
       "data": {
-        "$schema": "https://gobl.org/draft-0/bill/credit-note",
-        "type": "credit_note",
+        "$schema": "https://gobl.org/draft-0/bill/invoice",
+        "type": "credit-note",
         "preceding": [
           {
             "uuid": "019035bd-4524-73ab-bf44-6037841ce5d9",
@@ -293,7 +291,5 @@ Let's walk through both.
     * `correct.type` should be `credit-note` to indicate the correction type.
 
     If everything goes well, you'll get a `200 OK` response along with the JSON for your newly registered credit note.
-  </Tab>
-</Tabs>
 
 

--- a/guides/correct-invoice.mdx
+++ b/guides/correct-invoice.mdx
@@ -5,8 +5,6 @@ description: "Step by step guide to correct issued invoices with credit notes"
 icon: "eraser"
 ---
 
-## Goal of this tutorial
-
 In this tutorial, you will:
 
 1. Understand what invoice corrections are and when to use them.
@@ -17,7 +15,7 @@ In this tutorial, you will:
      * Auto-generate a credit note from an existing invoice
    * [Using the Console](#using-the-console) to create the credit note through the interface.
 
-## Understanding Invoice Corrections
+## Understanding invoice corrections
 
 Billing mistakes happen, and when they do, they need to be addressed correctly. Depending on the nature of the error, different types of financial documents can be issued to correct an invoice. These are credit notes, debit notes, and corrective invoices.
 
@@ -51,13 +49,11 @@ Countries that support corrective invoices include Spain and Poland.
 
 It's worth noting that not all countries support corrective invoices, and in some countries where the tax regime does, such as Spain, GOBL may attempt to map credit and debit notes into the appropriate corrective format.
 
-## Correcting Your First Invoice Using a Credit Note
+## Correcting your first invoice using a credit note
 
-Before we dive in, let's quickly recap where we are.
+Before we dive in make sure you've completed the [Quickstart](/guides/getting-started/quickstart) tutorial, you should now have a processed invoice in your workspace.
 
-If you've completed the [Quickstart](/guides/getting-started/quickstart) tutorial, you should now have a processed invoice in your workspace.
-
-Let's say there was a mistake in the invoice and we need to fix it. Once an invoice has been issued, it shouldn't be edited. Instead, we issue a *credit note* to make the correction.
+Let's say there was a mistake in the invoice and we need to fix it. Once an invoice has been issued, it shouldn't be edited. Instead, we issue a **credit note** to make the correction.
 
 There are two ways to do this:
 
@@ -116,12 +112,12 @@ Let's walk through both.
 
     Let's walk through each method:
 
-    ###  1. Upload of a Complete Credit Note
+    ###  1. Upload of a complete credit note
 
     This method gives you full control over the credit note. You define everything, from line items and taxes to the original invoice reference.
     It's perfect if you already have the credit note prepared, whether you built it manually or generated it somewhere else. Just upload it directly to Invopop and you're good to go.
 
-    #### How it works
+    **How it works**
 
     Use the [Create an Entry](/api-ref/silo/entries/create-an-entry-post) API endpoint with a request body that wraps your credit note in the required structure:
     - Set the `$schema` field so that it points to https://gobl.org/draft-0/bill/invoice.
@@ -268,15 +264,15 @@ Let's walk through both.
     If everything goes well, you'll get a `200 OK` response along with the JSON for your newly registered credit note.
 
 
-    ### 2. Auto-Generate Credit Note from Invoice
+    ### 2. Auto-generate a credit note from an invoice
 
-    Sending a complete credit note to Invopop is pretty straightforward, as long as you already have the full document ready to go.
+    Sending a complete credit note to Invopop is straightforward, as long as you already have the full document ready to go.
 
-    That said, building one from scratch can be complex, not just because of the structure, but because certain regimes require very specific references to the original invoice. For example, in Colombia, you need to include the original CUFE code, and in Verifactu, the credit note must reproduce a detailed breakdown of the original taxes. That's why it helps to have the system handle this automatically when possible.
+    That said, building one from scratch can be complex, not just because of the structure, but because certain regimes require very specific references to the original invoice. For example, in Colombia, you need to include the original CUFE code, and in VERI\*FACTU, the credit note must reproduce a detailed breakdown of the original taxes. That's why it helps to have the system handle this automatically when possible.
 
-    That's where Invopop really shines. Instead of defining everything yourself, you can simply reference the invoice you want to correct. Just pass the **Silo Entry ID** and the type of correction, and Invopop will take care of the rest.
+    This is where Invopop really shines. Instead of defining everything yourself, you can simply reference the invoice you want to correct. Just pass the **Silo Entry ID** and the type of correction, and Invopop will take care of the rest.
 
-    ### How it works
+    **How it works**
 
     Use the [Create an Entry](/api-ref/silo/entries/create-an-entry-post) API endpoint, but this time, skip the `data` field. Instead, you'll send a request body that tells Invopop to generate the credit note for you:
 


### PR DESCRIPTION
This PR fixes several inaccuracies in the Invoice correction guide, and removes tabs in favor of sequential Console and API implementations to improve UX. Titles are set to sentence case.