### PR TITLE
docs(fr-pa-status): pair each state example with its built version

### DIFF
--- a/guides/fr-pa-status.mdx
+++ b/guides/fr-pa-status.mdx
@@ -93,7 +93,7 @@ You build the natural GOBL document and the addon derives the CDV code — the f
 
 **Linking to the invoice.** Every status or payment references its invoice by the invoice's full number (`series` + `code`) and issue date. On a `bill.Status` line this field is `doc`; on a `bill.Payment` line it is `document`. On receipt the platform resolves the invoice by the supplier's SIREN + number + year and links the two in the console's **Related** tab.
 
-**Direction is automatic.** Party roles are derived (`SE` Seller on the supplier, `BY` Buyer on the customer), and the sending/receiving direction follows the event type — buyer-issued events (a `211` advice, the recipient-issued statuses) invert the issuer. You only provide the supplier and customer; the addon handles the rest.
+**Direction is automatic.** You always provide the same `supplier` (the seller) and `customer` (the buyer) as on the invoice; the addon derives each party's CDV role code. For statuses and payment receipts that is `SE` (Seller) on the supplier and `BY` (Buyer) on the customer. A **`211` payment advice is issued by the payer (the buyer), so it inverts the role codes** — in the built document the supplier carries `BY` and the customer `SE`. You don't swap the parties; only the derived roles flip, and the addon handles it.
 
 ### Reasons, faults and actions
 
@@ -181,7 +181,7 @@ One example per code you build, each referencing the same invoice (`INV-2026-004
     </CodeGroup>
   </Accordion>
   <Accordion title="211 — Paiement transmis (Payment advice)">
-    `bill.Payment` · `type: advice`. Issued by the buyer (payer); the `methods` carry the amount and the `value_date` the payment date.
+    `bill.Payment` · `type: advice`. Issued by the buyer (payer); the `methods` carry the amount and the `value_date` the payment date. Because it is payer-issued, the **built version inverts the CDV roles** — `BY` on the supplier and `SE` on the customer (you still place the seller in `supplier` and the buyer in `customer`; see [Direction is automatic](#building-a-status)).
     <CodeGroup>
       <State211Min />
       <State211 />

--- a/guides/fr-pa-status.mdx
+++ b/guides/fr-pa-status.mdx
@@ -8,17 +8,29 @@ import FranceResources from '/snippets/tables/france-resources.mdx';
 import FAQ from '/snippets/faqs/fr/composers/guide-pa-reporting.mdx';
 
 import State201 from '/snippets/examples/fr/states/201-issued.mdx';
+import State201Min from '/snippets/examples/fr/states/201-issued.min.mdx';
 import State202 from '/snippets/examples/fr/states/202-acknowledged.mdx';
+import State202Min from '/snippets/examples/fr/states/202-acknowledged.min.mdx';
 import State203 from '/snippets/examples/fr/states/203-made-available.mdx';
+import State203Min from '/snippets/examples/fr/states/203-made-available.min.mdx';
 import State204 from '/snippets/examples/fr/states/204-taken-into-account.mdx';
+import State204Min from '/snippets/examples/fr/states/204-taken-into-account.min.mdx';
 import State205 from '/snippets/examples/fr/states/205-approved.mdx';
+import State205Min from '/snippets/examples/fr/states/205-approved.min.mdx';
 import State206 from '/snippets/examples/fr/states/206-partially-approved.mdx';
+import State206Min from '/snippets/examples/fr/states/206-partially-approved.min.mdx';
 import State207 from '/snippets/examples/fr/states/207-in-dispute.mdx';
+import State207Min from '/snippets/examples/fr/states/207-in-dispute.min.mdx';
 import State208 from '/snippets/examples/fr/states/208-suspended.mdx';
+import State208Min from '/snippets/examples/fr/states/208-suspended.min.mdx';
 import State209 from '/snippets/examples/fr/states/209-completed.mdx';
+import State209Min from '/snippets/examples/fr/states/209-completed.min.mdx';
 import State210 from '/snippets/examples/fr/states/210-refused.mdx';
+import State210Min from '/snippets/examples/fr/states/210-refused.min.mdx';
 import State211 from '/snippets/examples/fr/states/211-payment-advice.mdx';
+import State211Min from '/snippets/examples/fr/states/211-payment-advice.min.mdx';
 import State212 from '/snippets/examples/fr/states/212-payment-receipt.mdx';
+import State212Min from '/snippets/examples/fr/states/212-payment-receipt.min.mdx';
 
 <Note>
   Lifecycle status updates on domestic B2B invoices — acknowledged, accepted, disputed, refused, paid. They are exchanged between PAs over Peppol, with the mandatory codes also forwarded to the PPF.
@@ -95,56 +107,92 @@ The supplier-issued **`209` Complétée** requires no reason, but it can carry o
 
 ### Examples
 
-One worked GOBL example per code you build — each a complete, ready-to-build document referencing the same invoice (`INV-2026-0042`, supplier SIREN `698680774`) on its effective `date`. The interesting detail is on the **dispute / partial / refusal** codes: their `reason` carries `faults` (the exact field, its actual vs expected value, and the XML path) plus an `action` telling the issuer what to do next. The plain acknowledgements (`201`–`205`) carry no reason — the code itself is the message.
+One example per code you build, each referencing the same invoice (`INV-2026-0042`, supplier SIREN `698680774`). Every example pairs the **Minimal** hand-authored GOBL input with the **Built version** produced by `gobl build` — which adds the derived fields (the `fr-ctc-flow6-*` extensions, party roles, ISO scheme ids and endpoints). The interesting detail is on the **dispute / partial / refusal** codes: their `reason` carries `faults` (the exact field, its actual vs expected value, and the XML path) plus an `action` telling the issuer what to do next. The plain acknowledgements (`201`–`205`) carry no reason — the code itself is the message.
 
 <AccordionGroup>
   <Accordion title="201 — Émise par la plateforme (Issued by platform)">
     `bill.Status` · `type: response` · line `key: issued`. A plain acknowledgement — no reason or action.
-    <State201 />
+    <CodeGroup>
+      <State201Min />
+      <State201 />
+    </CodeGroup>
   </Accordion>
   <Accordion title="202 — Reçue par la PA (Received)">
     `bill.Status` · `type: response` · line `key: acknowledged`. A plain acknowledgement.
-    <State202 />
+    <CodeGroup>
+      <State202Min />
+      <State202 />
+    </CodeGroup>
   </Accordion>
   <Accordion title="203 — Mise à disposition (Made available)">
     `bill.Status` · `type: response` · line `key: other`. A plain acknowledgement.
-    <State203 />
+    <CodeGroup>
+      <State203Min />
+      <State203 />
+    </CodeGroup>
   </Accordion>
   <Accordion title="204 — Prise en charge (Taken into account)">
     `bill.Status` · `type: response` · line `key: processing`. A plain acknowledgement.
-    <State204 />
+    <CodeGroup>
+      <State204Min />
+      <State204 />
+    </CodeGroup>
   </Accordion>
   <Accordion title="205 — Approuvée (Approved)">
     `bill.Status` · `type: response` · line `key: accepted`. A plain acknowledgement — the invoice is fully approved.
-    <State205 />
+    <CodeGroup>
+      <State205Min />
+      <State205 />
+    </CodeGroup>
   </Accordion>
   <Accordion title="206 — Approuvée partiellement (Partially approved)">
     `bill.Status` · `type: response` · line `key: rejected` + pinned ext `206`. The `reason` faults show the **invoiced vs approved quantity**; the `action` requests a partial credit note (`credit-partial` → CNP).
-    <State206 />
+    <CodeGroup>
+      <State206Min />
+      <State206 />
+    </CodeGroup>
   </Accordion>
   <Accordion title="207 — En litige (In dispute)">
     `bill.Status` · `type: response` · line `key: rejected` + pinned ext `207`. The `reason` faults pinpoint the disputed field — **actual VAT rate (DIV) vs expected (DVA)** and its XML path; the `action` requests a full credit note (`credit-full` → CNF).
-    <State207 />
+    <CodeGroup>
+      <State207Min />
+      <State207 />
+    </CodeGroup>
   </Accordion>
   <Accordion title="208 — Suspendue (Suspended)">
     `bill.Status` · `type: response` · line `key: querying`. The `reason` names **what is missing** (order reference); the `action` asks the supplier to provide it (`provide` → PIN).
-    <State208 />
+    <CodeGroup>
+      <State208Min />
+      <State208 />
+    </CodeGroup>
   </Accordion>
   <Accordion title="209 — Complétée (Completed)">
     `bill.Status` · `type: update` · line `key: other`. Issued by the supplier to lift a suspension raised over bank details: a `finance-terms` reason (condition `CBB`, *coordonnées bancaires à modifier*) whose fault **supplies the corrected IBAN** — code `MAJ` (the value to apply), the IBAN in the `message`, and the `paths` pointing at the invoice's IBAN field (BT-84).
-    <State209 />
+    <CodeGroup>
+      <State209Min />
+      <State209 />
+    </CodeGroup>
   </Accordion>
   <Accordion title="210 — Refusée (Refused by buyer)">
     `bill.Status` · `type: response` · line `key: rejected`. The `reason` faults pinpoint the failing field; the `action` asks for a corrected reissue (`reissue` → NIN).
-    <State210 />
+    <CodeGroup>
+      <State210Min />
+      <State210 />
+    </CodeGroup>
   </Accordion>
   <Accordion title="211 — Paiement transmis (Payment advice)">
     `bill.Payment` · `type: advice`. Issued by the buyer (payer); the `methods` carry the amount and the `value_date` the payment date.
-    <State211 />
+    <CodeGroup>
+      <State211Min />
+      <State211 />
+    </CodeGroup>
   </Accordion>
   <Accordion title="212 — Encaissée (Payment receipt)">
     `bill.Payment` · `type: receipt`. Issued by the supplier (payee); the `methods` carry the amount received.
-    <State212 />
+    <CodeGroup>
+      <State212Min />
+      <State212 />
+    </CodeGroup>
   </Accordion>
 </AccordionGroup>
 

--- a/snippets/examples/fr/states/201-issued.mdx
+++ b/snippets/examples/fr/states/201-issued.mdx
@@ -1,66 +1,91 @@
----
-title: "201 — Émise par la plateforme (Issued by platform)"
-description: "GOBL bill/status example for French CTC lifecycle code 201 (Issued by platform)"
----
-
-```json 201 — Émise par la plateforme (Issued by platform)
+```json Built version
 {
-  "$schema": "https://gobl.org/draft-0/bill/status",
-  "$addons": [
-    "fr-ctc-flow6-v1"
-  ],
-  "type": "response",
-  "issue_date": "2026-06-19",
-  "code": "ST-201",
-  "supplier": {
-    "name": "Example Supplier SARL",
-    "tax_id": {
-      "country": "FR",
-      "code": "83698680774"
-    },
-    "identities": [
-      {
-        "type": "SIREN",
-        "code": "698680774"
-      }
-    ],
-    "inboxes": [
-      {
-        "scheme": "0225",
-        "code": "698680774"
-      }
-    ]
-  },
-  "customer": {
-    "name": "Example Customer SAS",
-    "tax_id": {
-      "country": "FR",
-      "code": "67698681771"
-    },
-    "identities": [
-      {
-        "type": "SIREN",
-        "code": "698681771"
-      }
-    ],
-    "inboxes": [
-      {
-        "scheme": "0225",
-        "code": "698681771"
-      }
-    ]
-  },
-  "lines": [
-    {
-      "key": "issued",
-      "date": "2026-06-19",
-      "doc": {
-        "series": "INV",
-        "code": "2026-0042",
-        "issue_date": "2026-06-19",
-        "type": "380"
-      }
-    }
-  ]
+	"$schema": "https://gobl.org/draft-0/bill/status",
+	"$regime": "FR",
+	"$addons": [
+		"fr-ctc-flow6-v1"
+	],
+	"uuid": "0195ce71-dc9c-72c8-bf2c-9890a4a9f0a2",
+	"type": "response",
+	"issue_date": "2026-06-19",
+	"code": "ST-201",
+	"supplier": {
+		"name": "Example Supplier SARL",
+		"tax_id": {
+			"country": "FR",
+			"code": "83698680774"
+		},
+		"identities": [
+			{
+				"type": "SIREN",
+				"code": "698680774",
+				"ext": {
+					"iso-scheme-id": "0002"
+				}
+			}
+		],
+		"endpoints": [
+			{
+				"uri": "iso6523-actorid-upis::0225:698680774"
+			}
+		],
+		"inboxes": [
+			{
+				"key": "peppol",
+				"scheme": "0225",
+				"code": "698680774"
+			}
+		],
+		"ext": {
+			"fr-ctc-flow6-role": "SE"
+		}
+	},
+	"customer": {
+		"name": "Example Customer SAS",
+		"tax_id": {
+			"country": "FR",
+			"code": "67698681771"
+		},
+		"identities": [
+			{
+				"type": "SIREN",
+				"code": "698681771",
+				"ext": {
+					"iso-scheme-id": "0002"
+				}
+			}
+		],
+		"endpoints": [
+			{
+				"uri": "iso6523-actorid-upis::0225:698681771"
+			}
+		],
+		"inboxes": [
+			{
+				"key": "peppol",
+				"scheme": "0225",
+				"code": "698681771"
+			}
+		],
+		"ext": {
+			"fr-ctc-flow6-role": "BY"
+		}
+	},
+	"lines": [
+		{
+			"index": 1,
+			"key": "issued",
+			"date": "2026-06-19",
+			"doc": {
+				"type": "380",
+				"issue_date": "2026-06-19",
+				"series": "INV",
+				"code": "2026-0042"
+			},
+			"ext": {
+				"fr-ctc-flow6-status": "201"
+			}
+		}
+	]
 }
 ```

--- a/snippets/examples/fr/states/201-issued.min.mdx
+++ b/snippets/examples/fr/states/201-issued.min.mdx
@@ -1,0 +1,66 @@
+---
+title: "201 — Émise par la plateforme (Issued by platform)"
+description: "GOBL bill/status example for French CTC lifecycle code 201 (Issued by platform)"
+---
+
+```json Minimal
+{
+  "$schema": "https://gobl.org/draft-0/bill/status",
+  "$addons": [
+    "fr-ctc-flow6-v1"
+  ],
+  "type": "response",
+  "issue_date": "2026-06-19",
+  "code": "ST-201",
+  "supplier": {
+    "name": "Example Supplier SARL",
+    "tax_id": {
+      "country": "FR",
+      "code": "83698680774"
+    },
+    "identities": [
+      {
+        "type": "SIREN",
+        "code": "698680774"
+      }
+    ],
+    "inboxes": [
+      {
+        "scheme": "0225",
+        "code": "698680774"
+      }
+    ]
+  },
+  "customer": {
+    "name": "Example Customer SAS",
+    "tax_id": {
+      "country": "FR",
+      "code": "67698681771"
+    },
+    "identities": [
+      {
+        "type": "SIREN",
+        "code": "698681771"
+      }
+    ],
+    "inboxes": [
+      {
+        "scheme": "0225",
+        "code": "698681771"
+      }
+    ]
+  },
+  "lines": [
+    {
+      "key": "issued",
+      "date": "2026-06-19",
+      "doc": {
+        "series": "INV",
+        "code": "2026-0042",
+        "issue_date": "2026-06-19",
+        "type": "380"
+      }
+    }
+  ]
+}
+```

--- a/snippets/examples/fr/states/202-acknowledged.mdx
+++ b/snippets/examples/fr/states/202-acknowledged.mdx
@@ -1,66 +1,91 @@
----
-title: "202 — Reçue par la PA (Received by recipient)"
-description: "GOBL bill/status example for French CTC lifecycle code 202 (Received by recipient)"
----
-
-```json 202 — Reçue par la PA (Received by recipient)
+```json Built version
 {
-  "$schema": "https://gobl.org/draft-0/bill/status",
-  "$addons": [
-    "fr-ctc-flow6-v1"
-  ],
-  "type": "response",
-  "issue_date": "2026-06-19",
-  "code": "ST-202",
-  "supplier": {
-    "name": "Example Supplier SARL",
-    "tax_id": {
-      "country": "FR",
-      "code": "83698680774"
-    },
-    "identities": [
-      {
-        "type": "SIREN",
-        "code": "698680774"
-      }
-    ],
-    "inboxes": [
-      {
-        "scheme": "0225",
-        "code": "698680774"
-      }
-    ]
-  },
-  "customer": {
-    "name": "Example Customer SAS",
-    "tax_id": {
-      "country": "FR",
-      "code": "67698681771"
-    },
-    "identities": [
-      {
-        "type": "SIREN",
-        "code": "698681771"
-      }
-    ],
-    "inboxes": [
-      {
-        "scheme": "0225",
-        "code": "698681771"
-      }
-    ]
-  },
-  "lines": [
-    {
-      "key": "acknowledged",
-      "date": "2026-06-19",
-      "doc": {
-        "series": "INV",
-        "code": "2026-0042",
-        "issue_date": "2026-06-19",
-        "type": "380"
-      }
-    }
-  ]
+	"$schema": "https://gobl.org/draft-0/bill/status",
+	"$regime": "FR",
+	"$addons": [
+		"fr-ctc-flow6-v1"
+	],
+	"uuid": "0195ce71-dc9c-72c8-bf2c-9890a4a9f0a2",
+	"type": "response",
+	"issue_date": "2026-06-19",
+	"code": "ST-202",
+	"supplier": {
+		"name": "Example Supplier SARL",
+		"tax_id": {
+			"country": "FR",
+			"code": "83698680774"
+		},
+		"identities": [
+			{
+				"type": "SIREN",
+				"code": "698680774",
+				"ext": {
+					"iso-scheme-id": "0002"
+				}
+			}
+		],
+		"endpoints": [
+			{
+				"uri": "iso6523-actorid-upis::0225:698680774"
+			}
+		],
+		"inboxes": [
+			{
+				"key": "peppol",
+				"scheme": "0225",
+				"code": "698680774"
+			}
+		],
+		"ext": {
+			"fr-ctc-flow6-role": "SE"
+		}
+	},
+	"customer": {
+		"name": "Example Customer SAS",
+		"tax_id": {
+			"country": "FR",
+			"code": "67698681771"
+		},
+		"identities": [
+			{
+				"type": "SIREN",
+				"code": "698681771",
+				"ext": {
+					"iso-scheme-id": "0002"
+				}
+			}
+		],
+		"endpoints": [
+			{
+				"uri": "iso6523-actorid-upis::0225:698681771"
+			}
+		],
+		"inboxes": [
+			{
+				"key": "peppol",
+				"scheme": "0225",
+				"code": "698681771"
+			}
+		],
+		"ext": {
+			"fr-ctc-flow6-role": "BY"
+		}
+	},
+	"lines": [
+		{
+			"index": 1,
+			"key": "acknowledged",
+			"date": "2026-06-19",
+			"doc": {
+				"type": "380",
+				"issue_date": "2026-06-19",
+				"series": "INV",
+				"code": "2026-0042"
+			},
+			"ext": {
+				"fr-ctc-flow6-status": "202"
+			}
+		}
+	]
 }
 ```

--- a/snippets/examples/fr/states/202-acknowledged.min.mdx
+++ b/snippets/examples/fr/states/202-acknowledged.min.mdx
@@ -1,0 +1,66 @@
+---
+title: "202 — Reçue par la PA (Received by recipient)"
+description: "GOBL bill/status example for French CTC lifecycle code 202 (Received by recipient)"
+---
+
+```json Minimal
+{
+  "$schema": "https://gobl.org/draft-0/bill/status",
+  "$addons": [
+    "fr-ctc-flow6-v1"
+  ],
+  "type": "response",
+  "issue_date": "2026-06-19",
+  "code": "ST-202",
+  "supplier": {
+    "name": "Example Supplier SARL",
+    "tax_id": {
+      "country": "FR",
+      "code": "83698680774"
+    },
+    "identities": [
+      {
+        "type": "SIREN",
+        "code": "698680774"
+      }
+    ],
+    "inboxes": [
+      {
+        "scheme": "0225",
+        "code": "698680774"
+      }
+    ]
+  },
+  "customer": {
+    "name": "Example Customer SAS",
+    "tax_id": {
+      "country": "FR",
+      "code": "67698681771"
+    },
+    "identities": [
+      {
+        "type": "SIREN",
+        "code": "698681771"
+      }
+    ],
+    "inboxes": [
+      {
+        "scheme": "0225",
+        "code": "698681771"
+      }
+    ]
+  },
+  "lines": [
+    {
+      "key": "acknowledged",
+      "date": "2026-06-19",
+      "doc": {
+        "series": "INV",
+        "code": "2026-0042",
+        "issue_date": "2026-06-19",
+        "type": "380"
+      }
+    }
+  ]
+}
+```

--- a/snippets/examples/fr/states/203-made-available.mdx
+++ b/snippets/examples/fr/states/203-made-available.mdx
@@ -1,66 +1,91 @@
----
-title: "203 — Mise à disposition (Made available)"
-description: "GOBL bill/status example for French CTC lifecycle code 203 (Made available)"
----
-
-```json 203 — Mise à disposition (Made available)
+```json Built version
 {
-  "$schema": "https://gobl.org/draft-0/bill/status",
-  "$addons": [
-    "fr-ctc-flow6-v1"
-  ],
-  "type": "response",
-  "issue_date": "2026-06-19",
-  "code": "ST-203",
-  "supplier": {
-    "name": "Example Supplier SARL",
-    "tax_id": {
-      "country": "FR",
-      "code": "83698680774"
-    },
-    "identities": [
-      {
-        "type": "SIREN",
-        "code": "698680774"
-      }
-    ],
-    "inboxes": [
-      {
-        "scheme": "0225",
-        "code": "698680774"
-      }
-    ]
-  },
-  "customer": {
-    "name": "Example Customer SAS",
-    "tax_id": {
-      "country": "FR",
-      "code": "67698681771"
-    },
-    "identities": [
-      {
-        "type": "SIREN",
-        "code": "698681771"
-      }
-    ],
-    "inboxes": [
-      {
-        "scheme": "0225",
-        "code": "698681771"
-      }
-    ]
-  },
-  "lines": [
-    {
-      "key": "other",
-      "date": "2026-06-19",
-      "doc": {
-        "series": "INV",
-        "code": "2026-0042",
-        "issue_date": "2026-06-19",
-        "type": "380"
-      }
-    }
-  ]
+	"$schema": "https://gobl.org/draft-0/bill/status",
+	"$regime": "FR",
+	"$addons": [
+		"fr-ctc-flow6-v1"
+	],
+	"uuid": "0195ce71-dc9c-72c8-bf2c-9890a4a9f0a2",
+	"type": "response",
+	"issue_date": "2026-06-19",
+	"code": "ST-203",
+	"supplier": {
+		"name": "Example Supplier SARL",
+		"tax_id": {
+			"country": "FR",
+			"code": "83698680774"
+		},
+		"identities": [
+			{
+				"type": "SIREN",
+				"code": "698680774",
+				"ext": {
+					"iso-scheme-id": "0002"
+				}
+			}
+		],
+		"endpoints": [
+			{
+				"uri": "iso6523-actorid-upis::0225:698680774"
+			}
+		],
+		"inboxes": [
+			{
+				"key": "peppol",
+				"scheme": "0225",
+				"code": "698680774"
+			}
+		],
+		"ext": {
+			"fr-ctc-flow6-role": "SE"
+		}
+	},
+	"customer": {
+		"name": "Example Customer SAS",
+		"tax_id": {
+			"country": "FR",
+			"code": "67698681771"
+		},
+		"identities": [
+			{
+				"type": "SIREN",
+				"code": "698681771",
+				"ext": {
+					"iso-scheme-id": "0002"
+				}
+			}
+		],
+		"endpoints": [
+			{
+				"uri": "iso6523-actorid-upis::0225:698681771"
+			}
+		],
+		"inboxes": [
+			{
+				"key": "peppol",
+				"scheme": "0225",
+				"code": "698681771"
+			}
+		],
+		"ext": {
+			"fr-ctc-flow6-role": "BY"
+		}
+	},
+	"lines": [
+		{
+			"index": 1,
+			"key": "other",
+			"date": "2026-06-19",
+			"doc": {
+				"type": "380",
+				"issue_date": "2026-06-19",
+				"series": "INV",
+				"code": "2026-0042"
+			},
+			"ext": {
+				"fr-ctc-flow6-status": "203"
+			}
+		}
+	]
 }
 ```

--- a/snippets/examples/fr/states/203-made-available.min.mdx
+++ b/snippets/examples/fr/states/203-made-available.min.mdx
@@ -1,0 +1,66 @@
+---
+title: "203 — Mise à disposition (Made available)"
+description: "GOBL bill/status example for French CTC lifecycle code 203 (Made available)"
+---
+
+```json Minimal
+{
+  "$schema": "https://gobl.org/draft-0/bill/status",
+  "$addons": [
+    "fr-ctc-flow6-v1"
+  ],
+  "type": "response",
+  "issue_date": "2026-06-19",
+  "code": "ST-203",
+  "supplier": {
+    "name": "Example Supplier SARL",
+    "tax_id": {
+      "country": "FR",
+      "code": "83698680774"
+    },
+    "identities": [
+      {
+        "type": "SIREN",
+        "code": "698680774"
+      }
+    ],
+    "inboxes": [
+      {
+        "scheme": "0225",
+        "code": "698680774"
+      }
+    ]
+  },
+  "customer": {
+    "name": "Example Customer SAS",
+    "tax_id": {
+      "country": "FR",
+      "code": "67698681771"
+    },
+    "identities": [
+      {
+        "type": "SIREN",
+        "code": "698681771"
+      }
+    ],
+    "inboxes": [
+      {
+        "scheme": "0225",
+        "code": "698681771"
+      }
+    ]
+  },
+  "lines": [
+    {
+      "key": "other",
+      "date": "2026-06-19",
+      "doc": {
+        "series": "INV",
+        "code": "2026-0042",
+        "issue_date": "2026-06-19",
+        "type": "380"
+      }
+    }
+  ]
+}
+```

--- a/snippets/examples/fr/states/204-taken-into-account.mdx
+++ b/snippets/examples/fr/states/204-taken-into-account.mdx
@@ -1,66 +1,91 @@
----
-title: "204 — Prise en charge (Taken into account)"
-description: "GOBL bill/status example for French CTC lifecycle code 204 (Taken into account)"
----
-
-```json 204 — Prise en charge (Taken into account)
+```json Built version
 {
-  "$schema": "https://gobl.org/draft-0/bill/status",
-  "$addons": [
-    "fr-ctc-flow6-v1"
-  ],
-  "type": "response",
-  "issue_date": "2026-06-19",
-  "code": "ST-204",
-  "supplier": {
-    "name": "Example Supplier SARL",
-    "tax_id": {
-      "country": "FR",
-      "code": "83698680774"
-    },
-    "identities": [
-      {
-        "type": "SIREN",
-        "code": "698680774"
-      }
-    ],
-    "inboxes": [
-      {
-        "scheme": "0225",
-        "code": "698680774"
-      }
-    ]
-  },
-  "customer": {
-    "name": "Example Customer SAS",
-    "tax_id": {
-      "country": "FR",
-      "code": "67698681771"
-    },
-    "identities": [
-      {
-        "type": "SIREN",
-        "code": "698681771"
-      }
-    ],
-    "inboxes": [
-      {
-        "scheme": "0225",
-        "code": "698681771"
-      }
-    ]
-  },
-  "lines": [
-    {
-      "key": "processing",
-      "date": "2026-06-19",
-      "doc": {
-        "series": "INV",
-        "code": "2026-0042",
-        "issue_date": "2026-06-19",
-        "type": "380"
-      }
-    }
-  ]
+	"$schema": "https://gobl.org/draft-0/bill/status",
+	"$regime": "FR",
+	"$addons": [
+		"fr-ctc-flow6-v1"
+	],
+	"uuid": "0195ce71-dc9c-72c8-bf2c-9890a4a9f0a2",
+	"type": "response",
+	"issue_date": "2026-06-19",
+	"code": "ST-204",
+	"supplier": {
+		"name": "Example Supplier SARL",
+		"tax_id": {
+			"country": "FR",
+			"code": "83698680774"
+		},
+		"identities": [
+			{
+				"type": "SIREN",
+				"code": "698680774",
+				"ext": {
+					"iso-scheme-id": "0002"
+				}
+			}
+		],
+		"endpoints": [
+			{
+				"uri": "iso6523-actorid-upis::0225:698680774"
+			}
+		],
+		"inboxes": [
+			{
+				"key": "peppol",
+				"scheme": "0225",
+				"code": "698680774"
+			}
+		],
+		"ext": {
+			"fr-ctc-flow6-role": "SE"
+		}
+	},
+	"customer": {
+		"name": "Example Customer SAS",
+		"tax_id": {
+			"country": "FR",
+			"code": "67698681771"
+		},
+		"identities": [
+			{
+				"type": "SIREN",
+				"code": "698681771",
+				"ext": {
+					"iso-scheme-id": "0002"
+				}
+			}
+		],
+		"endpoints": [
+			{
+				"uri": "iso6523-actorid-upis::0225:698681771"
+			}
+		],
+		"inboxes": [
+			{
+				"key": "peppol",
+				"scheme": "0225",
+				"code": "698681771"
+			}
+		],
+		"ext": {
+			"fr-ctc-flow6-role": "BY"
+		}
+	},
+	"lines": [
+		{
+			"index": 1,
+			"key": "processing",
+			"date": "2026-06-19",
+			"doc": {
+				"type": "380",
+				"issue_date": "2026-06-19",
+				"series": "INV",
+				"code": "2026-0042"
+			},
+			"ext": {
+				"fr-ctc-flow6-status": "204"
+			}
+		}
+	]
 }
 ```

--- a/snippets/examples/fr/states/204-taken-into-account.min.mdx
+++ b/snippets/examples/fr/states/204-taken-into-account.min.mdx
@@ -1,0 +1,66 @@
+---
+title: "204 — Prise en charge (Taken into account)"
+description: "GOBL bill/status example for French CTC lifecycle code 204 (Taken into account)"
+---
+
+```json Minimal
+{
+  "$schema": "https://gobl.org/draft-0/bill/status",
+  "$addons": [
+    "fr-ctc-flow6-v1"
+  ],
+  "type": "response",
+  "issue_date": "2026-06-19",
+  "code": "ST-204",
+  "supplier": {
+    "name": "Example Supplier SARL",
+    "tax_id": {
+      "country": "FR",
+      "code": "83698680774"
+    },
+    "identities": [
+      {
+        "type": "SIREN",
+        "code": "698680774"
+      }
+    ],
+    "inboxes": [
+      {
+        "scheme": "0225",
+        "code": "698680774"
+      }
+    ]
+  },
+  "customer": {
+    "name": "Example Customer SAS",
+    "tax_id": {
+      "country": "FR",
+      "code": "67698681771"
+    },
+    "identities": [
+      {
+        "type": "SIREN",
+        "code": "698681771"
+      }
+    ],
+    "inboxes": [
+      {
+        "scheme": "0225",
+        "code": "698681771"
+      }
+    ]
+  },
+  "lines": [
+    {
+      "key": "processing",
+      "date": "2026-06-19",
+      "doc": {
+        "series": "INV",
+        "code": "2026-0042",
+        "issue_date": "2026-06-19",
+        "type": "380"
+      }
+    }
+  ]
+}
+```

--- a/snippets/examples/fr/states/205-approved.mdx
+++ b/snippets/examples/fr/states/205-approved.mdx
@@ -1,66 +1,91 @@
----
-title: "205 — Approuvée (Approved)"
-description: "GOBL bill/status example for French CTC lifecycle code 205 (Approved)"
----
-
-```json 205 — Approuvée (Approved)
+```json Built version
 {
-  "$schema": "https://gobl.org/draft-0/bill/status",
-  "$addons": [
-    "fr-ctc-flow6-v1"
-  ],
-  "type": "response",
-  "issue_date": "2026-06-19",
-  "code": "ST-205",
-  "supplier": {
-    "name": "Example Supplier SARL",
-    "tax_id": {
-      "country": "FR",
-      "code": "83698680774"
-    },
-    "identities": [
-      {
-        "type": "SIREN",
-        "code": "698680774"
-      }
-    ],
-    "inboxes": [
-      {
-        "scheme": "0225",
-        "code": "698680774"
-      }
-    ]
-  },
-  "customer": {
-    "name": "Example Customer SAS",
-    "tax_id": {
-      "country": "FR",
-      "code": "67698681771"
-    },
-    "identities": [
-      {
-        "type": "SIREN",
-        "code": "698681771"
-      }
-    ],
-    "inboxes": [
-      {
-        "scheme": "0225",
-        "code": "698681771"
-      }
-    ]
-  },
-  "lines": [
-    {
-      "key": "accepted",
-      "date": "2026-06-19",
-      "doc": {
-        "series": "INV",
-        "code": "2026-0042",
-        "issue_date": "2026-06-19",
-        "type": "380"
-      }
-    }
-  ]
+	"$schema": "https://gobl.org/draft-0/bill/status",
+	"$regime": "FR",
+	"$addons": [
+		"fr-ctc-flow6-v1"
+	],
+	"uuid": "0195ce71-dc9c-72c8-bf2c-9890a4a9f0a2",
+	"type": "response",
+	"issue_date": "2026-06-19",
+	"code": "ST-205",
+	"supplier": {
+		"name": "Example Supplier SARL",
+		"tax_id": {
+			"country": "FR",
+			"code": "83698680774"
+		},
+		"identities": [
+			{
+				"type": "SIREN",
+				"code": "698680774",
+				"ext": {
+					"iso-scheme-id": "0002"
+				}
+			}
+		],
+		"endpoints": [
+			{
+				"uri": "iso6523-actorid-upis::0225:698680774"
+			}
+		],
+		"inboxes": [
+			{
+				"key": "peppol",
+				"scheme": "0225",
+				"code": "698680774"
+			}
+		],
+		"ext": {
+			"fr-ctc-flow6-role": "SE"
+		}
+	},
+	"customer": {
+		"name": "Example Customer SAS",
+		"tax_id": {
+			"country": "FR",
+			"code": "67698681771"
+		},
+		"identities": [
+			{
+				"type": "SIREN",
+				"code": "698681771",
+				"ext": {
+					"iso-scheme-id": "0002"
+				}
+			}
+		],
+		"endpoints": [
+			{
+				"uri": "iso6523-actorid-upis::0225:698681771"
+			}
+		],
+		"inboxes": [
+			{
+				"key": "peppol",
+				"scheme": "0225",
+				"code": "698681771"
+			}
+		],
+		"ext": {
+			"fr-ctc-flow6-role": "BY"
+		}
+	},
+	"lines": [
+		{
+			"index": 1,
+			"key": "accepted",
+			"date": "2026-06-19",
+			"doc": {
+				"type": "380",
+				"issue_date": "2026-06-19",
+				"series": "INV",
+				"code": "2026-0042"
+			},
+			"ext": {
+				"fr-ctc-flow6-status": "205"
+			}
+		}
+	]
 }
 ```

--- a/snippets/examples/fr/states/205-approved.min.mdx
+++ b/snippets/examples/fr/states/205-approved.min.mdx
@@ -1,0 +1,66 @@
+---
+title: "205 — Approuvée (Approved)"
+description: "GOBL bill/status example for French CTC lifecycle code 205 (Approved)"
+---
+
+```json Minimal
+{
+  "$schema": "https://gobl.org/draft-0/bill/status",
+  "$addons": [
+    "fr-ctc-flow6-v1"
+  ],
+  "type": "response",
+  "issue_date": "2026-06-19",
+  "code": "ST-205",
+  "supplier": {
+    "name": "Example Supplier SARL",
+    "tax_id": {
+      "country": "FR",
+      "code": "83698680774"
+    },
+    "identities": [
+      {
+        "type": "SIREN",
+        "code": "698680774"
+      }
+    ],
+    "inboxes": [
+      {
+        "scheme": "0225",
+        "code": "698680774"
+      }
+    ]
+  },
+  "customer": {
+    "name": "Example Customer SAS",
+    "tax_id": {
+      "country": "FR",
+      "code": "67698681771"
+    },
+    "identities": [
+      {
+        "type": "SIREN",
+        "code": "698681771"
+      }
+    ],
+    "inboxes": [
+      {
+        "scheme": "0225",
+        "code": "698681771"
+      }
+    ]
+  },
+  "lines": [
+    {
+      "key": "accepted",
+      "date": "2026-06-19",
+      "doc": {
+        "series": "INV",
+        "code": "2026-0042",
+        "issue_date": "2026-06-19",
+        "type": "380"
+      }
+    }
+  ]
+}
+```

--- a/snippets/examples/fr/states/206-partially-approved.mdx
+++ b/snippets/examples/fr/states/206-partially-approved.mdx
@@ -1,100 +1,126 @@
----
-title: "206 — Approuvée partiellement (Partially approved)"
-description: "GOBL bill/status example for French CTC lifecycle code 206 (Partially approved)"
----
-
-```json 206 — Approuvée partiellement (Partially approved)
+```json Built version
 {
-  "$schema": "https://gobl.org/draft-0/bill/status",
-  "$addons": [
-    "fr-ctc-flow6-v1"
-  ],
-  "type": "response",
-  "issue_date": "2026-06-19",
-  "code": "ST-206",
-  "supplier": {
-    "name": "Example Supplier SARL",
-    "tax_id": {
-      "country": "FR",
-      "code": "83698680774"
-    },
-    "identities": [
-      {
-        "type": "SIREN",
-        "code": "698680774"
-      }
-    ],
-    "inboxes": [
-      {
-        "scheme": "0225",
-        "code": "698680774"
-      }
-    ]
-  },
-  "customer": {
-    "name": "Example Customer SAS",
-    "tax_id": {
-      "country": "FR",
-      "code": "67698681771"
-    },
-    "identities": [
-      {
-        "type": "SIREN",
-        "code": "698681771"
-      }
-    ],
-    "inboxes": [
-      {
-        "scheme": "0225",
-        "code": "698681771"
-      }
-    ]
-  },
-  "lines": [
-    {
-      "key": "rejected",
-      "date": "2026-06-19",
-      "doc": {
-        "series": "INV",
-        "code": "2026-0042",
-        "issue_date": "2026-06-19",
-        "type": "380"
-      },
-      "ext": {
-        "fr-ctc-flow6-status": "206"
-      },
-      "reasons": [
-        {
-          "key": "quantity",
-          "description": "Quantité facturée supérieure à la quantité livrée",
-          "ext": {
-            "fr-ctc-flow6-reason": "QTE_ERR"
-          },
-          "faults": [
-            {
-              "code": "DIV",
-              "message": "Quantité facturée: 10",
-              "paths": [
-                "/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:IncludedSupplyChainTradeLineItem/ram:SpecifiedLineTradeAgreement/ram:GrossProductTradePrice/ram:BasisQuantity"
-              ]
-            },
-            {
-              "code": "DVA",
-              "message": "Quantité approuvée: 8",
-              "paths": [
-                "/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:IncludedSupplyChainTradeLineItem/ram:SpecifiedLineTradeAgreement/ram:GrossProductTradePrice/ram:BasisQuantity"
-              ]
-            }
-          ]
-        }
-      ],
-      "actions": [
-        {
-          "key": "credit-partial",
-          "description": "Créer un avoir partiel pour les 2 unités non livrées"
-        }
-      ]
-    }
-  ]
+	"$schema": "https://gobl.org/draft-0/bill/status",
+	"$regime": "FR",
+	"$addons": [
+		"fr-ctc-flow6-v1"
+	],
+	"uuid": "0195ce71-dc9c-72c8-bf2c-9890a4a9f0a2",
+	"type": "response",
+	"issue_date": "2026-06-19",
+	"code": "ST-206",
+	"supplier": {
+		"name": "Example Supplier SARL",
+		"tax_id": {
+			"country": "FR",
+			"code": "83698680774"
+		},
+		"identities": [
+			{
+				"type": "SIREN",
+				"code": "698680774",
+				"ext": {
+					"iso-scheme-id": "0002"
+				}
+			}
+		],
+		"endpoints": [
+			{
+				"uri": "iso6523-actorid-upis::0225:698680774"
+			}
+		],
+		"inboxes": [
+			{
+				"key": "peppol",
+				"scheme": "0225",
+				"code": "698680774"
+			}
+		],
+		"ext": {
+			"fr-ctc-flow6-role": "SE"
+		}
+	},
+	"customer": {
+		"name": "Example Customer SAS",
+		"tax_id": {
+			"country": "FR",
+			"code": "67698681771"
+		},
+		"identities": [
+			{
+				"type": "SIREN",
+				"code": "698681771",
+				"ext": {
+					"iso-scheme-id": "0002"
+				}
+			}
+		],
+		"endpoints": [
+			{
+				"uri": "iso6523-actorid-upis::0225:698681771"
+			}
+		],
+		"inboxes": [
+			{
+				"key": "peppol",
+				"scheme": "0225",
+				"code": "698681771"
+			}
+		],
+		"ext": {
+			"fr-ctc-flow6-role": "BY"
+		}
+	},
+	"lines": [
+		{
+			"index": 1,
+			"key": "rejected",
+			"date": "2026-06-19",
+			"doc": {
+				"type": "380",
+				"issue_date": "2026-06-19",
+				"series": "INV",
+				"code": "2026-0042"
+			},
+			"reasons": [
+				{
+					"key": "quantity",
+					"description": "Quantité facturée supérieure à la quantité livrée",
+					"faults": [
+						{
+							"code": "DIV",
+							"message": "Quantité facturée: 10",
+							"paths": [
+								"/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:IncludedSupplyChainTradeLineItem/ram:SpecifiedLineTradeAgreement/ram:GrossProductTradePrice/ram:BasisQuantity"
+							]
+						},
+						{
+							"code": "DVA",
+							"message": "Quantité approuvée: 8",
+							"paths": [
+								"/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:IncludedSupplyChainTradeLineItem/ram:SpecifiedLineTradeAgreement/ram:GrossProductTradePrice/ram:BasisQuantity"
+							]
+						}
+					],
+					"ext": {
+						"fr-ctc-flow6-condition": "DIV",
+						"fr-ctc-flow6-reason": "QTE_ERR"
+					}
+				}
+			],
+			"actions": [
+				{
+					"key": "credit-partial",
+					"description": "Créer un avoir partiel pour les 2 unités non livrées",
+					"ext": {
+						"fr-ctc-flow6-action": "CNP"
+					}
+				}
+			],
+			"ext": {
+				"fr-ctc-flow6-status": "206"
+			}
+		}
+	]
 }
 ```

--- a/snippets/examples/fr/states/206-partially-approved.min.mdx
+++ b/snippets/examples/fr/states/206-partially-approved.min.mdx
@@ -1,0 +1,100 @@
+---
+title: "206 — Approuvée partiellement (Partially approved)"
+description: "GOBL bill/status example for French CTC lifecycle code 206 (Partially approved)"
+---
+
+```json Minimal
+{
+  "$schema": "https://gobl.org/draft-0/bill/status",
+  "$addons": [
+    "fr-ctc-flow6-v1"
+  ],
+  "type": "response",
+  "issue_date": "2026-06-19",
+  "code": "ST-206",
+  "supplier": {
+    "name": "Example Supplier SARL",
+    "tax_id": {
+      "country": "FR",
+      "code": "83698680774"
+    },
+    "identities": [
+      {
+        "type": "SIREN",
+        "code": "698680774"
+      }
+    ],
+    "inboxes": [
+      {
+        "scheme": "0225",
+        "code": "698680774"
+      }
+    ]
+  },
+  "customer": {
+    "name": "Example Customer SAS",
+    "tax_id": {
+      "country": "FR",
+      "code": "67698681771"
+    },
+    "identities": [
+      {
+        "type": "SIREN",
+        "code": "698681771"
+      }
+    ],
+    "inboxes": [
+      {
+        "scheme": "0225",
+        "code": "698681771"
+      }
+    ]
+  },
+  "lines": [
+    {
+      "key": "rejected",
+      "date": "2026-06-19",
+      "doc": {
+        "series": "INV",
+        "code": "2026-0042",
+        "issue_date": "2026-06-19",
+        "type": "380"
+      },
+      "ext": {
+        "fr-ctc-flow6-status": "206"
+      },
+      "reasons": [
+        {
+          "key": "quantity",
+          "description": "Quantité facturée supérieure à la quantité livrée",
+          "ext": {
+            "fr-ctc-flow6-reason": "QTE_ERR"
+          },
+          "faults": [
+            {
+              "code": "DIV",
+              "message": "Quantité facturée: 10",
+              "paths": [
+                "/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:IncludedSupplyChainTradeLineItem/ram:SpecifiedLineTradeAgreement/ram:GrossProductTradePrice/ram:BasisQuantity"
+              ]
+            },
+            {
+              "code": "DVA",
+              "message": "Quantité approuvée: 8",
+              "paths": [
+                "/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:IncludedSupplyChainTradeLineItem/ram:SpecifiedLineTradeAgreement/ram:GrossProductTradePrice/ram:BasisQuantity"
+              ]
+            }
+          ]
+        }
+      ],
+      "actions": [
+        {
+          "key": "credit-partial",
+          "description": "Créer un avoir partiel pour les 2 unités non livrées"
+        }
+      ]
+    }
+  ]
+}
+```

--- a/snippets/examples/fr/states/207-in-dispute.mdx
+++ b/snippets/examples/fr/states/207-in-dispute.mdx
@@ -1,100 +1,126 @@
----
-title: "207 — En litige (In dispute)"
-description: "GOBL bill/status example for French CTC lifecycle code 207 (In dispute)"
----
-
-```json 207 — En litige (In dispute)
+```json Built version
 {
-  "$schema": "https://gobl.org/draft-0/bill/status",
-  "$addons": [
-    "fr-ctc-flow6-v1"
-  ],
-  "type": "response",
-  "issue_date": "2026-06-19",
-  "code": "ST-207",
-  "supplier": {
-    "name": "Example Supplier SARL",
-    "tax_id": {
-      "country": "FR",
-      "code": "83698680774"
-    },
-    "identities": [
-      {
-        "type": "SIREN",
-        "code": "698680774"
-      }
-    ],
-    "inboxes": [
-      {
-        "scheme": "0225",
-        "code": "698680774"
-      }
-    ]
-  },
-  "customer": {
-    "name": "Example Customer SAS",
-    "tax_id": {
-      "country": "FR",
-      "code": "67698681771"
-    },
-    "identities": [
-      {
-        "type": "SIREN",
-        "code": "698681771"
-      }
-    ],
-    "inboxes": [
-      {
-        "scheme": "0225",
-        "code": "698681771"
-      }
-    ]
-  },
-  "lines": [
-    {
-      "key": "rejected",
-      "date": "2026-06-19",
-      "doc": {
-        "series": "INV",
-        "code": "2026-0042",
-        "issue_date": "2026-06-19",
-        "type": "380"
-      },
-      "ext": {
-        "fr-ctc-flow6-status": "207"
-      },
-      "reasons": [
-        {
-          "key": "legal",
-          "description": "Taux de TVA erroné",
-          "ext": {
-            "fr-ctc-flow6-reason": "TX_TVA_ERR"
-          },
-          "faults": [
-            {
-              "code": "DIV",
-              "message": "Taux TVA (BT-152): 10.00%",
-              "paths": [
-                "/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:IncludedSupplyChainTradeLineItem/ram:SpecifiedLineTradeSettlement/ram:ApplicableTradeTax/ram:RateApplicablePercent"
-              ]
-            },
-            {
-              "code": "DVA",
-              "message": "Taux TVA (BT-152): 20.00%",
-              "paths": [
-                "/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:IncludedSupplyChainTradeLineItem/ram:SpecifiedLineTradeSettlement/ram:ApplicableTradeTax/ram:RateApplicablePercent"
-              ]
-            }
-          ]
-        }
-      ],
-      "actions": [
-        {
-          "key": "credit-full",
-          "description": "Créer un avoir total puis réémettre"
-        }
-      ]
-    }
-  ]
+	"$schema": "https://gobl.org/draft-0/bill/status",
+	"$regime": "FR",
+	"$addons": [
+		"fr-ctc-flow6-v1"
+	],
+	"uuid": "0195ce71-dc9c-72c8-bf2c-9890a4a9f0a2",
+	"type": "response",
+	"issue_date": "2026-06-19",
+	"code": "ST-207",
+	"supplier": {
+		"name": "Example Supplier SARL",
+		"tax_id": {
+			"country": "FR",
+			"code": "83698680774"
+		},
+		"identities": [
+			{
+				"type": "SIREN",
+				"code": "698680774",
+				"ext": {
+					"iso-scheme-id": "0002"
+				}
+			}
+		],
+		"endpoints": [
+			{
+				"uri": "iso6523-actorid-upis::0225:698680774"
+			}
+		],
+		"inboxes": [
+			{
+				"key": "peppol",
+				"scheme": "0225",
+				"code": "698680774"
+			}
+		],
+		"ext": {
+			"fr-ctc-flow6-role": "SE"
+		}
+	},
+	"customer": {
+		"name": "Example Customer SAS",
+		"tax_id": {
+			"country": "FR",
+			"code": "67698681771"
+		},
+		"identities": [
+			{
+				"type": "SIREN",
+				"code": "698681771",
+				"ext": {
+					"iso-scheme-id": "0002"
+				}
+			}
+		],
+		"endpoints": [
+			{
+				"uri": "iso6523-actorid-upis::0225:698681771"
+			}
+		],
+		"inboxes": [
+			{
+				"key": "peppol",
+				"scheme": "0225",
+				"code": "698681771"
+			}
+		],
+		"ext": {
+			"fr-ctc-flow6-role": "BY"
+		}
+	},
+	"lines": [
+		{
+			"index": 1,
+			"key": "rejected",
+			"date": "2026-06-19",
+			"doc": {
+				"type": "380",
+				"issue_date": "2026-06-19",
+				"series": "INV",
+				"code": "2026-0042"
+			},
+			"reasons": [
+				{
+					"key": "legal",
+					"description": "Taux de TVA erroné",
+					"faults": [
+						{
+							"code": "DIV",
+							"message": "Taux TVA (BT-152): 10.00%",
+							"paths": [
+								"/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:IncludedSupplyChainTradeLineItem/ram:SpecifiedLineTradeSettlement/ram:ApplicableTradeTax/ram:RateApplicablePercent"
+							]
+						},
+						{
+							"code": "DVA",
+							"message": "Taux TVA (BT-152): 20.00%",
+							"paths": [
+								"/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:IncludedSupplyChainTradeLineItem/ram:SpecifiedLineTradeSettlement/ram:ApplicableTradeTax/ram:RateApplicablePercent"
+							]
+						}
+					],
+					"ext": {
+						"fr-ctc-flow6-condition": "DIV",
+						"fr-ctc-flow6-reason": "TX_TVA_ERR"
+					}
+				}
+			],
+			"actions": [
+				{
+					"key": "credit-full",
+					"description": "Créer un avoir total puis réémettre",
+					"ext": {
+						"fr-ctc-flow6-action": "CNF"
+					}
+				}
+			],
+			"ext": {
+				"fr-ctc-flow6-status": "207"
+			}
+		}
+	]
 }
 ```

--- a/snippets/examples/fr/states/207-in-dispute.min.mdx
+++ b/snippets/examples/fr/states/207-in-dispute.min.mdx
@@ -1,0 +1,100 @@
+---
+title: "207 — En litige (In dispute)"
+description: "GOBL bill/status example for French CTC lifecycle code 207 (In dispute)"
+---
+
+```json Minimal
+{
+  "$schema": "https://gobl.org/draft-0/bill/status",
+  "$addons": [
+    "fr-ctc-flow6-v1"
+  ],
+  "type": "response",
+  "issue_date": "2026-06-19",
+  "code": "ST-207",
+  "supplier": {
+    "name": "Example Supplier SARL",
+    "tax_id": {
+      "country": "FR",
+      "code": "83698680774"
+    },
+    "identities": [
+      {
+        "type": "SIREN",
+        "code": "698680774"
+      }
+    ],
+    "inboxes": [
+      {
+        "scheme": "0225",
+        "code": "698680774"
+      }
+    ]
+  },
+  "customer": {
+    "name": "Example Customer SAS",
+    "tax_id": {
+      "country": "FR",
+      "code": "67698681771"
+    },
+    "identities": [
+      {
+        "type": "SIREN",
+        "code": "698681771"
+      }
+    ],
+    "inboxes": [
+      {
+        "scheme": "0225",
+        "code": "698681771"
+      }
+    ]
+  },
+  "lines": [
+    {
+      "key": "rejected",
+      "date": "2026-06-19",
+      "doc": {
+        "series": "INV",
+        "code": "2026-0042",
+        "issue_date": "2026-06-19",
+        "type": "380"
+      },
+      "ext": {
+        "fr-ctc-flow6-status": "207"
+      },
+      "reasons": [
+        {
+          "key": "legal",
+          "description": "Taux de TVA erroné",
+          "ext": {
+            "fr-ctc-flow6-reason": "TX_TVA_ERR"
+          },
+          "faults": [
+            {
+              "code": "DIV",
+              "message": "Taux TVA (BT-152): 10.00%",
+              "paths": [
+                "/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:IncludedSupplyChainTradeLineItem/ram:SpecifiedLineTradeSettlement/ram:ApplicableTradeTax/ram:RateApplicablePercent"
+              ]
+            },
+            {
+              "code": "DVA",
+              "message": "Taux TVA (BT-152): 20.00%",
+              "paths": [
+                "/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:IncludedSupplyChainTradeLineItem/ram:SpecifiedLineTradeSettlement/ram:ApplicableTradeTax/ram:RateApplicablePercent"
+              ]
+            }
+          ]
+        }
+      ],
+      "actions": [
+        {
+          "key": "credit-full",
+          "description": "Créer un avoir total puis réémettre"
+        }
+      ]
+    }
+  ]
+}
+```

--- a/snippets/examples/fr/states/208-suspended.mdx
+++ b/snippets/examples/fr/states/208-suspended.mdx
@@ -1,81 +1,110 @@
----
-title: "208 — Suspendue (Suspended)"
-description: "GOBL bill/status example for French CTC lifecycle code 208 (Suspended)"
----
-
-```json 208 — Suspendue (Suspended)
+```json Built version
 {
-  "$schema": "https://gobl.org/draft-0/bill/status",
-  "$addons": [
-    "fr-ctc-flow6-v1"
-  ],
-  "type": "response",
-  "issue_date": "2026-06-19",
-  "code": "ST-208",
-  "supplier": {
-    "name": "Example Supplier SARL",
-    "tax_id": {
-      "country": "FR",
-      "code": "83698680774"
-    },
-    "identities": [
-      {
-        "type": "SIREN",
-        "code": "698680774"
-      }
-    ],
-    "inboxes": [
-      {
-        "scheme": "0225",
-        "code": "698680774"
-      }
-    ]
-  },
-  "customer": {
-    "name": "Example Customer SAS",
-    "tax_id": {
-      "country": "FR",
-      "code": "67698681771"
-    },
-    "identities": [
-      {
-        "type": "SIREN",
-        "code": "698681771"
-      }
-    ],
-    "inboxes": [
-      {
-        "scheme": "0225",
-        "code": "698681771"
-      }
-    ]
-  },
-  "lines": [
-    {
-      "key": "querying",
-      "date": "2026-06-19",
-      "doc": {
-        "series": "INV",
-        "code": "2026-0042",
-        "issue_date": "2026-06-19",
-        "type": "380"
-      },
-      "reasons": [
-        {
-          "key": "references",
-          "description": "Référence de commande manquante",
-          "ext": {
-            "fr-ctc-flow6-reason": "CMD_ERR"
-          }
-        }
-      ],
-      "actions": [
-        {
-          "key": "provide",
-          "description": "Fournir le numéro de commande"
-        }
-      ]
-    }
-  ]
+	"$schema": "https://gobl.org/draft-0/bill/status",
+	"$regime": "FR",
+	"$addons": [
+		"fr-ctc-flow6-v1"
+	],
+	"uuid": "0195ce71-dc9c-72c8-bf2c-9890a4a9f0a2",
+	"type": "response",
+	"issue_date": "2026-06-19",
+	"code": "ST-208",
+	"supplier": {
+		"name": "Example Supplier SARL",
+		"tax_id": {
+			"country": "FR",
+			"code": "83698680774"
+		},
+		"identities": [
+			{
+				"type": "SIREN",
+				"code": "698680774",
+				"ext": {
+					"iso-scheme-id": "0002"
+				}
+			}
+		],
+		"endpoints": [
+			{
+				"uri": "iso6523-actorid-upis::0225:698680774"
+			}
+		],
+		"inboxes": [
+			{
+				"key": "peppol",
+				"scheme": "0225",
+				"code": "698680774"
+			}
+		],
+		"ext": {
+			"fr-ctc-flow6-role": "SE"
+		}
+	},
+	"customer": {
+		"name": "Example Customer SAS",
+		"tax_id": {
+			"country": "FR",
+			"code": "67698681771"
+		},
+		"identities": [
+			{
+				"type": "SIREN",
+				"code": "698681771",
+				"ext": {
+					"iso-scheme-id": "0002"
+				}
+			}
+		],
+		"endpoints": [
+			{
+				"uri": "iso6523-actorid-upis::0225:698681771"
+			}
+		],
+		"inboxes": [
+			{
+				"key": "peppol",
+				"scheme": "0225",
+				"code": "698681771"
+			}
+		],
+		"ext": {
+			"fr-ctc-flow6-role": "BY"
+		}
+	},
+	"lines": [
+		{
+			"index": 1,
+			"key": "querying",
+			"date": "2026-06-19",
+			"doc": {
+				"type": "380",
+				"issue_date": "2026-06-19",
+				"series": "INV",
+				"code": "2026-0042"
+			},
+			"reasons": [
+				{
+					"key": "references",
+					"description": "Référence de commande manquante",
+					"ext": {
+						"fr-ctc-flow6-condition": "DIV",
+						"fr-ctc-flow6-reason": "CMD_ERR"
+					}
+				}
+			],
+			"actions": [
+				{
+					"key": "provide",
+					"description": "Fournir le numéro de commande",
+					"ext": {
+						"fr-ctc-flow6-action": "PIN"
+					}
+				}
+			],
+			"ext": {
+				"fr-ctc-flow6-status": "208"
+			}
+		}
+	]
 }
 ```

--- a/snippets/examples/fr/states/208-suspended.min.mdx
+++ b/snippets/examples/fr/states/208-suspended.min.mdx
@@ -1,0 +1,81 @@
+---
+title: "208 — Suspendue (Suspended)"
+description: "GOBL bill/status example for French CTC lifecycle code 208 (Suspended)"
+---
+
+```json Minimal
+{
+  "$schema": "https://gobl.org/draft-0/bill/status",
+  "$addons": [
+    "fr-ctc-flow6-v1"
+  ],
+  "type": "response",
+  "issue_date": "2026-06-19",
+  "code": "ST-208",
+  "supplier": {
+    "name": "Example Supplier SARL",
+    "tax_id": {
+      "country": "FR",
+      "code": "83698680774"
+    },
+    "identities": [
+      {
+        "type": "SIREN",
+        "code": "698680774"
+      }
+    ],
+    "inboxes": [
+      {
+        "scheme": "0225",
+        "code": "698680774"
+      }
+    ]
+  },
+  "customer": {
+    "name": "Example Customer SAS",
+    "tax_id": {
+      "country": "FR",
+      "code": "67698681771"
+    },
+    "identities": [
+      {
+        "type": "SIREN",
+        "code": "698681771"
+      }
+    ],
+    "inboxes": [
+      {
+        "scheme": "0225",
+        "code": "698681771"
+      }
+    ]
+  },
+  "lines": [
+    {
+      "key": "querying",
+      "date": "2026-06-19",
+      "doc": {
+        "series": "INV",
+        "code": "2026-0042",
+        "issue_date": "2026-06-19",
+        "type": "380"
+      },
+      "reasons": [
+        {
+          "key": "references",
+          "description": "Référence de commande manquante",
+          "ext": {
+            "fr-ctc-flow6-reason": "CMD_ERR"
+          }
+        }
+      ],
+      "actions": [
+        {
+          "key": "provide",
+          "description": "Fournir le numéro de commande"
+        }
+      ]
+    }
+  ]
+}
+```

--- a/snippets/examples/fr/states/209-completed.mdx
+++ b/snippets/examples/fr/states/209-completed.mdx
@@ -1,85 +1,111 @@
----
-title: "209 — Complétée (Completed)"
-description: "GOBL bill/status example for French CTC lifecycle code 209 (Completed)"
----
-
-```json 209 — Complétée (Completed)
+```json Built version
 {
-  "$schema": "https://gobl.org/draft-0/bill/status",
-  "$addons": [
-    "fr-ctc-flow6-v1"
-  ],
-  "type": "update",
-  "issue_date": "2026-06-19",
-  "code": "ST-209",
-  "supplier": {
-    "name": "Example Supplier SARL",
-    "tax_id": {
-      "country": "FR",
-      "code": "83698680774"
-    },
-    "identities": [
-      {
-        "type": "SIREN",
-        "code": "698680774"
-      }
-    ],
-    "inboxes": [
-      {
-        "scheme": "0225",
-        "code": "698680774"
-      }
-    ]
-  },
-  "customer": {
-    "name": "Example Customer SAS",
-    "tax_id": {
-      "country": "FR",
-      "code": "67698681771"
-    },
-    "identities": [
-      {
-        "type": "SIREN",
-        "code": "698681771"
-      }
-    ],
-    "inboxes": [
-      {
-        "scheme": "0225",
-        "code": "698681771"
-      }
-    ]
-  },
-  "lines": [
-    {
-      "key": "other",
-      "date": "2026-06-19",
-      "doc": {
-        "series": "INV",
-        "code": "2026-0042",
-        "issue_date": "2026-06-19",
-        "type": "380"
-      },
-      "description": "Coordonnées bancaires du bénéficiaire fournies",
-      "reasons": [
-        {
-          "key": "finance-terms",
-          "description": "Nouvel IBAN du bénéficiaire",
-          "ext": {
-            "fr-ctc-flow6-reason": "COORD_BANC_ERR"
-          },
-          "faults": [
-            {
-              "code": "MAJ",
-              "message": "IBAN (BT-84): FR7630006000011234567890189",
-              "paths": [
-                "/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeSettlement/ram:SpecifiedTradeSettlementPaymentMeans/ram:PayeePartyCreditorFinancialAccount/ram:IBANID"
-              ]
-            }
-          ]
-        }
-      ]
-    }
-  ]
+	"$schema": "https://gobl.org/draft-0/bill/status",
+	"$regime": "FR",
+	"$addons": [
+		"fr-ctc-flow6-v1"
+	],
+	"uuid": "0195ce71-dc9c-72c8-bf2c-9890a4a9f0a2",
+	"type": "update",
+	"issue_date": "2026-06-19",
+	"code": "ST-209",
+	"supplier": {
+		"name": "Example Supplier SARL",
+		"tax_id": {
+			"country": "FR",
+			"code": "83698680774"
+		},
+		"identities": [
+			{
+				"type": "SIREN",
+				"code": "698680774",
+				"ext": {
+					"iso-scheme-id": "0002"
+				}
+			}
+		],
+		"endpoints": [
+			{
+				"uri": "iso6523-actorid-upis::0225:698680774"
+			}
+		],
+		"inboxes": [
+			{
+				"key": "peppol",
+				"scheme": "0225",
+				"code": "698680774"
+			}
+		],
+		"ext": {
+			"fr-ctc-flow6-role": "SE"
+		}
+	},
+	"customer": {
+		"name": "Example Customer SAS",
+		"tax_id": {
+			"country": "FR",
+			"code": "67698681771"
+		},
+		"identities": [
+			{
+				"type": "SIREN",
+				"code": "698681771",
+				"ext": {
+					"iso-scheme-id": "0002"
+				}
+			}
+		],
+		"endpoints": [
+			{
+				"uri": "iso6523-actorid-upis::0225:698681771"
+			}
+		],
+		"inboxes": [
+			{
+				"key": "peppol",
+				"scheme": "0225",
+				"code": "698681771"
+			}
+		],
+		"ext": {
+			"fr-ctc-flow6-role": "BY"
+		}
+	},
+	"lines": [
+		{
+			"index": 1,
+			"key": "other",
+			"date": "2026-06-19",
+			"doc": {
+				"type": "380",
+				"issue_date": "2026-06-19",
+				"series": "INV",
+				"code": "2026-0042"
+			},
+			"description": "Coordonnées bancaires du bénéficiaire fournies",
+			"reasons": [
+				{
+					"key": "finance-terms",
+					"description": "Nouvel IBAN du bénéficiaire",
+					"faults": [
+						{
+							"code": "MAJ",
+							"message": "IBAN (BT-84): FR7630006000011234567890189",
+							"paths": [
+								"/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeSettlement/ram:SpecifiedTradeSettlementPaymentMeans/ram:PayeePartyCreditorFinancialAccount/ram:IBANID"
+							]
+						}
+					],
+					"ext": {
+						"fr-ctc-flow6-condition": "CBB",
+						"fr-ctc-flow6-reason": "COORD_BANC_ERR"
+					}
+				}
+			],
+			"ext": {
+				"fr-ctc-flow6-status": "209"
+			}
+		}
+	]
 }
 ```

--- a/snippets/examples/fr/states/209-completed.min.mdx
+++ b/snippets/examples/fr/states/209-completed.min.mdx
@@ -1,0 +1,85 @@
+---
+title: "209 — Complétée (Completed)"
+description: "GOBL bill/status example for French CTC lifecycle code 209 (Completed)"
+---
+
+```json Minimal
+{
+  "$schema": "https://gobl.org/draft-0/bill/status",
+  "$addons": [
+    "fr-ctc-flow6-v1"
+  ],
+  "type": "update",
+  "issue_date": "2026-06-19",
+  "code": "ST-209",
+  "supplier": {
+    "name": "Example Supplier SARL",
+    "tax_id": {
+      "country": "FR",
+      "code": "83698680774"
+    },
+    "identities": [
+      {
+        "type": "SIREN",
+        "code": "698680774"
+      }
+    ],
+    "inboxes": [
+      {
+        "scheme": "0225",
+        "code": "698680774"
+      }
+    ]
+  },
+  "customer": {
+    "name": "Example Customer SAS",
+    "tax_id": {
+      "country": "FR",
+      "code": "67698681771"
+    },
+    "identities": [
+      {
+        "type": "SIREN",
+        "code": "698681771"
+      }
+    ],
+    "inboxes": [
+      {
+        "scheme": "0225",
+        "code": "698681771"
+      }
+    ]
+  },
+  "lines": [
+    {
+      "key": "other",
+      "date": "2026-06-19",
+      "doc": {
+        "series": "INV",
+        "code": "2026-0042",
+        "issue_date": "2026-06-19",
+        "type": "380"
+      },
+      "description": "Coordonnées bancaires du bénéficiaire fournies",
+      "reasons": [
+        {
+          "key": "finance-terms",
+          "description": "Nouvel IBAN du bénéficiaire",
+          "ext": {
+            "fr-ctc-flow6-reason": "COORD_BANC_ERR"
+          },
+          "faults": [
+            {
+              "code": "MAJ",
+              "message": "IBAN (BT-84): FR7630006000011234567890189",
+              "paths": [
+                "/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeSettlement/ram:SpecifiedTradeSettlementPaymentMeans/ram:PayeePartyCreditorFinancialAccount/ram:IBANID"
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}
+```

--- a/snippets/examples/fr/states/210-refused.mdx
+++ b/snippets/examples/fr/states/210-refused.mdx
@@ -1,97 +1,126 @@
----
-title: "210 — Refusée (Rejected)"
-description: "GOBL bill/status example for French CTC lifecycle code 210 (Rejected)"
----
-
-```json 210 — Refusée (Rejected)
+```json Built version
 {
-  "$schema": "https://gobl.org/draft-0/bill/status",
-  "$addons": [
-    "fr-ctc-flow6-v1"
-  ],
-  "type": "response",
-  "issue_date": "2026-06-19",
-  "code": "ST-210",
-  "supplier": {
-    "name": "Example Supplier SARL",
-    "tax_id": {
-      "country": "FR",
-      "code": "83698680774"
-    },
-    "identities": [
-      {
-        "type": "SIREN",
-        "code": "698680774"
-      }
-    ],
-    "inboxes": [
-      {
-        "scheme": "0225",
-        "code": "698680774"
-      }
-    ]
-  },
-  "customer": {
-    "name": "Example Customer SAS",
-    "tax_id": {
-      "country": "FR",
-      "code": "67698681771"
-    },
-    "identities": [
-      {
-        "type": "SIREN",
-        "code": "698681771"
-      }
-    ],
-    "inboxes": [
-      {
-        "scheme": "0225",
-        "code": "698681771"
-      }
-    ]
-  },
-  "lines": [
-    {
-      "key": "rejected",
-      "date": "2026-06-19",
-      "doc": {
-        "series": "INV",
-        "code": "2026-0042",
-        "issue_date": "2026-06-19",
-        "type": "380"
-      },
-      "reasons": [
-        {
-          "key": "legal",
-          "description": "Taux de TVA erroné",
-          "ext": {
-            "fr-ctc-flow6-reason": "TX_TVA_ERR"
-          },
-          "faults": [
-            {
-              "code": "DIV",
-              "message": "Taux TVA (BT-152): 10.00%",
-              "paths": [
-                "/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:IncludedSupplyChainTradeLineItem/ram:SpecifiedLineTradeSettlement/ram:ApplicableTradeTax/ram:RateApplicablePercent"
-              ]
-            },
-            {
-              "code": "DVA",
-              "message": "Taux TVA (BT-152): 20.00%",
-              "paths": [
-                "/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:IncludedSupplyChainTradeLineItem/ram:SpecifiedLineTradeSettlement/ram:ApplicableTradeTax/ram:RateApplicablePercent"
-              ]
-            }
-          ]
-        }
-      ],
-      "actions": [
-        {
-          "key": "reissue",
-          "description": "Réémettre la facture avec le taux de TVA corrigé"
-        }
-      ]
-    }
-  ]
+	"$schema": "https://gobl.org/draft-0/bill/status",
+	"$regime": "FR",
+	"$addons": [
+		"fr-ctc-flow6-v1"
+	],
+	"uuid": "0195ce71-dc9c-72c8-bf2c-9890a4a9f0a2",
+	"type": "response",
+	"issue_date": "2026-06-19",
+	"code": "ST-210",
+	"supplier": {
+		"name": "Example Supplier SARL",
+		"tax_id": {
+			"country": "FR",
+			"code": "83698680774"
+		},
+		"identities": [
+			{
+				"type": "SIREN",
+				"code": "698680774",
+				"ext": {
+					"iso-scheme-id": "0002"
+				}
+			}
+		],
+		"endpoints": [
+			{
+				"uri": "iso6523-actorid-upis::0225:698680774"
+			}
+		],
+		"inboxes": [
+			{
+				"key": "peppol",
+				"scheme": "0225",
+				"code": "698680774"
+			}
+		],
+		"ext": {
+			"fr-ctc-flow6-role": "SE"
+		}
+	},
+	"customer": {
+		"name": "Example Customer SAS",
+		"tax_id": {
+			"country": "FR",
+			"code": "67698681771"
+		},
+		"identities": [
+			{
+				"type": "SIREN",
+				"code": "698681771",
+				"ext": {
+					"iso-scheme-id": "0002"
+				}
+			}
+		],
+		"endpoints": [
+			{
+				"uri": "iso6523-actorid-upis::0225:698681771"
+			}
+		],
+		"inboxes": [
+			{
+				"key": "peppol",
+				"scheme": "0225",
+				"code": "698681771"
+			}
+		],
+		"ext": {
+			"fr-ctc-flow6-role": "BY"
+		}
+	},
+	"lines": [
+		{
+			"index": 1,
+			"key": "rejected",
+			"date": "2026-06-19",
+			"doc": {
+				"type": "380",
+				"issue_date": "2026-06-19",
+				"series": "INV",
+				"code": "2026-0042"
+			},
+			"reasons": [
+				{
+					"key": "legal",
+					"description": "Taux de TVA erroné",
+					"faults": [
+						{
+							"code": "DIV",
+							"message": "Taux TVA (BT-152): 10.00%",
+							"paths": [
+								"/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:IncludedSupplyChainTradeLineItem/ram:SpecifiedLineTradeSettlement/ram:ApplicableTradeTax/ram:RateApplicablePercent"
+							]
+						},
+						{
+							"code": "DVA",
+							"message": "Taux TVA (BT-152): 20.00%",
+							"paths": [
+								"/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:IncludedSupplyChainTradeLineItem/ram:SpecifiedLineTradeSettlement/ram:ApplicableTradeTax/ram:RateApplicablePercent"
+							]
+						}
+					],
+					"ext": {
+						"fr-ctc-flow6-condition": "DIV",
+						"fr-ctc-flow6-reason": "TX_TVA_ERR"
+					}
+				}
+			],
+			"actions": [
+				{
+					"key": "reissue",
+					"description": "Réémettre la facture avec le taux de TVA corrigé",
+					"ext": {
+						"fr-ctc-flow6-action": "NIN"
+					}
+				}
+			],
+			"ext": {
+				"fr-ctc-flow6-status": "210"
+			}
+		}
+	]
 }
 ```

--- a/snippets/examples/fr/states/210-refused.min.mdx
+++ b/snippets/examples/fr/states/210-refused.min.mdx
@@ -1,0 +1,97 @@
+---
+title: "210 — Refusée (Rejected)"
+description: "GOBL bill/status example for French CTC lifecycle code 210 (Rejected)"
+---
+
+```json Minimal
+{
+  "$schema": "https://gobl.org/draft-0/bill/status",
+  "$addons": [
+    "fr-ctc-flow6-v1"
+  ],
+  "type": "response",
+  "issue_date": "2026-06-19",
+  "code": "ST-210",
+  "supplier": {
+    "name": "Example Supplier SARL",
+    "tax_id": {
+      "country": "FR",
+      "code": "83698680774"
+    },
+    "identities": [
+      {
+        "type": "SIREN",
+        "code": "698680774"
+      }
+    ],
+    "inboxes": [
+      {
+        "scheme": "0225",
+        "code": "698680774"
+      }
+    ]
+  },
+  "customer": {
+    "name": "Example Customer SAS",
+    "tax_id": {
+      "country": "FR",
+      "code": "67698681771"
+    },
+    "identities": [
+      {
+        "type": "SIREN",
+        "code": "698681771"
+      }
+    ],
+    "inboxes": [
+      {
+        "scheme": "0225",
+        "code": "698681771"
+      }
+    ]
+  },
+  "lines": [
+    {
+      "key": "rejected",
+      "date": "2026-06-19",
+      "doc": {
+        "series": "INV",
+        "code": "2026-0042",
+        "issue_date": "2026-06-19",
+        "type": "380"
+      },
+      "reasons": [
+        {
+          "key": "legal",
+          "description": "Taux de TVA erroné",
+          "ext": {
+            "fr-ctc-flow6-reason": "TX_TVA_ERR"
+          },
+          "faults": [
+            {
+              "code": "DIV",
+              "message": "Taux TVA (BT-152): 10.00%",
+              "paths": [
+                "/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:IncludedSupplyChainTradeLineItem/ram:SpecifiedLineTradeSettlement/ram:ApplicableTradeTax/ram:RateApplicablePercent"
+              ]
+            },
+            {
+              "code": "DVA",
+              "message": "Taux TVA (BT-152): 20.00%",
+              "paths": [
+                "/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:IncludedSupplyChainTradeLineItem/ram:SpecifiedLineTradeSettlement/ram:ApplicableTradeTax/ram:RateApplicablePercent"
+              ]
+            }
+          ]
+        }
+      ],
+      "actions": [
+        {
+          "key": "reissue",
+          "description": "Réémettre la facture avec le taux de TVA corrigé"
+        }
+      ]
+    }
+  ]
+}
+```

--- a/snippets/examples/fr/states/211-payment-advice.mdx
+++ b/snippets/examples/fr/states/211-payment-advice.mdx
@@ -1,88 +1,117 @@
----
-title: "211 — Paiement transmis (Payment advice)"
-description: "GOBL bill/payment example for French CTC lifecycle code 211 (Payment advice)"
----
-
-```json 211 — Paiement transmis (Payment advice)
+```json Built version
 {
-  "$schema": "https://gobl.org/draft-0/bill/payment",
-  "$addons": [
-    "fr-ctc-flow6-v1"
-  ],
-  "type": "advice",
-  "issue_date": "2026-06-19",
-  "value_date": "2026-06-19",
-  "series": "PAY",
-  "code": "2026-0042-A",
-  "currency": "EUR",
-  "supplier": {
-    "name": "Example Supplier SARL",
-    "tax_id": {
-      "country": "FR",
-      "code": "83698680774"
-    },
-    "identities": [
-      {
-        "type": "SIREN",
-        "code": "698680774"
-      }
-    ],
-    "inboxes": [
-      {
-        "scheme": "0225",
-        "code": "698680774"
-      }
-    ]
-  },
-  "customer": {
-    "name": "Example Customer SAS",
-    "tax_id": {
-      "country": "FR",
-      "code": "67698681771"
-    },
-    "identities": [
-      {
-        "type": "SIREN",
-        "code": "698681771"
-      }
-    ],
-    "inboxes": [
-      {
-        "scheme": "0225",
-        "code": "698681771"
-      }
-    ]
-  },
-  "methods": [
-    {
-      "key": "credit-transfer",
-      "amount": "120.00"
-    }
-  ],
-  "lines": [
-    {
-      "amount": "120.00",
-      "document": {
-        "series": "INV",
-        "code": "2026-0042",
-        "issue_date": "2026-06-19",
-        "type": "380"
-      },
-      "tax": {
-        "categories": [
-          {
-            "code": "VAT",
-            "rates": [
-              {
-                "base": "100.00",
-                "percent": "20.0%",
-                "amount": "20.00"
-              }
-            ]
-          }
-        ]
-      }
-    }
-  ]
+	"$schema": "https://gobl.org/draft-0/bill/payment",
+	"$regime": "FR",
+	"$addons": [
+		"fr-ctc-flow6-v1"
+	],
+	"uuid": "0195ce71-dc9c-72c8-bf2c-9890a4a9f0a2",
+	"type": "advice",
+	"series": "PAY",
+	"code": "2026-0042-A",
+	"issue_date": "2026-06-19",
+	"value_date": "2026-06-19",
+	"currency": "EUR",
+	"ext": {
+		"fr-ctc-flow6-condition": "MPA",
+		"fr-ctc-flow6-status": "211"
+	},
+	"supplier": {
+		"name": "Example Supplier SARL",
+		"tax_id": {
+			"country": "FR",
+			"code": "83698680774"
+		},
+		"identities": [
+			{
+				"type": "SIREN",
+				"code": "698680774",
+				"ext": {
+					"iso-scheme-id": "0002"
+				}
+			}
+		],
+		"endpoints": [
+			{
+				"uri": "iso6523-actorid-upis::0225:698680774"
+			}
+		],
+		"inboxes": [
+			{
+				"key": "peppol",
+				"scheme": "0225",
+				"code": "698680774"
+			}
+		],
+		"ext": {
+			"fr-ctc-flow6-role": "BY"
+		}
+	},
+	"customer": {
+		"name": "Example Customer SAS",
+		"tax_id": {
+			"country": "FR",
+			"code": "67698681771"
+		},
+		"identities": [
+			{
+				"type": "SIREN",
+				"code": "698681771",
+				"ext": {
+					"iso-scheme-id": "0002"
+				}
+			}
+		],
+		"endpoints": [
+			{
+				"uri": "iso6523-actorid-upis::0225:698681771"
+			}
+		],
+		"inboxes": [
+			{
+				"key": "peppol",
+				"scheme": "0225",
+				"code": "698681771"
+			}
+		],
+		"ext": {
+			"fr-ctc-flow6-role": "SE"
+		}
+	},
+	"lines": [
+		{
+			"i": 1,
+			"document": {
+				"type": "380",
+				"issue_date": "2026-06-19",
+				"series": "INV",
+				"code": "2026-0042"
+			},
+			"amount": "120.00",
+			"tax": {
+				"categories": [
+					{
+						"code": "VAT",
+						"rates": [
+							{
+								"base": "100.00",
+								"percent": "20.0%",
+								"amount": "20.00"
+							}
+						],
+						"amount": "20.00"
+					}
+				],
+				"sum": "20.00"
+			}
+		}
+	],
+	"methods": [
+		{
+			"key": "credit-transfer",
+			"amount": "120.00"
+		}
+	],
+	"total": "120.00"
 }
 ```

--- a/snippets/examples/fr/states/211-payment-advice.min.mdx
+++ b/snippets/examples/fr/states/211-payment-advice.min.mdx
@@ -1,0 +1,88 @@
+---
+title: "211 — Paiement transmis (Payment advice)"
+description: "GOBL bill/payment example for French CTC lifecycle code 211 (Payment advice)"
+---
+
+```json Minimal
+{
+  "$schema": "https://gobl.org/draft-0/bill/payment",
+  "$addons": [
+    "fr-ctc-flow6-v1"
+  ],
+  "type": "advice",
+  "issue_date": "2026-06-19",
+  "value_date": "2026-06-19",
+  "series": "PAY",
+  "code": "2026-0042-A",
+  "currency": "EUR",
+  "supplier": {
+    "name": "Example Supplier SARL",
+    "tax_id": {
+      "country": "FR",
+      "code": "83698680774"
+    },
+    "identities": [
+      {
+        "type": "SIREN",
+        "code": "698680774"
+      }
+    ],
+    "inboxes": [
+      {
+        "scheme": "0225",
+        "code": "698680774"
+      }
+    ]
+  },
+  "customer": {
+    "name": "Example Customer SAS",
+    "tax_id": {
+      "country": "FR",
+      "code": "67698681771"
+    },
+    "identities": [
+      {
+        "type": "SIREN",
+        "code": "698681771"
+      }
+    ],
+    "inboxes": [
+      {
+        "scheme": "0225",
+        "code": "698681771"
+      }
+    ]
+  },
+  "methods": [
+    {
+      "key": "credit-transfer",
+      "amount": "120.00"
+    }
+  ],
+  "lines": [
+    {
+      "amount": "120.00",
+      "document": {
+        "series": "INV",
+        "code": "2026-0042",
+        "issue_date": "2026-06-19",
+        "type": "380"
+      },
+      "tax": {
+        "categories": [
+          {
+            "code": "VAT",
+            "rates": [
+              {
+                "base": "100.00",
+                "percent": "20.0%",
+                "amount": "20.00"
+              }
+            ]
+          }
+        ]
+      }
+    }
+  ]
+}
+```

--- a/snippets/examples/fr/states/212-payment-receipt.mdx
+++ b/snippets/examples/fr/states/212-payment-receipt.mdx
@@ -1,88 +1,117 @@
----
-title: "212 — Encaissée (Payment receipt)"
-description: "GOBL bill/payment example for French CTC lifecycle code 212 (Payment receipt)"
----
-
-```json 212 — Encaissée (Payment receipt)
+```json Built version
 {
-  "$schema": "https://gobl.org/draft-0/bill/payment",
-  "$addons": [
-    "fr-ctc-flow6-v1"
-  ],
-  "type": "receipt",
-  "issue_date": "2026-06-19",
-  "value_date": "2026-06-19",
-  "series": "PAY",
-  "code": "2026-0042-R",
-  "currency": "EUR",
-  "supplier": {
-    "name": "Example Supplier SARL",
-    "tax_id": {
-      "country": "FR",
-      "code": "83698680774"
-    },
-    "identities": [
-      {
-        "type": "SIREN",
-        "code": "698680774"
-      }
-    ],
-    "inboxes": [
-      {
-        "scheme": "0225",
-        "code": "698680774"
-      }
-    ]
-  },
-  "customer": {
-    "name": "Example Customer SAS",
-    "tax_id": {
-      "country": "FR",
-      "code": "67698681771"
-    },
-    "identities": [
-      {
-        "type": "SIREN",
-        "code": "698681771"
-      }
-    ],
-    "inboxes": [
-      {
-        "scheme": "0225",
-        "code": "698681771"
-      }
-    ]
-  },
-  "methods": [
-    {
-      "key": "credit-transfer",
-      "amount": "120.00"
-    }
-  ],
-  "lines": [
-    {
-      "amount": "120.00",
-      "document": {
-        "series": "INV",
-        "code": "2026-0042",
-        "issue_date": "2026-06-19",
-        "type": "380"
-      },
-      "tax": {
-        "categories": [
-          {
-            "code": "VAT",
-            "rates": [
-              {
-                "base": "100.00",
-                "percent": "20.0%",
-                "amount": "20.00"
-              }
-            ]
-          }
-        ]
-      }
-    }
-  ]
+	"$schema": "https://gobl.org/draft-0/bill/payment",
+	"$regime": "FR",
+	"$addons": [
+		"fr-ctc-flow6-v1"
+	],
+	"uuid": "0195ce71-dc9c-72c8-bf2c-9890a4a9f0a2",
+	"type": "receipt",
+	"series": "PAY",
+	"code": "2026-0042-R",
+	"issue_date": "2026-06-19",
+	"value_date": "2026-06-19",
+	"currency": "EUR",
+	"ext": {
+		"fr-ctc-flow6-condition": "MEN",
+		"fr-ctc-flow6-status": "212"
+	},
+	"supplier": {
+		"name": "Example Supplier SARL",
+		"tax_id": {
+			"country": "FR",
+			"code": "83698680774"
+		},
+		"identities": [
+			{
+				"type": "SIREN",
+				"code": "698680774",
+				"ext": {
+					"iso-scheme-id": "0002"
+				}
+			}
+		],
+		"endpoints": [
+			{
+				"uri": "iso6523-actorid-upis::0225:698680774"
+			}
+		],
+		"inboxes": [
+			{
+				"key": "peppol",
+				"scheme": "0225",
+				"code": "698680774"
+			}
+		],
+		"ext": {
+			"fr-ctc-flow6-role": "SE"
+		}
+	},
+	"customer": {
+		"name": "Example Customer SAS",
+		"tax_id": {
+			"country": "FR",
+			"code": "67698681771"
+		},
+		"identities": [
+			{
+				"type": "SIREN",
+				"code": "698681771",
+				"ext": {
+					"iso-scheme-id": "0002"
+				}
+			}
+		],
+		"endpoints": [
+			{
+				"uri": "iso6523-actorid-upis::0225:698681771"
+			}
+		],
+		"inboxes": [
+			{
+				"key": "peppol",
+				"scheme": "0225",
+				"code": "698681771"
+			}
+		],
+		"ext": {
+			"fr-ctc-flow6-role": "BY"
+		}
+	},
+	"lines": [
+		{
+			"i": 1,
+			"document": {
+				"type": "380",
+				"issue_date": "2026-06-19",
+				"series": "INV",
+				"code": "2026-0042"
+			},
+			"amount": "120.00",
+			"tax": {
+				"categories": [
+					{
+						"code": "VAT",
+						"rates": [
+							{
+								"base": "100.00",
+								"percent": "20.0%",
+								"amount": "20.00"
+							}
+						],
+						"amount": "20.00"
+					}
+				],
+				"sum": "20.00"
+			}
+		}
+	],
+	"methods": [
+		{
+			"key": "credit-transfer",
+			"amount": "120.00"
+		}
+	],
+	"total": "120.00"
 }
 ```

--- a/snippets/examples/fr/states/212-payment-receipt.min.mdx
+++ b/snippets/examples/fr/states/212-payment-receipt.min.mdx
@@ -1,0 +1,88 @@
+---
+title: "212 — Encaissée (Payment receipt)"
+description: "GOBL bill/payment example for French CTC lifecycle code 212 (Payment receipt)"
+---
+
+```json Minimal
+{
+  "$schema": "https://gobl.org/draft-0/bill/payment",
+  "$addons": [
+    "fr-ctc-flow6-v1"
+  ],
+  "type": "receipt",
+  "issue_date": "2026-06-19",
+  "value_date": "2026-06-19",
+  "series": "PAY",
+  "code": "2026-0042-R",
+  "currency": "EUR",
+  "supplier": {
+    "name": "Example Supplier SARL",
+    "tax_id": {
+      "country": "FR",
+      "code": "83698680774"
+    },
+    "identities": [
+      {
+        "type": "SIREN",
+        "code": "698680774"
+      }
+    ],
+    "inboxes": [
+      {
+        "scheme": "0225",
+        "code": "698680774"
+      }
+    ]
+  },
+  "customer": {
+    "name": "Example Customer SAS",
+    "tax_id": {
+      "country": "FR",
+      "code": "67698681771"
+    },
+    "identities": [
+      {
+        "type": "SIREN",
+        "code": "698681771"
+      }
+    ],
+    "inboxes": [
+      {
+        "scheme": "0225",
+        "code": "698681771"
+      }
+    ]
+  },
+  "methods": [
+    {
+      "key": "credit-transfer",
+      "amount": "120.00"
+    }
+  ],
+  "lines": [
+    {
+      "amount": "120.00",
+      "document": {
+        "series": "INV",
+        "code": "2026-0042",
+        "issue_date": "2026-06-19",
+        "type": "380"
+      },
+      "tax": {
+        "categories": [
+          {
+            "code": "VAT",
+            "rates": [
+              {
+                "base": "100.00",
+                "percent": "20.0%",
+                "amount": "20.00"
+              }
+            ]
+          }
+        ]
+      }
+    }
+  ]
+}
+```


### PR DESCRIPTION
Follows the ZATCA guide's pattern (#448): every French CTC lifecycle example now shows **both** the minimal hand-authored GOBL input (**Minimal**) and the **Built version** produced by `gobl build`, side by side in a `CodeGroup`.

## What changed
- **`snippets/examples/fr/states/`** — each `<code>-<slug>.mdx` is split into:
  - `…​.min.mdx` — the minimal input (what you author)
  - `…​.mdx` — the **built** output, with the derived fields GOBL adds (`fr-ctc-flow6-*` extensions, `SE`/`BY` party roles, `iso-scheme-id`, Peppol `endpoints`).
- **`guides/fr-pa-status.mdx`** — each example accordion renders both partners in a `CodeGroup`; intro notes the Minimal / Built pairing.

## How the built versions were produced
All 12 built outputs are generated through gobl `Calculate` + `Validate` (not hand-written), so they're exact and verified — every one validates against `fr-ctc-flow6-v1` and derives the correct CDV code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)