### PR TITLE
docs(mx): digital platform reporting guide

### DIFF
--- a/compliance/mexico.mdx
+++ b/compliance/mexico.mdx
@@ -415,7 +415,9 @@ The issuer submits a cancellation request through SAT or a PAC, and the receiver
   </Accordion>
 
   <Accordion title="Real-time data access (May 2026)">
-    Article 30-B of the CFF, introduced in the 2026 RMF, requires technology platforms (domestic and foreign) to provide SAT with continuous online access to tax and operational data, available no later than the day after each transaction. This applies to marketplaces, ride-hailing, lodging, food delivery, and digital service providers operating in Mexico. It is a separate reporting obligation from the CFDI flow and is not covered by Invopop's CFDI app.
+    Article 30-B of the CFF, introduced in the 2026 RMF, requires technology platforms (domestic and foreign) to provide SAT with continuous online access to tax and operational data, available no later than the day after each transaction. This applies to marketplaces, ride-hailing, lodging, food delivery, and digital service providers operating in Mexico. It is a separate reporting obligation from the CFDI flow.
+
+    Invopop addresses this with [digital platform reporting](/guides/mx-sat-platform-reporting): register a platform, record each operation with the fields required by rule 2.9.21, and give SAT a private, access-controlled portal to browse, filter, and export them on demand.
   </Accordion>
 </AccordionGroup>
 

--- a/docs.json
+++ b/docs.json
@@ -311,7 +311,8 @@
 								"group": "🇲🇽 Mexico",
 								"pages": [
 									"/guides/mx-sat-issuing",
-									"/guides/mx-sat-receiving"
+									"/guides/mx-sat-receiving",
+									"/guides/mx-sat-platform-reporting"
 								]
 							},
 							"/guides/pl-ksef",

--- a/guides/mx-sat-platform-reporting.mdx
+++ b/guides/mx-sat-platform-reporting.mdx
@@ -1,0 +1,206 @@
+---
+title: "Digital platform reporting for Mexico"
+sidebarTitle: "Platform reporting"
+description: Expose the operations carried out through a digital platform to the SAT via a hosted, access-controlled portal.
+---
+
+<Warning>
+  Digital platform reporting is in active development. The action names and the portal layout may change. If you operate a platform in Mexico, talk to us before enabling it in production.
+</Warning>
+
+Operators of digital platforms ("plataformas digitales tecnológicas") that facilitate sales or services for third parties must keep, and make available to the SAT, the information of every operation carried out through them. This is a **separate obligation from CFDI issuance** — the platform itself reports the operations, regardless of who issued the underlying invoice.
+
+This feature lets you register a party as a platform reporter, record each operation with the legally required fields, and hand the SAT a private URL where it can browse, filter, and export those operations on demand.
+
+For the regulatory background — Article 30-B of the CFF (2026 RMF) and the operation-information requirements of rule 2.9.21 — see the [Mexico compliance page](/compliance/mexico).
+
+## How it works
+
+There are three provider actions, in the `platforms` namespace, plus a SAT-facing portal:
+
+| Step | Action | What it does |
+|---|---|---|
+| **Register** | `sat-mx.platforms.register` | Enrolls a party for platform reporting and produces the portal URL + access credentials. |
+| **Record** | `sat-mx.platforms.record` | Files a single operation (invoice / CFDI) with the required fields, ready for inspection. |
+| **Unregister** | `sat-mx.platforms.unregister` | Stops accepting new operations while keeping the portal and its history available. |
+
+The typical lifecycle is: **register the party once → record every operation as it happens → share the portal URL with the SAT**. The SAT logs in whenever it needs to inspect the operations. If the party stops reporting, you unregister it; the historical data stays accessible.
+
+## Recorded fields
+
+Each recorded operation captures the fields required by rule 2.9.21, section I, extracted automatically from the GOBL document:
+
+| # | Field | Source | Required |
+|---|---|---|---|
+| a | Tipo de servicio (service type) | Distinct line-item descriptions (capped at the first three, with "+N más") | Yes |
+| b | RFC del comprador (buyer tax ID) | Customer `tax_id.code`, when present | When known |
+| c | Monto sin IVA (amount before VAT) | Invoice totals | Yes |
+| d | IVA (VAT) | Invoice totals | Yes |
+| e | Monto con IVA (amount incl. VAT) | Invoice totals | Yes |
+| f | Folio fiscal (CFDI UUID) | The SAT stamp (`sat-uuid`); falls back to the invoice number when there is no CFDI | When available |
+| g | Forma de pago (payment method) | The Mexican `FormaPago` (`mx-cfdi-payment-means`) when present, otherwise the GOBL payment instruction key | Yes |
+
+<Note>
+  Fields **b** and **f** are conditional in the rule itself — a sale to público en general has no buyer RFC, and a non-CFDI operation has no folio fiscal. The recording action only rejects an operation when one of the always-required totals (c, d, e), the service type, or the payment method is missing.
+</Note>
+
+The feature does **not** restrict by country or tax regime: a foreign operator (for example, a German company operating in Mexico) can be registered and reported on just the same.
+
+## Registering a platform
+
+Run `sat-mx.platforms.register` against the operator's party. It enrolls the party, generates an HMAC-signed portal URL, and writes the link and credentials to the party's metadata so you can retrieve and re-share them at any time.
+
+The action returns, and stores on the party:
+
+- **URL** — the signed portal address to give to the SAT.
+- **Usuario** — the operator's RFC.
+- **Secreto** — the access secret (shown so you can share it; re-running register keeps the same secret).
+
+### How it works
+
+<Steps>
+  <Step title="Set State → processing">
+    Marks the silo entry as "Processing".
+  </Step>
+  <Step title="Register party for platform reporting">
+    Enrolls the party, signs the portal URL, and stores the link + credentials on the party metadata.
+  </Step>
+  <Step title="Set State → registered">
+    Marks the silo entry as "Registered".
+  </Step>
+</Steps>
+
+```json Register party for platform reporting
+{
+  "name": "Register platform for SAT reporting",
+  "description": "Enroll a party for digital platform reporting in Mexico",
+  "schema": "org/party",
+  "steps": [
+    {
+      "id": "1a9bcde0-a816-11ef-87b2-fd751e6d3b88",
+      "name": "Sign Envelope",
+      "provider": "silo.close"
+    },
+    {
+      "id": "2061c540-a816-11ef-87b2-fd751e6d3b88",
+      "name": "Register platform (Mexico)",
+      "provider": "sat-mx.platforms.register"
+    },
+    {
+      "id": "6f9282a0-3870-11ef-af29-4533d56cea03",
+      "name": "Set State",
+      "config": { "state": "processing" },
+      "summary": "Set state to `processing`{.state .processing}",
+      "provider": "silo.state"
+    }
+  ]
+}
+```
+
+## Recording operations
+
+Wire `sat-mx.platforms.record` as the workflow for the `bill/invoice` documents that flow through the platform. The action resolves the supplier from the invoice, extracts the required fields, and files the operation against that platform's portal.
+
+Recording is **idempotent on the invoice**: re-running the workflow for the same document updates the existing row instead of creating a duplicate. If the platform has been unregistered, new operations are rejected.
+
+### How it works
+
+<Steps>
+  <Step title="Set State → processing">
+    Marks the silo entry as "Processing".
+  </Step>
+  <Step title="Record operation for reporting">
+    Extracts the rule 2.9.21 fields and files the operation; errors if a required field is missing.
+  </Step>
+  <Step title="Set State → recorded">
+    Marks the silo entry as "Recorded".
+  </Step>
+</Steps>
+
+```json Record operation for platform reporting
+{
+  "name": "Record operation for SAT platform reporting",
+  "description": "File a single sale through the digital platform portal",
+  "schema": "bill/invoice",
+  "steps": [
+    {
+      "id": "3b1c2d40-a816-11ef-87b2-fd751e6d3b88",
+      "name": "Sign Envelope",
+      "provider": "silo.close"
+    },
+    {
+      "id": "4c2d3e50-a816-11ef-87b2-fd751e6d3b88",
+      "name": "Record operation (Mexico)",
+      "provider": "sat-mx.platforms.record"
+    },
+    {
+      "id": "5d3e4f60-a816-11ef-87b2-fd751e6d3b88",
+      "name": "Set State",
+      "config": { "state": "processing" },
+      "summary": "Set state to `processing`{.state .processing}",
+      "provider": "silo.state"
+    }
+  ]
+}
+```
+
+<Info>
+  An operation can only be recorded against a party that has been registered first. The record action resolves the platform from the invoice's supplier — register the supplier's party before sending it any operations.
+</Info>
+
+## The SAT portal
+
+The portal is the SAT-facing side of the feature. It needs no Invopop account: the SAT opens the signed URL from the register step and authenticates with the **Usuario** (RFC) and **Secreto**.
+
+Once logged in, the SAT sees a paginated table of every recorded operation for that platform, with the fields above, and can:
+
+- **Filter** by buyer RFC and by a date range. Filtering and pagination run server-side, so the table stays fast over very large histories.
+- **Export to CSV** — the full, filtered result set streams as a download, with no row-count ceiling.
+
+<Badge color="blue" size="sm">GET</Badge> `/<owner>/<entry>?sig=<signature>` — the signed portal entry point (login).<br />
+<Badge color="green" size="sm">GET</Badge> `/<owner>/<entry>/sales` — the filterable, paginated operations table.<br />
+<Badge color="green" size="sm">GET</Badge> `/<owner>/<entry>/sales.csv` — a streaming CSV export of the current filter.
+
+The session is a short-lived signed cookie; logging out (or letting it expire) returns the SAT to the login screen for the same signed link.
+
+## Unregistering
+
+When a party should no longer accept new operations, run `sat-mx.platforms.unregister`. New `record` calls are rejected from that point on, **but the portal URL and secret keep working** so the SAT can still inspect everything filed up to then.
+
+### How it works
+
+<Steps>
+  <Step title="Set State → processing">
+    Marks the silo entry as "Processing".
+  </Step>
+  <Step title="Unregister party from platform reporting">
+    Stops accepting new operations; preserves portal access and history.
+  </Step>
+  <Step title="Set State → void">
+    Marks the silo entry as "Void".
+  </Step>
+</Steps>
+
+```json Unregister party from platform reporting
+{
+  "name": "Unregister platform from SAT reporting",
+  "description": "Stop accepting new operations while keeping portal access",
+  "schema": "org/party",
+  "steps": [
+    {
+      "id": "6e4f5a70-a816-11ef-87b2-fd751e6d3b88",
+      "name": "Unregister platform (Mexico)",
+      "provider": "sat-mx.platforms.unregister"
+    },
+    {
+      "id": "7f5a6b80-a816-11ef-87b2-fd751e6d3b88",
+      "name": "Set State",
+      "config": { "state": "processing" },
+      "summary": "Set state to `processing`{.state .processing}",
+      "provider": "silo.state"
+    }
+  ]
+}
+```
+
+To resume reporting for the party, register it again — the existing portal URL and secret are reused.

--- a/guides/mx-sat-platform-reporting.mdx
+++ b/guides/mx-sat-platform-reporting.mdx
@@ -4,6 +4,10 @@ sidebarTitle: "Platform reporting"
 description: Expose the operations carried out through a digital platform to the SAT via a hosted, access-controlled portal.
 ---
 
+import RegisterWorkflow from '/snippets/workflows/mx/sat-platforms-register.mdx';
+import RecordWorkflow from '/snippets/workflows/mx/sat-platforms-record.mdx';
+import UnregisterWorkflow from '/snippets/workflows/mx/sat-platforms-unregister.mdx';
+
 <Warning>
   Digital platform reporting is in active development. The action names and the portal layout may change. If you operate a platform in Mexico, talk to us before enabling it in production.
 </Warning>
@@ -62,6 +66,9 @@ The action returns, and stores on the party:
   <Step title="Set State → processing">
     Marks the silo entry as "Processing".
   </Step>
+  <Step title="Sign envelope">
+    Closes (signs) the party envelope so it can be processed.
+  </Step>
   <Step title="Register party for platform reporting">
     Enrolls the party, signs the portal URL, and stores the link + credentials on the party metadata.
   </Step>
@@ -70,32 +77,17 @@ The action returns, and stores on the party:
   </Step>
 </Steps>
 
-```json Register party for platform reporting
-{
-  "name": "Register platform for SAT reporting",
-  "description": "Enroll a party for digital platform reporting in Mexico",
-  "schema": "org/party",
-  "steps": [
-    {
-      "id": "1a9bcde0-a816-11ef-87b2-fd751e6d3b88",
-      "name": "Sign Envelope",
-      "provider": "silo.close"
-    },
-    {
-      "id": "2061c540-a816-11ef-87b2-fd751e6d3b88",
-      "name": "Register platform (Mexico)",
-      "provider": "sat-mx.platforms.register"
-    },
-    {
-      "id": "6f9282a0-3870-11ef-af29-4533d56cea03",
-      "name": "Set State",
-      "config": { "state": "processing" },
-      "summary": "Set state to `processing`{.state .processing}",
-      "provider": "silo.state"
-    }
-  ]
-}
-```
+<Tabs>
+  <Tab title="Template">
+    <Card iconType="duotone" title="SAT register platform workflow" icon="code-branch" href="https://console.invopop.com/redirect/workflows/new?template=mx-sat-platforms-register" cta="Add to my workspace">
+      Enrolls a party for digital platform reporting and generates the SAT portal URL and credentials.
+    </Card>
+  </Tab>
+  <Tab title="Code">
+    Copy and paste into a new [Empty Party workflow](https://console.invopop.com/redirect/workflows/new?template=empty-party) code view.
+    <RegisterWorkflow />
+  </Tab>
+</Tabs>
 
 ## Recording operations
 
@@ -109,40 +101,28 @@ Recording is **idempotent on the invoice**: re-running the workflow for the same
   <Step title="Set State → processing">
     Marks the silo entry as "Processing".
   </Step>
+  <Step title="Sign envelope">
+    Closes (signs) the invoice envelope so it can be processed.
+  </Step>
   <Step title="Record operation for reporting">
     Extracts the rule 2.9.21 fields and files the operation; errors if a required field is missing.
   </Step>
-  <Step title="Set State → recorded">
-    Marks the silo entry as "Recorded".
+  <Step title="Set State → sent">
+    Marks the silo entry as "Sent".
   </Step>
 </Steps>
 
-```json Record operation for platform reporting
-{
-  "name": "Record operation for SAT platform reporting",
-  "description": "File a single sale through the digital platform portal",
-  "schema": "bill/invoice",
-  "steps": [
-    {
-      "id": "3b1c2d40-a816-11ef-87b2-fd751e6d3b88",
-      "name": "Sign Envelope",
-      "provider": "silo.close"
-    },
-    {
-      "id": "4c2d3e50-a816-11ef-87b2-fd751e6d3b88",
-      "name": "Record operation (Mexico)",
-      "provider": "sat-mx.platforms.record"
-    },
-    {
-      "id": "5d3e4f60-a816-11ef-87b2-fd751e6d3b88",
-      "name": "Set State",
-      "config": { "state": "processing" },
-      "summary": "Set state to `processing`{.state .processing}",
-      "provider": "silo.state"
-    }
-  ]
-}
-```
+<Tabs>
+  <Tab title="Template">
+    <Card iconType="duotone" title="SAT record operation workflow" icon="code-branch" href="https://console.invopop.com/redirect/workflows/new?template=mx-sat-platforms-record" cta="Add to my workspace">
+      Files a single sale through the digital platform portal, ready for SAT inspection.
+    </Card>
+  </Tab>
+  <Tab title="Code">
+    Copy and paste into a new [Empty Invoice workflow](https://console.invopop.com/redirect/workflows/new?template=empty-invoice) code view.
+    <RecordWorkflow />
+  </Tab>
+</Tabs>
 
 <Info>
   An operation can only be recorded against a party that has been registered first. The record action resolves the platform from the invoice's supplier — register the supplier's party before sending it any operations.
@@ -181,26 +161,16 @@ When a party should no longer accept new operations, run `sat-mx.platforms.unreg
   </Step>
 </Steps>
 
-```json Unregister party from platform reporting
-{
-  "name": "Unregister platform from SAT reporting",
-  "description": "Stop accepting new operations while keeping portal access",
-  "schema": "org/party",
-  "steps": [
-    {
-      "id": "6e4f5a70-a816-11ef-87b2-fd751e6d3b88",
-      "name": "Unregister platform (Mexico)",
-      "provider": "sat-mx.platforms.unregister"
-    },
-    {
-      "id": "7f5a6b80-a816-11ef-87b2-fd751e6d3b88",
-      "name": "Set State",
-      "config": { "state": "processing" },
-      "summary": "Set state to `processing`{.state .processing}",
-      "provider": "silo.state"
-    }
-  ]
-}
-```
+<Tabs>
+  <Tab title="Template">
+    <Card iconType="duotone" title="SAT unregister platform workflow" icon="code-branch" href="https://console.invopop.com/redirect/workflows/new?template=mx-sat-platforms-unregister" cta="Add to my workspace">
+      Stops accepting new operations for a platform while preserving portal access and history.
+    </Card>
+  </Tab>
+  <Tab title="Code">
+    Copy and paste into a new [Empty Party workflow](https://console.invopop.com/redirect/workflows/new?template=empty-party) code view.
+    <UnregisterWorkflow />
+  </Tab>
+</Tabs>
 
 To resume reporting for the party, register it again — the existing portal URL and secret are reused.

--- a/snippets/workflows/mx/sat-platforms-record.mdx
+++ b/snippets/workflows/mx/sat-platforms-record.mdx
@@ -1,0 +1,56 @@
+---
+title: "SAT record operation for reporting"
+description: "File a single sale through the digital platform portal for SAT reporting in Mexico"
+countryCode: "mx"
+appId: "sat-mx"
+schema: "bill/invoice"
+---
+
+```json Example SAT record operation workflow
+{
+    "name": "Record operation for SAT platform reporting",
+    "description": "File a single sale through the digital platform portal",
+    "schema": "bill/invoice",
+    "steps": [
+        {
+            "id": "a2000000-0002-11f1-a000-000000000001",
+            "name": "Set State",
+            "provider": "silo.state",
+            "summary": "Set state to `processing`{.state .processing}",
+            "config": {
+                "state": "processing"
+            }
+        },
+        {
+            "id": "a2000000-0002-11f1-a000-000000000002",
+            "name": "Sign Envelope",
+            "provider": "silo.close"
+        },
+        {
+            "id": "a2000000-0002-11f1-a000-000000000003",
+            "name": "Record operation (Mexico)",
+            "provider": "sat-mx.platforms.record"
+        },
+        {
+            "id": "a2000000-0002-11f1-a000-000000000004",
+            "name": "Set State",
+            "provider": "silo.state",
+            "summary": "Set state to `sent`{.state .sent}",
+            "config": {
+                "state": "sent"
+            }
+        }
+    ],
+    "rescue": [
+        {
+            "id": "a2000000-0002-11f1-a000-000000000099",
+            "name": "Set State",
+            "provider": "silo.state",
+            "summary": "Set state to `error`{.state .error}",
+            "config": {
+                "state": "error"
+            }
+        }
+    ]
+}
+```

--- a/snippets/workflows/mx/sat-platforms-register.mdx
+++ b/snippets/workflows/mx/sat-platforms-register.mdx
@@ -1,0 +1,56 @@
+---
+title: "SAT register platform for reporting"
+description: "Enroll a party for digital platform reporting in Mexico and generate the SAT portal URL and credentials"
+countryCode: "mx"
+appId: "sat-mx"
+schema: "org/party"
+---
+
+```json Example SAT register platform workflow
+{
+    "name": "Register platform for SAT reporting",
+    "description": "Enroll a party for digital platform reporting in Mexico",
+    "schema": "org/party",
+    "steps": [
+        {
+            "id": "a1000000-0001-11f1-a000-000000000001",
+            "name": "Set State",
+            "provider": "silo.state",
+            "summary": "Set state to `processing`{.state .processing}",
+            "config": {
+                "state": "processing"
+            }
+        },
+        {
+            "id": "a1000000-0001-11f1-a000-000000000002",
+            "name": "Sign Envelope",
+            "provider": "silo.close"
+        },
+        {
+            "id": "a1000000-0001-11f1-a000-000000000003",
+            "name": "Register platform (Mexico)",
+            "provider": "sat-mx.platforms.register"
+        },
+        {
+            "id": "a1000000-0001-11f1-a000-000000000004",
+            "name": "Set State",
+            "provider": "silo.state",
+            "summary": "Set state to `registered`{.state .registered}",
+            "config": {
+                "state": "registered"
+            }
+        }
+    ],
+    "rescue": [
+        {
+            "id": "a1000000-0001-11f1-a000-000000000099",
+            "name": "Set State",
+            "provider": "silo.state",
+            "summary": "Set state to `error`{.state .error}",
+            "config": {
+                "state": "error"
+            }
+        }
+    ]
+}
+```

--- a/snippets/workflows/mx/sat-platforms-unregister.mdx
+++ b/snippets/workflows/mx/sat-platforms-unregister.mdx
@@ -1,0 +1,51 @@
+---
+title: "SAT unregister platform from reporting"
+description: "Stop accepting new operations for a platform while keeping the SAT portal and its history available"
+countryCode: "mx"
+appId: "sat-mx"
+schema: "org/party"
+---
+
+```json Example SAT unregister platform workflow
+{
+    "name": "Unregister platform from SAT reporting",
+    "description": "Stop accepting new operations while keeping portal access",
+    "schema": "org/party",
+    "steps": [
+        {
+            "id": "a3000000-0003-11f1-a000-000000000001",
+            "name": "Set State",
+            "provider": "silo.state",
+            "summary": "Set state to `processing`{.state .processing}",
+            "config": {
+                "state": "processing"
+            }
+        },
+        {
+            "id": "a3000000-0003-11f1-a000-000000000002",
+            "name": "Unregister platform (Mexico)",
+            "provider": "sat-mx.platforms.unregister"
+        },
+        {
+            "id": "a3000000-0003-11f1-a000-000000000003",
+            "name": "Set State",
+            "provider": "silo.state",
+            "summary": "Set state to `void`{.state .void}",
+            "config": {
+                "state": "void"
+            }
+        }
+    ],
+    "rescue": [
+        {
+            "id": "a3000000-0003-11f1-a000-000000000099",
+            "name": "Set State",
+            "provider": "silo.state",
+            "summary": "Set state to `error`{.state .error}",
+            "config": {
+                "state": "error"
+            }
+        }
+    ]
+}
+```


### PR DESCRIPTION
Adds documentation for the new **digital platform reporting** feature under SAT Mexico.

## What's here
- **New guide** `guides/mx-sat-platform-reporting.mdx`:
  - **Why it's needed** — digital platforms must keep and expose their operations to the SAT (Art. 30-B CFF / 2026 RMF; operation-info fields of rule 2.9.21), separate from CFDI issuance.
  - **How it works** — the three `platforms.*` provider actions and the SAT portal lifecycle (register → record → inspect → unregister).
  - **Recorded fields** — the rule 2.9.21 §I fields (a–g) and where each is extracted from, including CFDI folio vs. invoice-number fallback and the Mexican `FormaPago`.
  - **Step-by-step** for each action (`sat-mx.platforms.register` / `.record` / `.unregister`) with `<Steps>` breakdowns and copy-paste workflow JSON.
  - **The SAT portal** — signed login (Usuario = RFC, Secreto), server-side filtering by buyer RFC + date range, pagination, and streaming CSV export.
- **Nav** — registered in the 🇲🇽 Mexico guides group in `docs.json`.
- **Compliance page** — updated the "Real-time data access (May 2026)" accordion to point at the new guide (it previously said this was *not* covered).

## Notes
- `mint broken-links` passes.
- The provider action namespace is `platforms.*` (e.g. `sat-mx.platforms.register`), matching the corresponding rename in the `sat-mx` service.

🤖 Generated with [Claude Code](https://claude.com/claude-code)