### PR TITLE
docs(series): fix create-series API examples to use `start`

### DIFF
--- a/guides/series.mdx
+++ b/guides/series.mdx
@@ -61,7 +61,7 @@ You can create series through the Invopop Console or via the API. The Console pr
 | **Code** (Optional)        | Internal or business code used to categorize series.                                                           | `code`                                  |
 | **Prefix** (Optional)      | Text placed before the numeric portion of the generated code.                                                  | `prefix`                                |
 | **Padding**                | Total number of digits in the numeric sequence. Zeros are added to the left when necessary.                    | `padding`                               |
-| **Start Number**           | The first number to be issued in the sequence.                                                                 | `last_index`                            |
+| **Start Number**           | The first number to be issued in the sequence.                                                                 | `start`                                 |
 | **Suffix** (Optional)      | Text appended after the numeric part.                                                                          | `suffix`                                |
 | **Description** (Optional) | Free text for internal documentation or identification.                                                        | `description`                           |
 
@@ -86,7 +86,7 @@ curl -X PUT "https://api.invopop.com/sequence/v1/series/{id}" \
     "code": "INV",
     "prefix": "ES-",
     "padding": 5,
-    "last_index": 1,
+    "start": 1,
     "suffix": "",
     "description": "Series for Spanish invoice numbering"
   }'


### PR DESCRIPTION
## What changed

The series guide's create-series API examples incorrectly used `last_index` for the starting index. Corrected to `start`:

- **Series properties table** — "Start Number" now maps to the `start` API property.
- **Create a series `curl` example** — request body now sends `"start": 1`.

## Why

The [Sequence API spec](openapi/sequence_v1.yaml) defines the create request body (`SequenceCreateSeries`) with a `start` property for the initial index. `last_index` is a read-only field that only appears on the response object (`SequenceSeries`), where it tracks the last index used. The guide was sending a field the create endpoint doesn't accept.

## Notes for reviewer

The remaining `last_index` references in the guide (response example, FAQ, best practices) are correct — they describe the response object, not the request. The entry-creation example was verified against the spec and is accurate as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)