### PR TITLE
docs(fr): fix invalid frontmatter in fr-pa-send-record-document

### DIFF
--- a/snippets/workflows/fr/fr-pa-send-record-document.mdx
+++ b/snippets/workflows/fr/fr-pa-send-record-document.mdx
@@ -1,6 +1,6 @@
 ---
-title: "Record and send through Peppol and PPF or record for reporting",
-description: "Checks if both parties are registered in the Annuaire and branches on e-invoicing or e-reporting flow",
+title: "Record and send through Peppol and PPF or record for reporting"
+description: "Checks if both parties are registered in the Annuaire and branches on e-invoicing or e-reporting flow"
 countryCode: "fr"
 appId: "gov-fr"
 schema: "bill/invoice"


### PR DESCRIPTION
Remove stray trailing commas from the YAML frontmatter of the France PA record/send workflow snippet.

The `title` and `description` keys had trailing commas — invalid YAML and inconsistent with every sibling file in `snippets/workflows/fr/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)