### PR TITLE
Update workflow action display names

### DIFF
--- a/apps/argentina.mdx
+++ b/apps/argentina.mdx
@@ -67,15 +67,15 @@ import FAQ from '/snippets/faqs/ar/composers/app-arca.mdx';
 
 		#### Supplier actions
 
-		<Card title="Register supplier in ARCA" icon="https://assets.invopop.com/flags/ar.svg" horizontal>
+		<Card title="Register supplier with ARCA" icon="https://assets.invopop.com/flags/ar.svg" horizontal>
 			Generates a unique URL in the `meta` property with a `url` key value for the supplier to register in ARCA.
 		</Card>
 
-		<Card title="Wait for authorization via ARCA" icon="https://assets.invopop.com/flags/ar.svg" horizontal>
+		<Card title="Wait for ARCA certificate upload" icon="https://assets.invopop.com/flags/ar.svg" horizontal>
 			Long running action that continues when the supplier successfully uploads their ARCA certificate.
 		</Card>
 
-		<Card title="Unregister supplier in ARCA" icon="https://assets.invopop.com/flags/ar.svg" horizontal>
+		<Card title="Unregister supplier from ARCA" icon="https://assets.invopop.com/flags/ar.svg" horizontal>
 			Removes invoice issuing entitlements to the supplier.
 		</Card>
 

--- a/apps/at-portugal.mdx
+++ b/apps/at-portugal.mdx
@@ -85,17 +85,17 @@ Make sure to check out our [AT Portugal Guide](/guides/pt-at) for instructions o
 	<Tab title="Actions">
 		The following workflow actions will be available once you install and enable this app:
 
-		<Card title="Record for SAF-T (Portugal)" icon="https://assets.invopop.com/apps/at-pt/icon.svg"  horizontal>
+		<Card title="Record document for SAF-T" icon="https://assets.invopop.com/apps/at-pt/icon.svg"  horizontal>
 		 <div class="pop-count"><Icon icon="https://assets.invopop.com/icons/pops.svg" /> 1</div>
 		 Record a GOBL document for SAF-T PT reporting.
 		</Card>
-		<Card title="Send to the AT (Portugal)" icon="https://assets.invopop.com/apps/at-pt/icon.svg"  horizontal>
+		<Card title="Send document to AT" icon="https://assets.invopop.com/apps/at-pt/icon.svg"  horizontal>
 		  Send document to the AT in realtime via web service.
 		</Card>
-		<Card title="Register AT Issuer (Portugal)" icon="https://assets.invopop.com/apps/at-pt/icon.svg"  horizontal>
+		<Card title="Register supplier with AT" icon="https://assets.invopop.com/apps/at-pt/icon.svg"  horizontal>
 		 Register a GOBL party to report taxes to the AT in their name.
 		</Card>
-		<Card title="Cancel SAF-T record (Portugal)" icon="https://assets.invopop.com/apps/at-pt/icon.svg" horizontal>
+		<Card title="Cancel SAF-T record" icon="https://assets.invopop.com/apps/at-pt/icon.svg" horizontal>
 		 Cancel a previously recorded GOBL document for SAF-T PT reporting.
 		</Card>
 	</Tab>

--- a/apps/chargebee.mdx
+++ b/apps/chargebee.mdx
@@ -45,7 +45,7 @@ import ZUGFeRDExample from '/snippets/workflows/chargebee/cb-zugferd.mdx';
 	<Tab title="Actions">
 		The following workflow actions will be available once you install and enable this app:
 
-		<Card title="Import Chargebee document" icon="https://assets.invopop.com/apps/chargebee/icon.svg" horizontal>
+		<Card title="Import document from Chargebee" icon="https://assets.invopop.com/apps/chargebee/icon.svg" horizontal>
 		 Import invoice and credit note data from Chargebee into Invopop.
 		</Card>
 

--- a/apps/choruspro-france.mdx
+++ b/apps/choruspro-france.mdx
@@ -52,11 +52,11 @@ The platform supports various e-invoicing formats including [Cross Industry Invo
 
 	</Tab>
 	<Tab title="Actions">
-		<Card title="Send an invoice to Chorus Pro" icon="https://assets.invopop.com/apps/chroruspro/icon.svg" horizontal>
+		<Card title="Send invoice to Chorus Pro" icon="https://assets.invopop.com/apps/chroruspro/icon.svg" horizontal>
 			<div class="pop-count"><Icon icon="https://assets.invopop.com/icons/pops.svg" /> 3</div>
-			Creates a flux with the generated file and sends it to Chorus-Pro.
+			Creates a flux with the generated file and sends it to Chorus Pro.
 		</Card>
-		<Card title="Register a supplier for Chorus Pro" icon="https://assets.invopop.com/apps/chroruspro/icon.svg" horizontal>
+		<Card title="Register supplier with Chorus Pro" icon="https://assets.invopop.com/apps/chroruspro/icon.svg" horizontal>
 			Register a supplier in Invopop to enable e-invoicing in Chorus Pro. A supplier must then provide a Technical Account.
 		</Card>
 		<Card title="Wait for Chorus Pro credentials" icon="https://assets.invopop.com/apps/chroruspro/icon.svg" horizontal>

--- a/apps/documentos-fiscais-electronicos-brazil.mdx
+++ b/apps/documentos-fiscais-electronicos-brazil.mdx
@@ -61,28 +61,28 @@ import FAQ from '/snippets/faqs/br/composers/app-dfe.mdx';
 	<Tab title="Actions">
 		The following workflow actions will be available once you install and enable this app:
 
-		<Card title="Send NFS-e (Brazil)" icon="https://assets.invopop.com/apps/notas-fiscais-eletronicas-brazil/icon.svg" horizontal>
+		<Card title="Send NFS-e to Prefeitura" icon="https://assets.invopop.com/apps/notas-fiscais-eletronicas-brazil/icon.svg" horizontal>
 		 <div class="pop-count"><Icon icon="https://assets.invopop.com/icons/pops.svg" /> 5</div>
 		 Send NFS-e in Brazil via Plugnotas.
 		</Card>
-		<Card title="Send NF-e (Brazil)" icon="https://assets.invopop.com/apps/notas-fiscais-eletronicas-brazil/icon.svg" horizontal>
+		<Card title="Send NF-e to SEFAZ" icon="https://assets.invopop.com/apps/notas-fiscais-eletronicas-brazil/icon.svg" horizontal>
 		 <div class="pop-count"><Icon icon="https://assets.invopop.com/icons/pops.svg" /> 5</div>
 		 Send NF-e in Brazil via Plugnotas.
 		</Card>
-		<Card title="Send NFC-e (Brazil)" icon="https://assets.invopop.com/apps/notas-fiscais-eletronicas-brazil/icon.svg" horizontal>
+		<Card title="Send NFC-e to SEFAZ" icon="https://assets.invopop.com/apps/notas-fiscais-eletronicas-brazil/icon.svg" horizontal>
 		 <div class="pop-count"><Icon icon="https://assets.invopop.com/icons/pops.svg" /> 5</div>
 		 Send NFC-e in Brazil via Plugnotas
 		</Card>
-		<Card title="Register DF-e supplier (Brazil)" icon="https://assets.invopop.com/apps/notas-fiscais-eletronicas-brazil/icon.svg" horizontal>
+		<Card title="Register supplier in Brazil" icon="https://assets.invopop.com/apps/notas-fiscais-eletronicas-brazil/icon.svg" horizontal>
 		 Register suppliers to issue electronic fiscal documents on their behalf.
 		</Card>
-		<Card title="Cancel NFS-e (Brazil)" icon="https://assets.invopop.com/apps/notas-fiscais-eletronicas-brazil/icon.svg" horizontal>
+		<Card title="Cancel NFS-e with Prefeitura" icon="https://assets.invopop.com/apps/notas-fiscais-eletronicas-brazil/icon.svg" horizontal>
 		 Cancel a previously sent NFS-e invoice via PlugNotas. The cancellation reason and code can be set on the workflow step configuration or overridden per job using the `nfe-br-cancel-reason` and `nfe-br-cancel-code` arguments.
 		</Card>
-		<Card title="Cancel NF-e (Brazil)" icon="https://assets.invopop.com/apps/notas-fiscais-eletronicas-brazil/icon.svg" horizontal>
+		<Card title="Cancel NF-e with SEFAZ" icon="https://assets.invopop.com/apps/notas-fiscais-eletronicas-brazil/icon.svg" horizontal>
 		 Cancel a previously sent NF-e invoice via PlugNotas. The cancellation reason can be set on the workflow step or overridden per job using the `nfe-br-cancel-reason` argument.
 		</Card>
-		<Card title="Cancel NFC-e (Brazil)" icon="https://assets.invopop.com/apps/notas-fiscais-eletronicas-brazil/icon.svg" horizontal>
+		<Card title="Cancel NFC-e with SEFAZ" icon="https://assets.invopop.com/apps/notas-fiscais-eletronicas-brazil/icon.svg" horizontal>
 		 Cancel a previously sent NFC-e invoice via PlugNotas. The cancellation reason can be set on the workflow step or overridden per job using the `nfe-br-cancel-reason` argument.
 		</Card>
 	</Tab>

--- a/apps/email.mdx
+++ b/apps/email.mdx
@@ -45,7 +45,7 @@ mode: wide
 	<Tab title="Actions">
 		The following workflow actions will be available once you install and enable this app:
 
-		<Card title="Send Email" icon="https://assets.invopop.com/apps/email/icon.png" horizontal>
+		<Card title="Send email" icon="https://assets.invopop.com/apps/email/icon.png" horizontal>
 		 <div class="pop-count"><Icon icon="https://assets.invopop.com/icons/pops.svg" /> 1</div>
 		  Send billing documents via email.
 		</Card>
@@ -56,7 +56,7 @@ mode: wide
 		</Card>
 	</Tab>
 	<Tab title="Workflows">
-		The Email app integrates seamlessly into your existing workflows. Typically, you'll add the `Send Email` step after you have issued an invoice via the corresponding tax authority and generated a PDF (if required). This ensures the necessary files are attached and that the invoice complies with local regulatory requirements.
+		The Email app integrates seamlessly into your existing workflows. Typically, you'll add the `Send email` step after you have issued an invoice via the corresponding tax authority and generated a PDF (if required). This ensures the necessary files are attached and that the invoice complies with local regulatory requirements.
 
 		For simple notifications without attachments, you can use the `Notify via Email` action at any point in your workflow.
 

--- a/apps/france.mdx
+++ b/apps/france.mdx
@@ -81,7 +81,7 @@ import FAQ from '/snippets/faqs/fr/composers/app-france.mdx';
 		<Card title="Register in Annuaire" icon="https://assets.invopop.com/apps/peppol/icon.svg" horizontal>
 			Register a party in the French Annuaire so they can issue and receive regulated e-invoices.
 		</Card>
-		<Card title="Register Peppol party" icon="https://assets.invopop.com/apps/peppol/icon.svg" horizontal>
+		<Card title="Register party on Peppol" icon="https://assets.invopop.com/apps/peppol/icon.svg" horizontal>
 			Register the party on the Peppol network for transport.
 		</Card>
 		<Card title="Register reporter" icon="https://assets.invopop.com/apps/peppol/icon.svg" horizontal>

--- a/apps/ilyda-greece.mdx
+++ b/apps/ilyda-greece.mdx
@@ -56,7 +56,7 @@ import FAQ from '/snippets/faqs/gr/composers/app-mydata.mdx';
 	<Tab title="Actions">
 		The following workflow actions will be available once you install and enable this app:
 
-		<Card title="Send to IAPR via ILYDA" icon="https://assets.invopop.com/apps/ilyda/icon.svg" horizontal>
+		<Card title="Send invoice to MyDATA" icon="https://assets.invopop.com/apps/ilyda/icon.svg" horizontal>
 		 <div class="pop-count"><Icon icon="https://assets.invopop.com/icons/pops.svg" /> 5</div>
 		    Send GOBL invoices to the Greek IAPR via ILYDA eInvoicing.
 		</Card>

--- a/apps/oasis-ubl.mdx
+++ b/apps/oasis-ubl.mdx
@@ -43,11 +43,11 @@ import PeppolStandardInvoice from '/snippets/invoices/de/peppol-standard.mdx'
 
 	</Tab>
 	<Tab title="Actions">
-		<Card title="Generate UBL Document" icon="https://assets.invopop.com/apps/ubl/logo.svg" horizontal>
+		<Card title="Generate UBL document" icon="https://assets.invopop.com/apps/ubl/logo.svg" horizontal>
         <div class="pop-count"><Icon icon="https://assets.invopop.com/icons/pops.svg" /> 1</div>
 			Generate a new UBL document from the GOBL source.
 		</Card>
-		<Card title="Import UBL Document" icon="https://assets.invopop.com/apps/ubl/logo.svg" horizontal>
+		<Card title="Import UBL document" icon="https://assets.invopop.com/apps/ubl/logo.svg" horizontal>
         <div class="pop-count"><Icon icon="https://assets.invopop.com/icons/pops.svg" /> 1</div>
 			Convert an incoming UBL XML into a GOBL document.
 		</Card>

--- a/apps/peppol.mdx
+++ b/apps/peppol.mdx
@@ -57,7 +57,7 @@ import SpainInvoiceExamples from '/snippets/invoices/es/peppol-accordion.mdx';
 
 	<Accordion title="Handling 'Receiver Not Found' Errors">
 
-		If your job fails with a `KO` error status showing `receiver not found in the peppol network`, treat this the same as an invalid email address. As countries roll out their Peppol networks, you'll encounter a mix of registered and unregistered companies, so it's important to catch these issues early. Use the Peppol **Lookup Participant ID** step to validate the Peppol ID before sending anything to the network. We recommend to create a separate workflow for this validation and run it against customer's information. This will catch the error before creating the invoice.
+		If your job fails with a `KO` error status showing `receiver not found in the peppol network`, treat this the same as an invalid email address. As countries roll out their Peppol networks, you'll encounter a mix of registered and unregistered companies, so it's important to catch these issues early. Use the Peppol **Lookup Peppol participant** step to validate the Peppol ID before sending anything to the network. We recommend to create a separate workflow for this validation and run it against customer's information. This will catch the error before creating the invoice.
 
 	</Accordion>
 
@@ -65,25 +65,25 @@ import SpainInvoiceExamples from '/snippets/invoices/es/peppol-accordion.mdx';
 	<Tab title="Actions">
 		The following workflow actions will be available once you install and enable this app:
 
-		<Card title="Send Peppol Document" icon="https://assets.invopop.com/apps/peppol/icon.svg" horizontal>
+		<Card title="Send Peppol document" icon="https://assets.invopop.com/apps/peppol/icon.svg" horizontal>
 		 <div class="pop-count"><Icon icon="https://assets.invopop.com/icons/pops.svg" /> 2</div>
 		    Send a document over the Peppol Network.
 		</Card>
 
-		<Card title="Import Peppol Document" icon="https://assets.invopop.com/apps/peppol/icon.svg" horizontal>
+		<Card title="Import Peppol document" icon="https://assets.invopop.com/apps/peppol/icon.svg" horizontal>
 		 <div class="pop-count"><Icon icon="https://assets.invopop.com/icons/pops.svg" /> 3</div>
 		 Receive and import invoices from the Peppol network, supporting both UBL and CII formats.
 		</Card>
 
-		<Card title="Register Peppol Party" icon="https://assets.invopop.com/apps/peppol/icon.svg" horizontal>
+		<Card title="Register party on Peppol" icon="https://assets.invopop.com/apps/peppol/icon.svg" horizontal>
 		 Register a company as a Peppol participant with the network.
 		</Card>
 
-		<Card title="Register Party for Approval" icon="https://assets.invopop.com/apps/peppol/icon.svg" horizontal>
+		<Card title="Register party for Peppol approval" icon="https://assets.invopop.com/apps/peppol/icon.svg" horizontal>
 		 Generate a registration link for proof of ownership submission.
 		</Card>
 
-		<Card title="Wait for Approval" icon="https://assets.invopop.com/apps/peppol/icon.svg" horizontal>
+		<Card title="Wait for Peppol approval" icon="https://assets.invopop.com/apps/peppol/icon.svg" horizontal>
 		 Wait for company identity and ownership validation.
 		</Card>
 	</Tab>

--- a/apps/sat-mexico.mdx
+++ b/apps/sat-mexico.mdx
@@ -59,12 +59,12 @@ import FAQ from '/snippets/faqs/mx/composers/app-sat.mdx';
   </Tab>
   <Tab title="Actions">
     The following workflow actions will be available once you install and enable this app:
-    <Card title="Send to SAT (Mexico)" icon="https://assets.invopop.com/apps/sat-mexico/icon.svg" horizontal>
+    <Card title="Send invoice to SAT" icon="https://assets.invopop.com/apps/sat-mexico/icon.svg" horizontal>
       Send GOBL invoices to the Mexican SAT using the CFDI format.
       <div class="pop-count"><Icon icon="https://assets.invopop.com/icons/pops.svg" /> 5</div>
     </Card>
 
-    <Card title="Import CFDI" icon="https://assets.invopop.com/apps/sat-mexico/icon.svg" horizontal>
+    <Card title="Import CFDI from SAT" icon="https://assets.invopop.com/apps/sat-mexico/icon.svg" horizontal>
       Convert a CFDI XML document to GOBL format. Accepts a URL pointing to the CFDI file (typically a Spool URL provided by the [SW Sapien app](/apps/sw-sapien)).
     </Card>
 

--- a/apps/sdi-italy.mdx
+++ b/apps/sdi-italy.mdx
@@ -61,16 +61,16 @@ import FAQ from '/snippets/faqs/it/composers/app-sdi.mdx';
 	<Tab title="Actions">
 		The following workflow actions will be available once you install and enable this app:
 
-		<Card title="Send FatturaPA to SDI (Italy)" icon="https://assets.invopop.com/apps/sdi-italy/icon.svg" horizontal>
+		<Card title="Send invoice to SDI" icon="https://assets.invopop.com/apps/sdi-italy/icon.svg" horizontal>
 		 <div class="pop-count"><Icon icon="https://assets.invopop.com/icons/pops.svg" /> 3</div>
 		 Issue GOBL invoices in the Italian SDI using the FatturaPA format.
 		</Card>
 
-		<Card title="Register party with SDI (Italy)" icon="https://assets.invopop.com/apps/sdi-italy/icon.svg" horizontal>
+		<Card title="Register supplier with SDI" icon="https://assets.invopop.com/apps/sdi-italy/icon.svg" horizontal>
 		 Register a GOBL party to receive invoices to the Italian SDI.
 		</Card>
 
-		<Card title="Import FatturaPA from SDI (Italy)" icon="https://assets.invopop.com/apps/sdi-italy/icon.svg" horizontal>
+		<Card title="Import invoice from SDI" icon="https://assets.invopop.com/apps/sdi-italy/icon.svg" horizontal>
 		 <div class="pop-count"><Icon icon="https://assets.invopop.com/icons/pops.svg" /> 3</div>
 		 Import invoices from the Italian SDI using the FatturaPA format.
 		</Card>

--- a/apps/smart-receipts-italy.mdx
+++ b/apps/smart-receipts-italy.mdx
@@ -67,17 +67,17 @@ import FAQ from '/snippets/faqs/it/composers/app-ticket.mdx';
 	<Tab title="Actions">
 		The following workflow actions will be available once you install and enable this app:
 
-		<Card title="Send a receipt to AdE" icon="https://assets.invopop.com/apps/agenzia-entrate/icon.svg" horizontal>
+		<Card title="Send receipt to AdE" icon="https://assets.invopop.com/apps/agenzia-entrate/icon.svg" horizontal>
 		 <div class="pop-count"><Icon icon="https://assets.invopop.com/icons/pops.svg" /> 3</div>
 		 Issue GOBL invoices to the Italian AdE using their receipt (documento commerciale) format.
 		</Card>
 
-		<Card title="Void a receipt in AdE" icon="https://assets.invopop.com/apps/agenzia-entrate/icon.svg" horizontal>
+		<Card title="Void receipt with AdE" icon="https://assets.invopop.com/apps/agenzia-entrate/icon.svg" horizontal>
 		 <div class="pop-count"><Icon icon="https://assets.invopop.com/icons/pops.svg" /> 3</div>
 		 Void a receipt previously sent to the Italian AdE.
 		</Card>
 
-		<Card title="Register Issuer in AdE" icon="https://assets.invopop.com/apps/agenzia-entrate/icon.svg" horizontal>
+		<Card title="Register supplier with AdE" icon="https://assets.invopop.com/apps/agenzia-entrate/icon.svg" horizontal>
 		 Register a GOBL party to issue receipts in the Italian AdE.
 		</Card>
 	</Tab>

--- a/apps/spain.mdx
+++ b/apps/spain.mdx
@@ -194,12 +194,12 @@ import FAQ from '/snippets/faqs/es/composers/app-spain.mdx';
 		SII actions
 		<Card title="Record Issued Invoice with SII" icon="https://assets.invopop.com/apps/sii/icon.svg" horizontal>
 			<div class="pop-count"><Icon icon="https://assets.invopop.com/icons/pops.svg" /> 2</div>
-			Record issued invoices in the the SII system.
+			Record issued invoices in the SII system.
 		</Card>
 
 		<Card title="Record Received Invoice with SII" icon="https://assets.invopop.com/apps/sii/icon.svg" horizontal>
 			<div class="pop-count"><Icon icon="https://assets.invopop.com/icons/pops.svg" /> 2</div>
-			Record received invoices in the the SII system.
+			Record received invoices in the SII system.
 		</Card>
 
 		<Card title="Register supplier with SII" icon="https://assets.invopop.com/apps/sii/icon.svg" horizontal>

--- a/apps/spain.mdx
+++ b/apps/spain.mdx
@@ -149,12 +149,12 @@ import FAQ from '/snippets/faqs/es/composers/app-spain.mdx';
 		The following workflow actions will be available once you install and enable this app:
 
 		AEAT Lookup actions
-		<Card title="Verify Spanish Tax ID (NIF/CIF)" icon="https://assets.invopop.com/apps/gov-es/icon.svg" horizontal>
+		<Card title="Verify Spanish Tax ID" icon="https://assets.invopop.com/apps/gov-es/icon.svg" horizontal>
 			<div class="pop-count"><Icon icon="https://assets.invopop.com/icons/pops.svg" /> 1</div>
 			Verify that a Spanish tax ID (NIF/CIF) exists in the AEAT census. For companies, this confirms the tax ID is valid. For individuals, it also verifies that the name matches the tax ID on record.
 		</Card>
 
-		<Card title="Verify & Correct Tax Details" icon="https://assets.invopop.com/apps/gov-es/icon.svg" horizontal>
+		<Card title="Verify & correct tax details" icon="https://assets.invopop.com/apps/gov-es/icon.svg" horizontal>
 			<div class="pop-count"><Icon icon="https://assets.invopop.com/icons/pops.svg" /> 1</div>
 				Verify the tax ID and normalize names using AEAT data. For companies, it sets the official name; for individuals, it applies the AEAT-returned format.
 		</Card>
@@ -167,27 +167,27 @@ import FAQ from '/snippets/faqs/es/composers/app-spain.mdx';
 		</Card>
 
 		TicketBAI actions
-		<Card title="Send TicketBAI (Spain)" icon="https://assets.invopop.com/apps/ticketbai/icon.svg" horizontal>
+		<Card title="Send invoice to TicketBAI" icon="https://assets.invopop.com/apps/ticketbai/icon.svg" horizontal>
 		 <div class="pop-count"><Icon icon="https://assets.invopop.com/icons/pops.svg" /> 1</div>
 		 Convert GOBL Invoices into TicketBAI XML format and send to the tax agency in Spain.
 		</Card>
-		<Card title="Generate TicketBAI (Spain)" icon="https://assets.invopop.com/apps/ticketbai/icon.svg" horizontal>
+		<Card title="Generate TicketBAI XML" icon="https://assets.invopop.com/apps/ticketbai/icon.svg" horizontal>
 		 <div class="pop-count"><Icon icon="https://assets.invopop.com/icons/pops.svg" /> 1</div>
 		 Generate a TicketBAI XML document from a GOBL invoice.
 		</Card>
-		<Card title="Cancel TicketBAI Invoice" icon="https://assets.invopop.com/apps/ticketbai/icon.svg" horizontal>
+		<Card title="Cancel invoice in TicketBAI" icon="https://assets.invopop.com/apps/ticketbai/icon.svg" horizontal>
 		  Send a cancel request for a previously sent TicketBAI invoice.
 		</Card>
-		<Card title="Register with TicketBAI" icon="https://assets.invopop.com/apps/ticketbai/icon.svg" horizontal>
+		<Card title="Register supplier with TicketBAI" icon="https://assets.invopop.com/apps/ticketbai/icon.svg" horizontal>
 			Register TicketBAI parties before issuing invoices on their behalf.
 		</Card>
-		<Card title="Wait for Upload TicketBAI" icon="https://assets.invopop.com/apps/ticketbai/icon.svg" horizontal>
+		<Card title="Wait for TicketBAI supplier agreement upload" icon="https://assets.invopop.com/apps/ticketbai/icon.svg" horizontal>
 			Block the job while waiting for the end-user to complete their registration steps.
 		</Card>
-		<Card title="Wait for Approval TicketBAI" icon="https://assets.invopop.com/apps/ticketbai/icon.svg" horizontal>
+		<Card title="Wait for TicketBAI supplier approval" icon="https://assets.invopop.com/apps/ticketbai/icon.svg" horizontal>
 			Wait for approval that the uploaded documentation is correct.
 		</Card>
-		<Card title="Unregister with TicketBAI" icon="https://assets.invopop.com/apps/ticketbai/icon.svg" horizontal>
+		<Card title="Unregister supplier with TicketBAI" icon="https://assets.invopop.com/apps/ticketbai/icon.svg" horizontal>
 			Disables a previously registered party from issuing invoices.
 		</Card>
 
@@ -202,49 +202,49 @@ import FAQ from '/snippets/faqs/es/composers/app-spain.mdx';
 			Record received invoices in the the SII system.
 		</Card>
 
-		<Card title="Register with SII" icon="https://assets.invopop.com/apps/sii/icon.svg" horizontal>
+		<Card title="Register supplier with SII" icon="https://assets.invopop.com/apps/sii/icon.svg" horizontal>
 			Register SII parties before reporting invoices on their behalf.
 		</Card>
 
-		<Card title="Wait for Upload SII" icon="https://assets.invopop.com/apps/sii/icon.svg" horizontal>
+		<Card title="Wait for SII supplier agreement upload" icon="https://assets.invopop.com/apps/sii/icon.svg" horizontal>
 			Block the job while waiting for the end-user to complete their registration steps.
 		</Card>
 
-		<Card title="Wait for Approval SII" icon="https://assets.invopop.com/apps/sii/icon.svg" horizontal>
+		<Card title="Wait for SII supplier approval" icon="https://assets.invopop.com/apps/sii/icon.svg" horizontal>
 			Wait for approval that the uploaded documentation is correct.
 		</Card>
 
-		<Card title="Unregister with SII" icon="https://assets.invopop.com/apps/sii/icon.svg" horizontal>
+		<Card title="Unregister supplier with SII" icon="https://assets.invopop.com/apps/sii/icon.svg" horizontal>
 			Disables a previously registered party from reporting invoices.
 		</Card>
 
 		NO VERI\*FACTU actions
 
-		<Card title="Generate NO VERI*FACTU Invoice Record" icon="https://assets.invopop.com/apps/verifactu/icon.svg" horizontal>
+		<Card title="Generate invoice for NO VERI*FACTU" icon="https://assets.invopop.com/apps/verifactu/icon.svg" horizontal>
 			Generate and digitally sign an invoicing record XML from a GOBL invoice.
 		</Card>
 
-		<Card title="Generate NO VERI*FACTU Cancellation Record" icon="https://assets.invopop.com/apps/verifactu/icon.svg" horizontal>
+		<Card title="Generate cancellation for NO VERI*FACTU" icon="https://assets.invopop.com/apps/verifactu/icon.svg" horizontal>
 			Generate and digitally sign a cancellation record for a previously recorded invoice.
 		</Card>
 
-		<Card title="Generate NO VERI*FACTU Event Record" icon="https://assets.invopop.com/apps/verifactu/icon.svg" horizontal>
+		<Card title="Generate event for NO VERI*FACTU" icon="https://assets.invopop.com/apps/verifactu/icon.svg" horizontal>
 			Generate and digitally sign an event record XML from a GOBL status.
 		</Card>
 
-		<Card title="Store NO VERI*FACTU Record" icon="https://assets.invopop.com/apps/verifactu/icon.svg" horizontal>
+		<Card title="Record for NO VERI*FACTU" icon="https://assets.invopop.com/apps/verifactu/icon.svg" horizontal>
 			Persist a signed record in the database for regulatory compliance.
 		</Card>
 
-		<Card title="Build NO VERI*FACTU Status Event" icon="https://assets.invopop.com/apps/verifactu/icon.svg" horizontal>
+		<Card title="Build status for NO VERI*FACTU" icon="https://assets.invopop.com/apps/verifactu/icon.svg" horizontal>
 			Build a GOBL status event document and upload it as a silo entry.
 		</Card>
 
-		<Card title="Register with NO VERI*FACTU" icon="https://assets.invopop.com/apps/verifactu/icon.svg" horizontal>
+		<Card title="Register supplier with NO VERI*FACTU" icon="https://assets.invopop.com/apps/verifactu/icon.svg" horizontal>
 			Register a party for NO VERI\*FACTU mode.
 		</Card>
 
-		<Card title="Unregister NO VERI*FACTU" icon="https://assets.invopop.com/apps/verifactu/icon.svg" horizontal>
+		<Card title="Unregister supplier from NO VERI*FACTU" icon="https://assets.invopop.com/apps/verifactu/icon.svg" horizontal>
 			Remove a party's NO VERI\*FACTU registration.
 		</Card>
 	</Tab>

--- a/apps/stripe.mdx
+++ b/apps/stripe.mdx
@@ -47,15 +47,15 @@ import VerifactuExample from '/snippets/workflows/stripe/stripe-verifactu.mdx';
 	<Tab title="Actions">
 		The following workflow actions will be available once you install and enable this app:
 
-		<Card title="Import data from Stripe" icon="https://assets.invopop.com/apps/stripe/icon.svg" horizontal>
+		<Card title="Import invoice from Stripe" icon="https://assets.invopop.com/apps/stripe/icon.svg" horizontal>
 		 Import invoice and credit note data from Stripe into Invopop.
 		</Card>
 
-		<Card title="Process invoice payment" icon="https://assets.invopop.com/apps/stripe/icon.svg" horizontal>
+		<Card title="Process invoice payment with Stripe" icon="https://assets.invopop.com/apps/stripe/icon.svg" horizontal>
 		 	Processes payment for an invoice through Stripe
 		</Card>
 
-		<Card title="Assign a Virtual IBAN" icon="https://assets.invopop.com/apps/stripe/icon.svg" horizontal>
+		<Card title="Assign virtual IBAN" icon="https://assets.invopop.com/apps/stripe/icon.svg" horizontal>
 		 Adds to the Payment Instructions the Virtual IBAN assigned to the customer
 		</Card>
 	</Tab>

--- a/apps/ticketbai-spain.mdx
+++ b/apps/ticketbai-spain.mdx
@@ -57,7 +57,7 @@ import InvoiceAccordion from '/snippets/invoices/es/ticketbai-accordion.mdx';
 		</Card>
 		<Card title="Generate TicketBAI XML" icon="https://assets.invopop.com/apps/ticketbai/icon.svg"  horizontal>
 		 <div class="pop-count"><Icon icon="https://assets.invopop.com/icons/pops.svg" /> 1</div> 
-		 Send a previously generated VERI\*FACTU document to the tax agency in Spain.
+		 Generate a TicketBAI XML document from a GOBL invoice.
 		</Card>
 		<Card title="Cancel invoice in TicketBAI" icon="https://assets.invopop.com/apps/ticketbai/icon.svg"  horizontal>
 		  Send a cancel request for previously sent VERI\*FACTU Invoice.

--- a/apps/ticketbai-spain.mdx
+++ b/apps/ticketbai-spain.mdx
@@ -51,15 +51,15 @@ import InvoiceAccordion from '/snippets/invoices/es/ticketbai-accordion.mdx';
 	<Tab title="Actions">
 		The following workflow actions will be available once you install and enable this app:
 
-		<Card title="Send TicketBAI (Spain)" icon="https://assets.invopop.com/apps/ticketbai/icon.svg" horizontal>
+		<Card title="Send invoice to TicketBAI" icon="https://assets.invopop.com/apps/ticketbai/icon.svg" horizontal>
 		 <div class="pop-count"><Icon icon="https://assets.invopop.com/icons/pops.svg" /> 1</div>
 		 Convert GOBL Invoices into VERI\*FACTU XML format used in Spain.
 		</Card>
-		<Card title="Generate TicketBAI (Spain)" icon="https://assets.invopop.com/apps/ticketbai/icon.svg"  horizontal>
+		<Card title="Generate TicketBAI XML" icon="https://assets.invopop.com/apps/ticketbai/icon.svg"  horizontal>
 		 <div class="pop-count"><Icon icon="https://assets.invopop.com/icons/pops.svg" /> 1</div> 
 		 Send a previously generated VERI\*FACTU document to the tax agency in Spain.
 		</Card>
-		<Card title="Cancel TicketBAI Invoice" icon="https://assets.invopop.com/apps/ticketbai/icon.svg"  horizontal>
+		<Card title="Cancel invoice in TicketBAI" icon="https://assets.invopop.com/apps/ticketbai/icon.svg"  horizontal>
 		  Send a cancel request for previously sent VERI\*FACTU Invoice.
 		</Card>
 	</Tab>

--- a/apps/ticketbai-spain.mdx
+++ b/apps/ticketbai-spain.mdx
@@ -53,7 +53,7 @@ import InvoiceAccordion from '/snippets/invoices/es/ticketbai-accordion.mdx';
 
 		<Card title="Send invoice to TicketBAI" icon="https://assets.invopop.com/apps/ticketbai/icon.svg" horizontal>
 		 <div class="pop-count"><Icon icon="https://assets.invopop.com/icons/pops.svg" /> 1</div>
-		 Convert GOBL Invoices into VERI\*FACTU XML format used in Spain.
+		 Convert GOBL invoices into TicketBAI XML format used in Spain.
 		</Card>
 		<Card title="Generate TicketBAI XML" icon="https://assets.invopop.com/apps/ticketbai/icon.svg"  horizontal>
 		 <div class="pop-count"><Icon icon="https://assets.invopop.com/icons/pops.svg" /> 1</div> 

--- a/apps/uncefact-cii.mdx
+++ b/apps/uncefact-cii.mdx
@@ -52,7 +52,7 @@ import ChorusProB2GInvoice from '/snippets/invoices/fr/chorus-pro-b2g.mdx'
 		</Card>
 		<Card title="Import CII document" icon="https://assets.invopop.com/apps/ubl/logo.svg" horizontal>
         <div class="pop-count"><Icon icon="https://assets.invopop.com/icons/pops.svg" /> 1</div>
-			Import a UN/CEFACT CII document like an invoice, and covert to GOBL.
+			Import a UN/CEFACT CII document like an invoice, and convert to GOBL.
 		</Card>
 	</Tab>
 	<Tab title="Documents">

--- a/apps/uncefact-cii.mdx
+++ b/apps/uncefact-cii.mdx
@@ -46,11 +46,11 @@ import ChorusProB2GInvoice from '/snippets/invoices/fr/chorus-pro-b2g.mdx'
             - `FR` · Chorus Pro V1
 	</Tab>
 	<Tab title="Actions">
-		<Card title="Generate UN/CEFACT CII Invoice" icon="https://assets.invopop.com/apps/ubl/logo.svg" horizontal>
+		<Card title="Generate CII document" icon="https://assets.invopop.com/apps/ubl/logo.svg" horizontal>
         <div class="pop-count"><Icon icon="https://assets.invopop.com/icons/pops.svg" /> 1</div>
 			Generate a UN/CEFACT CII XML Invoice.
 		</Card>
-		<Card title="Import UN/CEFACT CII Document" icon="https://assets.invopop.com/apps/ubl/logo.svg" horizontal>
+		<Card title="Import CII document" icon="https://assets.invopop.com/apps/ubl/logo.svg" horizontal>
         <div class="pop-count"><Icon icon="https://assets.invopop.com/icons/pops.svg" /> 1</div>
 			Import a UN/CEFACT CII document like an invoice, and covert to GOBL.
 		</Card>

--- a/apps/verifactu-spain.mdx
+++ b/apps/verifactu-spain.mdx
@@ -61,27 +61,27 @@ import FAQ from '/snippets/faqs/es/composers/app-verifactu.mdx';
 	<Tab title="Actions">
 		The following workflow actions will be available once you install and enable this app:
 
-		<Card title="Generate VERI*FACTU" icon="https://assets.invopop.com/apps/verifactu/icon.svg" horizontal>
+		<Card title="Generate VERI*FACTU XML" icon="https://assets.invopop.com/apps/verifactu/icon.svg" horizontal>
 		 <div class="pop-count"><Icon icon="https://assets.invopop.com/icons/pops.svg" /> 1</div>
 		 Convert GOBL Invoices into VERI\*FACTU XML format used in Spain.
 		</Card>
-		<Card title="Send VERI*FACTU" icon="https://assets.invopop.com/apps/verifactu/icon.svg"  horizontal>
+		<Card title="Send invoice to VERI*FACTU" icon="https://assets.invopop.com/apps/verifactu/icon.svg"  horizontal>
 		 <div class="pop-count"><Icon icon="https://assets.invopop.com/icons/pops.svg" /> 1</div> 
 		 Send a previously generated VERI\*FACTU document to the tax agency in Spain.
 		</Card>
-		<Card title="Cancel VERI*FACTU" icon="https://assets.invopop.com/apps/verifactu/icon.svg"  horizontal>
+		<Card title="Cancel invoice in VERI*FACTU" icon="https://assets.invopop.com/apps/verifactu/icon.svg"  horizontal>
 		  Send a cancel request for previously sent VERI\*FACTU Invoice.
 		</Card>
-		<Card title="Register with VERI*FACTU" icon="https://assets.invopop.com/apps/verifactu/icon.svg"  horizontal>
+		<Card title="Register supplier with VERI*FACTU" icon="https://assets.invopop.com/apps/verifactu/icon.svg"  horizontal>
 		  Register VERI\*FACTU parties before issuing invoices on their behalf.
 		</Card>
-		<Card title="Wait for Upload VERI*FACTU" icon="https://assets.invopop.com/apps/verifactu/icon.svg"  horizontal>
+		<Card title="Wait for VERI*FACTU supplier agreement upload" icon="https://assets.invopop.com/apps/verifactu/icon.svg"  horizontal>
 		  Block the job while waiting for the end-user to complete their registration steps.
 		</Card>
-		<Card title="Wait for Approval VERI*FACTU" icon="https://assets.invopop.com/apps/verifactu/icon.svg"  horizontal>
+		<Card title="Wait for VERI*FACTU supplier approval" icon="https://assets.invopop.com/apps/verifactu/icon.svg"  horizontal>
 		  Wait for a approval that the uploaded documentation is correct.
 		</Card>
-		<Card title="Unregister VERI*FACTU" icon="https://assets.invopop.com/apps/verifactu/icon.svg"  horizontal>
+		<Card title="Unregister supplier from VERI*FACTU" icon="https://assets.invopop.com/apps/verifactu/icon.svg"  horizontal>
 		  Disables a previously registered party from issuing invoices .
 		</Card>
 	</Tab>

--- a/console/_quickstart.mdx
+++ b/console/_quickstart.mdx
@@ -125,17 +125,17 @@ Now let's create your first workflow. We'll start with a simple workflow that ge
     Select the "PDF Invoice" template and click on <kbd>Load template</kbd>.
   </Step>
   <Step  title="Modify the workflow">
-    Let's add a step that sets the Document state to `Sent` after the PDF is generated. Click on the <kbd>+</kbd> button below the top right corner and select **Set State** in the right sidebar.
+    Let's add a step that sets the Document state to `Sent` after the PDF is generated. Click on the <kbd>+</kbd> button below the top right corner and select **Set state** in the right sidebar.
     <Frame>
       <img
-        alt= "Add Set State action"
+        alt= "Add Set state action"
         src="/assets/guides/start-add-step.gif"
         width="100%"
       />
     </Frame>
   </Step>
   <Step  title="Configure the step">
-    You should now see the configuration of the **Set State** step, otherwise click on the step you've just added. Select `Sent` in the **State** dropdown. 
+    You should now see the configuration of the **Set state** step, otherwise click on the step you've just added. Select `Sent` in the **State** dropdown. 
   </Step>
   <Step title="Save and Publish">
     Click on the <kbd>Save Draft</kbd> button save your draft workflow. Now click on <kbd>Publish</kbd> so you can start using it in your workspace.  

--- a/console/doc-states.mdx
+++ b/console/doc-states.mdx
@@ -11,7 +11,7 @@ sidebarTitle: States
 States are labels that do not reflect the internal state of the document. They are labels that don't represent the condition of the document itself. This decoupling means the state system provides metadata about workflow events, not assertions about the document's validity or integrity.
 
 
-Instead, states help you track the history of what happened to your document through a job run. For example, if a job encounters an error but doesn't explicitly set a state label, the document's state won't be marked as `Error`, even though the document may actually be affected. The state label only changes when you explicitly change it through the "Set State" workflow step or [through the API](/api-ref/silo/entries/update-an-entry#response-state) (though `Empty` and `Invalid` are exceptions to this rule). 
+Instead, states help you track the history of what happened to your document through a job run. For example, if a job encounters an error but doesn't explicitly set a state label, the document's state won't be marked as `Error`, even though the document may actually be affected. The state label only changes when you explicitly change it through the "Set state" workflow step or [through the API](/api-ref/silo/entries/update-an-entry#response-state) (though `Empty` and `Invalid` are exceptions to this rule). 
 
 
 We provide the following states to label the document throughout its lifecycle. Here they are described in order to assist you in selecting appropriate states for your documents (via API or workflows).
@@ -21,7 +21,7 @@ We provide the following states to label the document throughout its lifecycle. 
 | **Invalid** | This state cannot be selected. It is set by the system when a GOBL document is uploaded through the API with the `allow_invalid` option, or is received through a network such as Peppol or SDI which allow receiving invoices. |
 | **Empty** | Initial creation state before processing |
 | **Draft** | Mainly used to mark documents that will require further changes. |
-| **Processing** | Mainly used to indicate the document is being processed. Typically, the **Set State** step will be placed at the beginning of a workflow and changed later in the workflow, such as `Sent` or `Error` depending on the outcome. |
+| **Processing** | Mainly used to indicate the document is being processed. Typically, the **Set state** step will be placed at the beginning of a workflow and changed later in the workflow, such as `Sent` or `Error` depending on the outcome. |
 | **Registered** | When a party has been granted invoice issuing entitlements, or a document has been registered for reporting. |
 | **Completed** | Generic label for completion of a process. |
 | **Sent** | Document has been successfully transmitted (e.g., to tax authority or customer) |

--- a/console/series.mdx
+++ b/console/series.mdx
@@ -65,7 +65,7 @@ Here you can verify the final output format before saving.
 You will be able to use the series you've created from the API or through the "Add sequential code" step in your workflow. This will ensure your invoice numbers remain numbered correctly, as many regimes require not only unique invoice identifiers but also sequential numbering.
 
 
-### 'Add Sequential Code' workflow step
+### 'Add sequential code' workflow step
 
 <Frame>
 	<img src="/assets/console/add-dynamic-sequence.png" width="398" />
@@ -92,7 +92,7 @@ This workflow step allows you to use previously created Series, or to use a new 
 
 <AccordionGroup>
 	<Accordion title="Job fails with 'series required when code_id not present'">
-		 This happens because you have not defined a `series` in your document. This is used to determine which dynamic sequence to assign in the "Add Sequential Code" workflow step.
+		 This happens because you have not defined a `series` in your document. This is used to determine which dynamic sequence to assign in the "Add sequential code" workflow step.
 	</Accordion>
 	<Accordion title="Should I use a different series for each document type?">
 		Many jurisdictions require separate numbering series for different document types; e.g., one for standard invoices and another for credit notes. Even when it’s not mandatory, keeping distinct series is simply good practice and makes administration easier, so we recommend this approach.

--- a/console/workflow-create.mdx
+++ b/console/workflow-create.mdx
@@ -92,7 +92,7 @@ Any step that causes an error (`KO`) from which the job can't recover, and is no
 <AccordionGroup>
 <Accordion title="How do I update deprecated workflow steps?">
 
-If your step conditions displays a **This step contains deprecated conditions** warning, your workflow will continue working normally, but we recommend updating your workflow so that you can modify it without unexpected behavior.
+If your step conditions display a **This step contains deprecated conditions** warning, your workflow will continue working normally, but we recommend updating your workflow so that you can modify it without unexpected behavior.
 
 Steps under deprecated conditions will display with a warning symbol ⚠️ with the label "Go to [action name]". Click on the menu button `...` and select "Replace", and then select the replacement action from the sidebar. So, for example, if the deprecated step is labelled "Go to Set state", replace this step with "Set state" and choose the same configuration as the original step (which you should find further down within the same workflow).
 

--- a/console/workflow-create.mdx
+++ b/console/workflow-create.mdx
@@ -96,7 +96,7 @@ If your step conditions display a **This step contains deprecated conditions** w
 
 Steps under deprecated conditions will display with a warning symbol ⚠️ with the label "Go to [action name]". Click on the menu button `...` and select "Replace", and then select the replacement action from the sidebar. So, for example, if the deprecated step is labelled "Go to Set state", replace this step with "Set state" and choose the same configuration as the original step (which you should find further down within the same workflow).
 
-Once all deprecated steps are replaced, locate the the referenced action(s) and delete.
+Once all deprecated steps are replaced, locate the referenced action(s) and delete.
 </Accordion>
 </AccordionGroup>
 

--- a/console/workflow-create.mdx
+++ b/console/workflow-create.mdx
@@ -94,7 +94,7 @@ Any step that causes an error (`KO`) from which the job can't recover, and is no
 
 If your step conditions displays a **This step contains deprecated conditions** warning, your workflow will continue working normally, but we recommend updating your workflow so that you can modify it without unexpected behavior.
 
-Steps under deprecated conditions will display with a warning symbol ⚠️ with the label "Go to [action name]". Click on the menu button `...` and select "Replace", and then select the replacement action from the sidebar. So, for example, if the deprecated step is labelled "Go to Set State", replace this step with "Set State" and choose the same configuration as the original step (which you should find further down within the same workflow).
+Steps under deprecated conditions will display with a warning symbol ⚠️ with the label "Go to [action name]". Click on the menu button `...` and select "Replace", and then select the replacement action from the sidebar. So, for example, if the deprecated step is labelled "Go to Set state", replace this step with "Set state" and choose the same configuration as the original step (which you should find further down within the same workflow).
 
 Once all deprecated steps are replaced, locate the the referenced action(s) and delete.
 </Accordion>

--- a/get-started/pricing.mdx
+++ b/get-started/pricing.mdx
@@ -23,7 +23,7 @@ Pops are calculated based on a combination of the monthly documents you process 
 
 `Total Pops = (Docs Processed × Base Pop Cost) + (Document Actions × Action Pop Cost)`
 
-* Core actions such as Send Email or Generate PDF cost 1 pop.
+* Core actions such as Send email or Generate PDF cost 1 pop.
 * Format conversions such as Facturae, X-Rechnung, UBL or CII also costs 1 pop.
 * Each network or tax authority has a different price depending on complexity of operation and implementation: 
 		* TicketBAI, VERI\*FACTU or Peppol cost 2 pops.

--- a/get-started/quickstart.mdx
+++ b/get-started/quickstart.mdx
@@ -124,17 +124,17 @@ Now let's create your first workflow. We'll start with a simple workflow that ge
     Select the "PDF Invoice" template and click on **Load template**.
   </Step>
   <Step  title="Modify the workflow">
-    Let's add a step that sets the Document state to `Sent` after the PDF is generated. Click on the **+** button below the top right corner and select **Set State** in the right sidebar.
+    Let's add a step that sets the Document state to `Sent` after the PDF is generated. Click on the **+** button below the top right corner and select **Set state** in the right sidebar.
     <Frame>
       <img
-        alt= "Add Set State action"
+        alt= "Add Set state action"
         src="/assets/guides/start-add-step.gif"
         width="100%"
       />
     </Frame>
   </Step>
   <Step  title="Configure the step">
-    You should now see the configuration of the **Set State** step, otherwise click on the step you've just added. Select `Sent` in the **State** dropdown. 
+    You should now see the configuration of the **Set state** step, otherwise click on the step you've just added. Select `Sent` in the **State** dropdown. 
   </Step>
   <Step title="Save and Publish">
     Click on the **Save Draft** button save your draft workflow. Now click on **Publish** so you can start using it in your workspace.  

--- a/guides/ar-arca-invoices.mdx
+++ b/guides/ar-arca-invoices.mdx
@@ -38,10 +38,10 @@ Add a new workflow to your workspace for issuing invoices. You can start with th
 
     Configure the workflow with these steps:
 
-    1. **Set State** — Set to "Processing"
-    2. **Send to ARCA** — Submits the invoice to ARCA and receives authorization
+    1. **Set state** — Set to "Processing"
+    2. **Send invoice to ARCA** — Submits the invoice to ARCA and receives authorization
     3. **Generate PDF** — Creates a PDF with the ARCA authorization code (CAE) and QR code
-    4. **Set State** — Set to "Sent"
+    4. **Set state** — Set to "Sent"
 
     Add any additional steps you need, then save the workflow.
   </Tab>
@@ -60,11 +60,11 @@ Keep the `Workflow ID` at hand. You'll use it later.
     - Do not set `code` (Invopop will assign it during authorization)
 
     <Warning>
-      Do not sign your invoice before sending it to ARCA. The workflow assigns the invoice code and signs the document automatically during the **Send to ARCA** step.
+      Do not sign your invoice before sending it to ARCA. The workflow assigns the invoice code and signs the document automatically during the **Send invoice to ARCA** step.
     </Warning>
 
     <Info>
-      ARCA requires invoices to be numbered sequentially without gaps. Invopop assigns the invoice `code` during the **Send to ARCA** workflow step based on the last issued invoice number.
+      ARCA requires invoices to be numbered sequentially without gaps. Invopop assigns the invoice `code` during the **Send invoice to ARCA** workflow step based on the last issued invoice number.
     </Info>
 
     Choose the appropriate invoice type based on your tax classification and customer type:

--- a/guides/ar-arca-suppliers.mdx
+++ b/guides/ar-arca-suppliers.mdx
@@ -55,10 +55,10 @@ To issue invoices in Argentina through ARCA, each supplier must generate a digit
 
         The new workflow will need to perform the following steps:
 
-        1. **Set State** — select "Processing".
-        2. **Register supplier in ARCA** - will generate a unique URL and add it into a `url` key value within the `meta` property. Optionally, add a webhook or email step after this step to notify the supplier.
-        3. **Wait for ARCA authorization** - waits for the supplier to complete the registration process in the ARCA webpage.
-        4. **Set State** — select "Registered".
+        1. **Set state** — select "Processing".
+        2. **Register supplier with ARCA** - will generate a unique URL and add it into a `url` key value within the `meta` property. Optionally, add a webhook or email step after this step to notify the supplier.
+        3. **Wait for ARCA certificate upload** - waits for the supplier to complete the registration process in the ARCA webpage.
+        4. **Set state** — select "Registered".
 
         Add any additional steps you may need, and save the new workflow.
       </Tab>
@@ -130,7 +130,7 @@ The registration process is the same whether you're issuing invoices on behalf o
     </Frame>
 
     <Badge color="blue">Third-party companies</Badge><br />
-        To send the registration link to your customer, add a webhook step before **Wait for ARCA Authorization**.
+        To send the registration link to your customer, add a webhook step before **Wait for ARCA certificate upload**.
 
         The webhook payload includes the `siloEntryId`. Use the [Fetch an Entry endpoint](/api-ref/silo/entries/fetch-an-entry) to retrieve the full entry, including the `meta` object containing the registration link.
 

--- a/guides/br-dfe.mdx
+++ b/guides/br-dfe.mdx
@@ -136,7 +136,7 @@ Follow one of the methods below and ensure to **Save** and **Publish** the workf
 
       In [Console](https://console.invopop.com), create a new workflow and choose [Empty Party workflow](https://console.invopop.com/redirect/workflows/new?template=empty-party) as the base. Then name the workflow with a descriptive label such as "DF-e process supplier post-registration".
 
-      This worfkow is composed by a single step:
+      This workflow is composed of a single step:
 
       1. **Set state** - To `Registered`.
   </Tab>

--- a/guides/br-dfe.mdx
+++ b/guides/br-dfe.mdx
@@ -104,9 +104,9 @@ Follow one of the methods below and ensure to **Save** and **Publish** the workf
 
     The new workflow will need to perform three steps:
 
-    - **Sign the Envelope**
-    - **Register DF-e issuer (Brazil)**
-    - **Set State** - with configuration set to `Processing`.
+    - **Sign envelope**
+    - **Register supplier in Brazil**
+    - **Set state** - with configuration set to `Processing`.
 
     Add any additional steps you may need, and save the new workflow.
 
@@ -138,7 +138,7 @@ Follow one of the methods below and ensure to **Save** and **Publish** the workf
 
       This worfkow is composed by a single step:
 
-      1. **Set State** - To `Registered`.
+      1. **Set state** - To `Registered`.
   </Tab>
 </Tabs>
 
@@ -175,12 +175,12 @@ Follow one of the methods below and ensure to **Save** and **Publish** the workf
 
       The new workflow will need to perform these steps:
 
-      - **Set State** - to `Processing`.
-      - **Add Sequential Code** - with dynamic sequences and a name like "NFS-e".
-      - **Send NFS-e (Brazil)**.
-      - **Set State** - to `Sent`.
+      - **Set state** - to `Processing`.
+      - **Add sequential code** - with dynamic sequences and a name like "NFS-e".
+      - **Send NFS-e to Prefeitura**.
+      - **Set state** - to `Sent`.
 
-      Finally, in the Error Handling area, add the **Set State** action and select `Error`.
+      Finally, in the Error Handling area, add the **Set state** action and select `Error`.
 
       Add any additional steps you may need, and save the new workflow.
     </Tab>
@@ -212,12 +212,12 @@ Follow one of the methods below and ensure to **Save** and **Publish** the workf
 
       The new workflow will need to perform these steps:
 
-      - **Set State** - to `Processing`.
-      - **Add Sequential Code** - with dynamic sequences and a name like "NF-e".
-      - **Send NF-e (Brazil)**.
-      - **Set State** - to `Sent`.
+      - **Set state** - to `Processing`.
+      - **Add sequential code** - with dynamic sequences and a name like "NF-e".
+      - **Send NF-e to SEFAZ**.
+      - **Set state** - to `Sent`.
 
-      Finally, in the Error Handling area, add the **Set State** action and select `Error`.
+      Finally, in the Error Handling area, add the **Set state** action and select `Error`.
 
       Add any additional steps you may need, and save the new workflow.
     </Tab>
@@ -249,12 +249,12 @@ Follow one of the methods below and ensure to **Save** and **Publish** the workf
 
       The new workflow will need to perform these steps:
 
-      - **Set State** - to `Processing`.
-      - **Add Sequential Code** - with dynamic sequences and a name like "NFC-e".
-      - **Send NFC-e (Brazil)**.
-      - **Set State** - to `Sent`.
+      - **Set state** - to `Processing`.
+      - **Add sequential code** - with dynamic sequences and a name like "NFC-e".
+      - **Send NFC-e to SEFAZ**.
+      - **Set state** - to `Sent`.
 
-      Finally, in the Error Handling area, add the **Set State** action and select `Error`.
+      Finally, in the Error Handling area, add the **Set state** action and select `Error`.
 
       Add any additional steps you may need, and save the new workflow.
     </Tab>
@@ -286,11 +286,11 @@ Follow one of the methods below and ensure to **Save** and **Publish** the workf
 
       The new workflow will need to perform these steps:
 
-      - **Set State** - to `Processing`.
-      - **Cancel NFS-e**.
-      - **Set State** - to `Void`.
+      - **Set state** - to `Processing`.
+      - **Cancel NFS-e with Prefeitura**.
+      - **Set state** - to `Void`.
 
-      Finally, in the Error Handling area, add the **Set State** action and select `Error`.
+      Finally, in the Error Handling area, add the **Set state** action and select `Error`.
 
       Add any additional steps you may need, and save the new workflow.
     </Tab>
@@ -322,11 +322,11 @@ Follow one of the methods below and ensure to **Save** and **Publish** the workf
 
       The new workflow will need to perform these steps:
 
-      - **Set State** - to `Processing`.
-      - **Cancel NF-e**.
-      - **Set State** - to `Void`.
+      - **Set state** - to `Processing`.
+      - **Cancel NF-e with SEFAZ**.
+      - **Set state** - to `Void`.
 
-      Finally, in the Error Handling area, add the **Set State** action and select `Error`.
+      Finally, in the Error Handling area, add the **Set state** action and select `Error`.
 
       Add any additional steps you may need, and save the new workflow.
     </Tab>
@@ -358,11 +358,11 @@ Follow one of the methods below and ensure to **Save** and **Publish** the workf
 
       The new workflow will need to perform these steps:
 
-      - **Set State** - to `Processing`.
-      - **Cancel NFC-e**.
-      - **Set State** - to `Void`.
+      - **Set state** - to `Processing`.
+      - **Cancel NFC-e with SEFAZ**.
+      - **Set state** - to `Void`.
 
-      Finally, in the Error Handling area, add the **Set State** action and select `Error`.
+      Finally, in the Error Handling area, add the **Set state** action and select `Error`.
 
       Add any additional steps you may need, and save the new workflow.
     </Tab>

--- a/guides/chargebee.mdx
+++ b/guides/chargebee.mdx
@@ -72,7 +72,7 @@ This guide assumes that you already have a Chargebee site configured and using P
 
         In [Console](https://console.invopop.com), create a new workflow and choose [Empty Invoice workflow](https://console.invopop.com/redirect/workflows/new?template=empty-invoice) as the base. Then name the workflow with a descriptive label such as "Sync with Chargebee".
 
-        It's essential to add the **Import Chargebee document** step at the very beginning of the workflow to import the document. Also, be sure to add a **Update Chargebee** step at the end of the workflow to report back to Chargebee once the document has been processed.
+        It's essential to add the **Import document from Chargebee** step at the very beginning of the workflow to import the document. Also, be sure to add a **Update Chargebee** step at the end of the workflow to report back to Chargebee once the document has been processed.
       </Tab>
     </Tabs>
     <Tabs>
@@ -93,7 +93,7 @@ This guide assumes that you already have a Chargebee site configured and using P
 
         In [Console](https://console.invopop.com), create a new workflow and choose [Empty Invoice workflow](https://console.invopop.com/redirect/workflows/new?template=empty-invoice) as the base. Then name the workflow with a descriptive label such as "Sync with Chargebee".
 
-        It's essential to add the **Import Chargebee document** step at the very beginning of the workflow to import the document. Also, be sure to add a **Update Chargebee** step at the end of the workflow to report back to Chargebee once the document has been processed.
+        It's essential to add the **Import document from Chargebee** step at the very beginning of the workflow to import the document. Also, be sure to add a **Update Chargebee** step at the end of the workflow to report back to Chargebee once the document has been processed.
       </Tab>
     </Tabs>
   </Step>
@@ -205,7 +205,7 @@ Belgium uses the Peppol network for e-invoicing, which became mandatory in Janua
     </Note>
 
     <Note>
-      The **Lookup Participant ID** step automatically looks up your customer's Peppol participant ID from the Peppol network at the time the invoice is processed. If you have already set the `cf_gobl_customer_inbox_peppol` [custom field](/guides/chargebee#custom-fields-metadata) on your customers in Chargebee, Invopop will use that value directly and you can remove this step.
+      The **Lookup Peppol participant** step automatically looks up your customer's Peppol participant ID from the Peppol network at the time the invoice is processed. If you have already set the `cf_gobl_customer_inbox_peppol` [custom field](/guides/chargebee#custom-fields-metadata) on your customers in Chargebee, Invopop will use that value directly and you can remove this step.
     </Note>
     <PeppolExample />
   </Tab>
@@ -213,7 +213,7 @@ Belgium uses the Peppol network for e-invoicing, which became mandatory in Janua
 
 #### Participant ID lookup
 
-Belgium enforces a standard set of Peppol participant ID schemes, all derived from the customer's **BCE number** (Belgian company registration number). Since this number is typically available in Chargebee, the **Lookup Participant ID** step can automatically resolve the correct Peppol ID for each customer — no manual setup required in most cases.
+Belgium enforces a standard set of Peppol participant ID schemes, all derived from the customer's **BCE number** (Belgian company registration number). Since this number is typically available in Chargebee, the **Lookup Peppol participant** step can automatically resolve the correct Peppol ID for each customer — no manual setup required in most cases.
 
 If you want to specify a Peppol ID manually for a particular customer (or override the lookup result), you can do so with the following custom field:
 
@@ -225,7 +225,7 @@ If you want to specify a Peppol ID manually for a particular customer (or overri
 
 ### 🇩🇰 Denmark
 
-Denmark also uses the Peppol network and the same Peppol BIS Billing UBL format. However, unlike Belgium, Danish Peppol participant IDs come in a wide variety of schemes — GLN numbers, CVR numbers, and others — and they don't all derive from the VAT number. This makes automatic lookup unreliable, so **this workflow does not include a Lookup Participant ID step**. You will need to set the Peppol ID directly on each customer as a custom field.
+Denmark also uses the Peppol network and the same Peppol BIS Billing UBL format. However, unlike Belgium, Danish Peppol participant IDs come in a wide variety of schemes — GLN numbers, CVR numbers, and others — and they don't all derive from the VAT number. This makes automatic lookup unreliable, so **this workflow does not include a Lookup Peppol participant step**. You will need to set the Peppol ID directly on each customer as a custom field.
 
 If you do want to use automatic lookup for some customers, you can add the lookup step from the [generic Peppol template](/guides/peppol).
 
@@ -257,7 +257,7 @@ If you do want to use automatic lookup for some customers, you can add the looku
     </Note>
 
     <Note>
-      Unlike other Peppol countries, this template does not include a **Lookup Participant ID** step. Danish Peppol participant IDs can take a variety of formats — such as GLN numbers — that are difficult to resolve automatically from a VAT number alone. We recommend setting the `cf_gobl_customer_inbox_peppol` [custom field](/guides/chargebee#custom-fields-metadata) directly on each customer in Chargebee so that Invopop can use it without needing to perform a lookup.
+      Unlike other Peppol countries, this template does not include a **Lookup Peppol participant** step. Danish Peppol participant IDs can take a variety of formats — such as GLN numbers — that are difficult to resolve automatically from a VAT number alone. We recommend setting the `cf_gobl_customer_inbox_peppol` [custom field](/guides/chargebee#custom-fields-metadata) directly on each customer in Chargebee so that Invopop can use it without needing to perform a lookup.
     </Note>
 
     <Note>
@@ -396,7 +396,7 @@ Once a silo entry (invoice) has been created in Invopop, retriggering from Charg
 
 #### Error is downstream — data hasn't changed
 
-If the failure happened after the invoice was already signed (e.g. the Generate UBL or Send Peppol step failed) and nothing has changed in Chargebee, you can simply run the workflow again:
+If the failure happened after the invoice was already signed (e.g. the Generate UBL document or Send Peppol document step failed) and nothing has changed in Chargebee, you can simply run the workflow again:
 
 1. In the [Invopop console](https://console.invopop.com), navigate to the workflow that processed the invoice
 2. Find the last job for that invoice
@@ -406,7 +406,7 @@ The import step will detect that the invoice is already signed and skip the upda
 
 #### Data has changed in Chargebee — signature needs to be removed
 
-The **Import Chargebee document** step updates the invoice with fresh data from Chargebee each time it runs. However, if the invoice has already been signed, the import step will skip this update to preserve the signature. If you need the latest data from Chargebee to be pulled in — for example, because you updated a customer's custom fields, corrected an error, or the failure happened before or during signing — you must first remove the signature:
+The **Import document from Chargebee** step updates the invoice with fresh data from Chargebee each time it runs. However, if the invoice has already been signed, the import step will skip this update to preserve the signature. If you need the latest data from Chargebee to be pulled in — for example, because you updated a customer's custom fields, corrected an error, or the failure happened before or during signing — you must first remove the signature:
 
 1. In the [Invopop console](https://console.invopop.com), navigate to the silo entry for that invoice
 2. Click **Edit**, then **Save** — this removes the signature without altering the data

--- a/guides/chargebee.mdx
+++ b/guides/chargebee.mdx
@@ -93,7 +93,7 @@ This guide assumes that you already have a Chargebee site configured and using P
 
         In [Console](https://console.invopop.com), create a new workflow and choose [Empty Invoice workflow](https://console.invopop.com/redirect/workflows/new?template=empty-invoice) as the base. Then name the workflow with a descriptive label such as "Sync with Chargebee".
 
-        It's essential to add the **Import document from Chargebee** step at the very beginning of the workflow to import the document. Also, be sure to add a **Update Chargebee** step at the end of the workflow to report back to Chargebee once the document has been processed.
+        It's essential to add the **Import document from Chargebee** step at the very beginning of the workflow to import the document. Also, be sure to add an **Update Chargebee** step at the end of the workflow to report back to Chargebee once the document has been processed.
       </Tab>
     </Tabs>
   </Step>

--- a/guides/chargebee.mdx
+++ b/guides/chargebee.mdx
@@ -72,7 +72,7 @@ This guide assumes that you already have a Chargebee site configured and using P
 
         In [Console](https://console.invopop.com), create a new workflow and choose [Empty Invoice workflow](https://console.invopop.com/redirect/workflows/new?template=empty-invoice) as the base. Then name the workflow with a descriptive label such as "Sync with Chargebee".
 
-        It's essential to add the **Import document from Chargebee** step at the very beginning of the workflow to import the document. Also, be sure to add a **Update Chargebee** step at the end of the workflow to report back to Chargebee once the document has been processed.
+        It's essential to add the **Import document from Chargebee** step at the very beginning of the workflow to import the document. Also, be sure to add an **Update Chargebee** step at the end of the workflow to report back to Chargebee once the document has been processed.
       </Tab>
     </Tabs>
     <Tabs>

--- a/guides/co-dian.mdx
+++ b/guides/co-dian.mdx
@@ -126,14 +126,14 @@ You can invoice using the Plemsi provider on behalf of multiple suppliers. For e
       <Tab title="Build from scratch">
         In [Console](https://console.invopop.com) create a new workflow and select [Empty Invoice workflow](https://console.invopop.com/redirect/workflows/new?template=empty-invoice) in the template selector, then add the following steps:
 
-          1. **Set State** - Select `Processing`. This initial state marks the document as being processed.
-          2. **Add Sequential Code** - Use a `Dynamic` series which will allow you to use the same workflow for both invoices and credit notes. Make sure to configure it according to the parameters of the authorised numbering range. Generally, you'll want to set the padding to 1 (so no zeros are prepended) and put no prefix or suffix.
-          3. **Sign Envelope** - The envelope must be signed before processing.
-          4. **Send to DIAN via Plemsi (Colombia)** - No configuration required.
+          1. **Set state** - Select `Processing`. This initial state marks the document as being processed.
+          2. **Add sequential code** - Use a `Dynamic` series which will allow you to use the same workflow for both invoices and credit notes. Make sure to configure it according to the parameters of the authorised numbering range. Generally, you'll want to set the padding to 1 (so no zeros are prepended) and put no prefix or suffix.
+          3. **Sign envelope** - The envelope must be signed before processing.
+          4. **Send invoice to DIAN** - No configuration required.
           5. **Generate PDF** - Select `es-Spanish` as the Locale and layout `Letter`.
-          6. **Set State** - Select `Sent`.
+          6. **Set state** - Select `Sent`.
 
-          Finally, in the Error Handling area, add the **Set State** action and select `Error`.
+          Finally, in the Error Handling area, add the **Set state** action and select `Error`.
 
           This is the minimal workflow you can use to issue invoices in Colombia. You can now add other optional integrations to, for example, send an email with the invoice, notify another system with a webhook or upload the invoices to a Dropbox account.
       </Tab>

--- a/guides/de-ubl.mdx
+++ b/guides/de-ubl.mdx
@@ -83,12 +83,12 @@ To issue XRechnung or ZUGFeRD invoices, follow these instructions in the [Invopo
 
         In [Console](https://console.invopop.com) create a new workflow and select [Empty Invoice workflow](https://console.invopop.com/redirect/workflows/new?template=empty-invoice) in the template selector, then add the essential steps:
 
-        1. **Set State** - Select `Processing`
-        2. **Sign Envelope**: The envelope must be signed before processing.
-        3. **Generate UBL Document**: In "Invoice Output Document Type" select `XRechnung UBL Invoice v2.0`. It's also possible to use the **Generate UN/CEFACT CII Invoice** step selecting `XRechnung V3` as both UBL and CII are valid formats for XRechnung.
-        4. **Set State** - Select `Sent`.
+        1. **Set state** - Select `Processing`
+        2. **Sign envelope**: The envelope must be signed before processing.
+        3. **Generate UBL document**: In "Invoice Output Document Type" select `XRechnung UBL Invoice v2.0`. It's also possible to use the **Generate CII document** step selecting `XRechnung V3` as both UBL and CII are valid formats for XRechnung.
+        4. **Set state** - Select `Sent`.
 
-        Finally, in the "Error Handling" area, add **Set State** and select `Error`.
+        Finally, in the "Error Handling" area, add **Set state** and select `Error`.
       </Tab>
     </Tabs>
 
@@ -124,13 +124,13 @@ To issue XRechnung or ZUGFeRD invoices, follow these instructions in the [Invopo
 
         In [Console](https://console.invopop.com) create a new workflow and select [Empty Invoice workflow](https://console.invopop.com/redirect/workflows/new?template=empty-invoice) in the template selector, then add the essential steps:
 
-        1. **Set State** - Select `Processing`
-        2. **Sign Envelope**: The envelope must be signed before processing.
-        3. **Generate UN/CEFACT CII Invoice**: In "Invoice Output Document Type" select `ZUGFeRD v2`.
+        1. **Set state** - Select `Processing`
+        2. **Sign envelope**: The envelope must be signed before processing.
+        3. **Generate CII document**: In "Invoice Output Document Type" select `ZUGFeRD v2`.
         4. **Generate PDF**: this step creates the PDF with the embedded XML.
-        5. **Set State** - Select `Sent`.
+        5. **Set state** - Select `Sent`.
 
-        Finally, in the "Error Handling" area, add **Set State** and select `Error`.
+        Finally, in the "Error Handling" area, add **Set state** and select `Error`.
       </Tab>
     </Tabs>
 

--- a/guides/email.mdx
+++ b/guides/email.mdx
@@ -50,7 +50,7 @@ You can add as many senders as you need by tapping on the `Add` button. Email pr
 
 <Step title="Set up your workflow">
 
-Whether you start from an existing or new workflow, make sure that you add the `Send Email` step after you have issued an invoice via the corresponding tax authority and generated a PDF (if required). This will ensure the necessary files are attached, and that the invoice complies with local regulatory requirements.
+Whether you start from an existing or new workflow, make sure that you add the `Send email` step after you have issued an invoice via the corresponding tax authority and generated a PDF (if required). This will ensure the necessary files are attached, and that the invoice complies with local regulatory requirements.
 
 <img src="https://assets.invopop.com/docs/email/email-screen2.png" width="100%" alt="Workflow with email actions" />
 
@@ -65,7 +65,7 @@ If you simply want to send a `Notification via Email`, this suggestion does not 
 
 The Email app adds two items to your workflow action list:
 
-1. **Send Email**: this action will attach the files associated with a silo entry, and is mainly used for sending invoices to customers or other recipients.
+1. **Send email**: this action will attach the files associated with a silo entry, and is mainly used for sending invoices to customers or other recipients.
 2. **Notify via Email**: this action will _not_ attach files, and is meant for sending messages such as notifications or failures.
 
 ## Workflow step configuration

--- a/guides/es-facturae.mdx
+++ b/guides/es-facturae.mdx
@@ -53,8 +53,8 @@ No additional configuration is needed.
 
     In [Console](https://console.invopop.com) create a new workflow and select [Empty Invoice workflow](https://console.invopop.com/redirect/workflows/new?template=empty-invoice) in the template selector, then add the essential steps:
 
-    1. **Add Sequential Code**: Assigns a sequential code to the invoice.
-    2. **Sign Envelope**: The envelope must be signed before processing.
+    1. **Add sequential code**: Assigns a sequential code to the invoice.
+    2. **Sign envelope**: The envelope must be signed before processing.
     3. **Generate Facturae XML**: Produces the Facturae 3.2.2 XML document.
   </Tab>
 </Tabs>

--- a/guides/es-lookup.mdx
+++ b/guides/es-lookup.mdx
@@ -26,23 +26,23 @@ Enable the Spain app to use AEAT verification:
 After connecting, you’ll see Spain listed under Enabled Apps. Two workflow steps will become available:
 
 * [Verify Tax IDs (NIF/CIF)](#verify-tax-ids-nif%2Fcif)
-* [Verify & Correct Tax Details](#verify-%26-correct-tax-details)
+* [Verify & correct tax details](#verify-%26-correct-tax-details)
 
 ## Verify Tax IDs (NIF/CIF)
 
-You can add the **Verify Spanish Tax ID (NIF/CIF)** step to your `invoice` or `party` workflows.
+You can add the **Verify Spanish Tax ID** step to your `invoice` or `party` workflows.
 
 In invoice workflows, it evaluates supplier and customer by default. You can configure this in the step:
 
-<Frame caption="Configure the Verify Spanish Tax ID (NIF/CIF) step for invoices">
+<Frame caption="Configure the Verify Spanish Tax ID step for invoices">
   <img
     width="600"
     src="/assets/guides/es-lookup-config.png"
-    alt="Configure the Verify Spanish Tax ID (NIF/CIF) step for invoices"
+    alt="Configure the Verify Spanish Tax ID step for invoices"
   />
 </Frame>
 
-For companies, the "Verify Spanish Tax ID (NIF/CIF)" step confirms the tax ID exists in the AEAT census. For individuals, the step additionally confirms that the tax id matches the person’s full name.
+For companies, the "Verify Spanish Tax ID" step confirms the tax ID exists in the AEAT census. For individuals, the step additionally confirms that the tax id matches the person’s full name.
 
 The following outcomes are possible:
 
@@ -59,7 +59,7 @@ The following outcomes are possible:
       <img
         width="600"
         src="/assets/guides/es-lookup-verify-invoice-wf.png"
-        alt="Example of an invoice workflow using Verify Spanish Tax ID (NIF/CIF)"
+        alt="Example of an invoice workflow using Verify Spanish Tax ID"
       />
     </Frame>
   </Tab>
@@ -68,7 +68,7 @@ The following outcomes are possible:
       <img
         width="600"
         src="/assets/guides/es-lookup-verify-party-wf.png"
-        alt="Example of a party workflow using Verify Spanish Tax ID (NIF/CIF)"
+        alt="Example of a party workflow using Verify Spanish Tax ID"
       />
     </Frame>
   </Tab>
@@ -76,17 +76,17 @@ The following outcomes are possible:
 
 
 
-## Verify & Correct Tax Details
+## Verify & correct tax details
 
 This step both verifies the tax ID and normalizes names with AEAT data. If the party is a company, the entry will be updated with the official company name in the AEAT census. In the case of individuals, a name is still required for matching, but the step updates the name to the AEAT-returned format. Example: for “Pablo Martínez Gutiérrez,” AEAT may return `MARTINEZ GUTIERREZ PABLO`.
 
 Use this when you want the system to automatically update the `invoice` or `party` entry with the normalized name. The workflow usage is identical to the verification-only step; the difference is that this step also writes the corrected values.
 
-<Frame caption="Verify & Correct step">
+<Frame caption="Verify & correct tax details step">
   <img
     width="600"
     src="/assets/guides/es-lookup-verify-correct.png"
-    alt="Verify & Correct step"
+    alt="Verify & correct tax details step"
   />
 </Frame>
 

--- a/guides/es-noverifactu-supplier.mdx
+++ b/guides/es-noverifactu-supplier.mdx
@@ -58,13 +58,13 @@ NO VERI\*FACTU supplier registration does not require an agreement signing proce
 
         The new workflow will need the following steps:
 
-        1. **Set State** — select "Processing".
-        2. **Sign Envelope** — signs the GOBL envelope.
+        1. **Set state** — select "Processing".
+        2. **Sign envelope** — signs the GOBL envelope.
         3. **Generate Event Record** — generates and digitally signs the event XML from the `bill.Status` document.
         4. **Store Record** — persists the signed event record in the database.
-        5. **Set State** — select "Registered".
+        5. **Set state** — select "Registered".
 
-        In the Error Handling area, add the **Set State** action and select `Error`.
+        In the Error Handling area, add the **Set state** action and select `Error`.
       </Tab>
     </Tabs>
   </Step>
@@ -93,7 +93,7 @@ NO VERI\*FACTU supplier registration does not require an agreement signing proce
         1. **Build Summary Event** — configured with event type `10` ("Summary event"). Aggregates invoicing and event record counts, tax totals, and references for the period since the last summary.
         2. **Process Event** — creates a job to process the summary event. Set the **Workflow** field to the **NO VERI\*FACTU event processing** workflow created in the previous step.
 
-        In the Error Handling section, add the **Set State** action and select `Error`.
+        In the Error Handling section, add the **Set state** action and select `Error`.
       </Tab>
     </Tabs>
 
@@ -125,17 +125,17 @@ NO VERI\*FACTU supplier registration does not require an agreement signing proce
 
         The new workflow will need to perform the following steps:
 
-        1. **Set State** — select "Processing".
+        1. **Set state** — select "Processing".
         2. **Register supplier** — registers the supplier for NO VERI\*FACTU mode. Registration is immediate (auto-approved).
         3. **Build Start Event** — configured with event type `01` ("Start of NO VERI\*FACTU mode"). Builds a `bill.Status` document and uploads it as a silo entry.
         4. **Process Event** — creates a job to process the event. Set the **Workflow** field to the **NO VERI\*FACTU event processing** workflow.
         5. **Subscribe to summary event cron** — uses the [Cron app](/apps/cron) to subscribe the supplier to periodic execution every 6 hours. Set the **Workflow** field to the **NO VERI\*FACTU summary event** workflow.
-        6. **Set State** — select "Registered".
+        6. **Set state** — select "Registered".
 
         In the Error Handling area, add the following steps:
 
         1. **Unregister supplier** — clears the registration.
-        2. **Set State** — select `Rejected`.
+        2. **Set state** — select `Rejected`.
       </Tab>
     </Tabs>
   </Step>
@@ -161,14 +161,14 @@ NO VERI\*FACTU supplier registration does not require an agreement signing proce
       <Tab title="Build from scratch">
         In [Console](https://console.invopop.com) create a new workflow and select [Empty Party workflow](https://console.invopop.com/redirect/workflows/new?template=empty-party) in the template selector, then add the following steps:
 
-        1. **Set State** — select "Processing".
+        1. **Set state** — select "Processing".
         2. **Unsubscribe from summary event cron** — uses the [Cron app](/apps/cron) to remove the periodic summary event subscription for this supplier.
         3. **Unregister supplier** — clears the NO VERI\*FACTU registration state.
         4. **Build End Event** — configured with event type `02` ("End of NO VERI\*FACTU mode"). Builds a `bill.Status` document and uploads it as a silo entry.
         5. **Process Event** — creates a job to process the event. Set the **Workflow** field to the **NO VERI\*FACTU event processing** workflow.
-        6. **Set State** — select `Void`.
+        6. **Set state** — select `Void`.
 
-        In the Error Handling section, add the **Set State** action and select `Error`.
+        In the Error Handling section, add the **Set state** action and select `Error`.
       </Tab>
     </Tabs>
   </Step>

--- a/guides/es-noverifactu.mdx
+++ b/guides/es-noverifactu.mdx
@@ -56,14 +56,14 @@ Add a new workflow to your workspace for issuing invoices. You can start with th
   <Tab title="Build from scratch">
     In [Console](https://console.invopop.com) create a new workflow and select [Empty Invoice workflow](https://console.invopop.com/redirect/workflows/new?template=empty-invoice) in the template selector, then add the following steps:
 
-    1. **Set State** — select "Processing".
-    2. **Sign Envelope** — Signs the GOBL envelope.
+    1. **Set state** — select "Processing".
+    2. **Sign envelope** — Signs the GOBL envelope.
     3. **Generate Invoice Record** — Generates the XML record from the GOBL invoice and digitally signs it using XAdES Enveloped Signature.
     4. **Store Record** — Persists the signed record in the database for regulatory compliance.
     5. **Generate PDF** — Creates the PDF invoice with the required QR code.
-    6. **Set State** — select "Registered".
+    6. **Set state** — select "Registered".
 
-    In the Error Handling section, add the **Set State** action and select `Error`.
+    In the Error Handling section, add the **Set state** action and select `Error`.
 
   </Tab>
 </Tabs>
@@ -247,12 +247,12 @@ In general, you should only cancel an invoice if it hasn't been handed to the cu
 
         We recommend adding the following steps:
 
-        1. **Set State** — select "Processing".
+        1. **Set state** — select "Processing".
         2. **Generate Cancellation Record** — Generates and signs the cancellation XML record.
         3. **Store Record** — Persists the signed cancellation record.
-        4. **Set State** — select _Void_ in the step configuration.
+        4. **Set state** — select _Void_ in the step configuration.
 
-        In the Error Handling area, **Set State** — select `Error`.
+        In the Error Handling area, **Set state** — select `Error`.
       </Tab>
     </Tabs>
   </Step>

--- a/guides/es-sii-supplier.mdx
+++ b/guides/es-sii-supplier.mdx
@@ -69,15 +69,15 @@ This guide will...
         The new workflow will need to perform the following steps:
 
         1. **Register supplier** - will generate a unique URL and add it into a `url` key value within the `meta` property. You would add a webhook after this step to notify the supplier.
-        2. **Set State** — select "Processing".
+        2. **Set state** — select "Processing".
         3. **Wait for supplier registration** - waits for the supplier to upload the required documents (signed agreement and ID). The supplier will be entitled to issue invoices through SII immediately after the documents are uploaded.
-        4. **Set State** — select "Registered".
+        4. **Set state** — select "Registered".
         5. **Wait for supplier approval** - In live environments, Invopop will review the documents provided by the supplier in less than 72 hours. In sandbox, you can configure the workflow step to accept or reject providers. Open rejection the workflow will error with a `KO` and the reason for rejection can be reviewed in the Supplier or in the executed job. The supplier's invoice issuing entitlement will be revoked immediately.
-        6. **Set State** — select "Registered"
+        6. **Set state** — select "Registered"
 
         Finally, in the Error Handling area, add the following steps:
 
-        1. **Set State** — select `Rejected`.
+        1. **Set state** — select `Rejected`.
         2. **Unregister supplier** - will clear the registration attempt allowing you to re-register them later.
 
         Add any additional steps you may need, and save the new workflow.
@@ -193,17 +193,17 @@ The process is best explained looking at the workflow steps:
     </Frame>
 
     1. **Register supplier** will generate a unique URL and add it into a `url` key value within the `meta` property. You would add a webhook after this step to notify the supplier.
-    2. **Set State to Processing** labels the silo entry so you know it's in process of registration.
+    2. **Set state to Processing** labels the silo entry so you know it's in process of registration.
     3. **Wait for supplier registration** waits for the supplier to upload the required documents (signed agreement and ID). The supplier will be entitled to issue invoices through SII immediately after the documents are uploaded.
-    4. **Set State to Registered** labels the silo entry so you know registration is complete.
+    4. **Set state to Registered** labels the silo entry so you know registration is complete.
     5. **Wait for supplier approval** In live environments, Invopop will review the documents provided by the supplier in less than 72 hours. In sandbox, you can configure the workflow step to accept or reject providers. Open rejection the workflow will error with a `KO` and the reason for rejection can be reviewed in the Supplier or in the executed job. The supplier's invoice issuing entitlement will be revoked immediately.
 
     <Note>In sandbox "Wait for supplier approval" can be configured to accept or reject suppliers.</Note>
 
     **Error flow:** if the supplier's documentation is rejected, or the supplier does not complete the registration within the job's time limit (100 days) a `KO` will be generated, triggering the error flow. Then these steps will be run:
 
-    1. **Unregister SII** will clean up all registration processes and entitlements. You will be able to re-register the party later.
-    2. **Set State to Rejected** labels the silo entry so you know the registration was rejected (due to timeout or incorrect documentation).
+    1. **Unregister supplier with SII** will clean up all registration processes and entitlements. You will be able to re-register the party later.
+    2. **Set state to Rejected** labels the silo entry so you know the registration was rejected (due to timeout or incorrect documentation).
 
 
 ## Register a Supplier
@@ -379,9 +379,9 @@ Unregistering a supplier is essentially revoking their invoice issuing privilege
         In [Console](https://console.invopop.com) create a new workflow and select [Empty Party workflow](https://console.invopop.com/redirect/workflows/new?template=empty-party) in the template selector, then add the following steps:
 
         1. **Unregister supplier** - Revokes invoice issuing authorization by the AEAT.
-        2. **Set State** - Select `void` to label the supplier accordingly.
+        2. **Set state** - Select `void` to label the supplier accordingly.
 
-        In the Error Handling section, add the **Set State** action and select `Error`.
+        In the Error Handling section, add the **Set state** action and select `Error`.
 
       </Tab>
     </Tabs>

--- a/guides/es-sii.mdx
+++ b/guides/es-sii.mdx
@@ -47,14 +47,14 @@ Add a new workflow to your workspace to issue invoices. You can start with the t
   <Tab title="Build from scratch">
     In [Console](https://console.invopop.com) create a new workflow and select [Empty Invoice workflow](https://console.invopop.com/redirect/workflows/new?template=empty-invoice) in the template selector, then add the following steps:
 
-    1. **Set State** - Select `Processing`. This initial state marks the document as being processed.
-    2. **Add Sequential Code** - Use a `Dynamic` series with a name like "SII".
-    3. **Sign Envelope** - Signs the document.
+    1. **Set state** - Select `Processing`. This initial state marks the document as being processed.
+    2. **Add sequential code** - Use a `Dynamic` series with a name like "SII".
+    3. **Sign envelope** - Signs the document.
     4. **Record issued invoice in SII** - Records the issued invoice in SII.
     5. **Generate PDF** - Creates the PDF invoice with the required QR code.
-    6. **Set State** - Select `Sent`. This final state marks the document as being sent.
+    6. **Set state** - Select `Sent`. This final state marks the document as being sent.
 
-    In the Error Handling section, add the **Set State** action and select `Error`.
+    In the Error Handling section, add the **Set state** action and select `Error`.
 
   </Tab>
 </Tabs>
@@ -75,14 +75,14 @@ You can also add a new workflow to your workspace to record received invoices, i
   <Tab title="Build from scratch">
     In [Console](https://console.invopop.com) create a new workflow and select [Empty Invoice workflow](https://console.invopop.com/redirect/workflows/new?template=empty-invoice) in the template selector, then add the following steps:
 
-    1. **Set State** - Select `Processing`. This initial state marks the document as being processed.
-    2. **Add Sequential Code** - Use a `Dynamic` series with a name like "SII".
-    3. **Sign Envelope** - Signs the document.
+    1. **Set state** - Select `Processing`. This initial state marks the document as being processed.
+    2. **Add sequential code** - Use a `Dynamic` series with a name like "SII".
+    3. **Sign envelope** - Signs the document.
     4. **Record received invoice in SII** - Records the received invoice in SII.
     5. **Generate PDF** - Creates the PDF invoice with the required QR code.
-    6. **Set State** - Select `Sent`. This final state marks the document as being sent.
+    6. **Set state** - Select `Sent`. This final state marks the document as being sent.
 
-    In the Error Handling section, add the **Set State** action and select `Error`.
+    In the Error Handling section, add the **Set state** action and select `Error`.
 
   </Tab>
 </Tabs>
@@ -304,8 +304,8 @@ Different from a credit note or a corrective, canceling an invoice doesn't produ
         We recommend adding the following steps:
 
         1. **Cancel invoice** - Cancels the SII document.
-        2. **Set State** - select _Void_ in the step configuration. This will set the state of the invoice to `Void`.
-        3. In the Error Handling area, **Set State** - select `Error` in the step configuration.
+        2. **Set state** - select _Void_ in the step configuration. This will set the state of the invoice to `Void`.
+        3. In the Error Handling area, **Set state** - select `Error` in the step configuration.
 
         Add any additional steps you may need, and save the new workflow.
       </Tab>

--- a/guides/es-ticketbai-supplier.mdx
+++ b/guides/es-ticketbai-supplier.mdx
@@ -62,15 +62,15 @@ This guide will...
         The new workflow will need to perform the following steps:
 
         1. **Register supplier** - will generate a unique URL and add it into a `url` key value within the `meta` property. You would add a webhook after this step to notify the supplier.
-        2. **Set State** — select "Processing".
+        2. **Set state** — select "Processing".
         3. **Wait for supplier registration** - waits for the supplier to upload the required documents (signed agreement and ID). The supplier will be entitled to issue invoices through TicketBAI immediately after the documents are uploaded.
-        4. **Set State** — select "Registered".
+        4. **Set state** — select "Registered".
         5. **Wait for supplier approval** - In live environments, Invopop will review the documents provided by the supplier in less than 72 hours. In sandbox, you can configure the workflow step to accept or reject providers. Open rejection the workflow will error with a `KO` and the reason for rejection can be reviewed in the Supplier or in the executed job. The supplier's invoice issuing entitlement will be revoked immediately.
-        6. **Set State** — select "Registered"
+        6. **Set state** — select "Registered"
 
         Finally, in the Error Handling area, add the following steps:
 
-        1. **Set State** — select `Rejected`.
+        1. **Set state** — select `Rejected`.
         2. **Unregister supplier** - will clear the registration attempt allowing you to re-register them later.
 
         Add any additional steps you may need, and save the new workflow.
@@ -189,17 +189,17 @@ The process is best explained looking at the workflow steps:
     </Frame>
 
     1. **Register supplier** will generate a unique URL and add it into a `url` key value within the `meta` property. You would add a webhook after this step to notify the supplier.
-    2. **Set State to Processing** labels the silo entry so you know it's in process of registration.
+    2. **Set state to Processing** labels the silo entry so you know it's in process of registration.
     3. **Wait for supplier registration** waits for the supplier to upload the required documents (signed agreement and ID). The supplier will be entitled to issue invoices through TicketBAI immediately after the documents are uploaded.
-    4. **Set State to Registered** labels the silo entry so you know registration is complete.
+    4. **Set state to Registered** labels the silo entry so you know registration is complete.
     5. **Wait for supplier approval** In live environments, Invopop will review the documents provided by the supplier in less than 72 hours. In sandbox, you can configure the workflow step to accept or reject providers. Open rejection the workflow will error with a `KO` and the reason for rejection can be reviewed in the Supplier or in the executed job. The supplier's invoice issuing entitlement will be revoked immediately.
 
     <Note>In sandbox "Wait for supplier approval" can be configured to accept or reject suppliers.</Note>
 
       **Error flow:** if the supplier's documentation is rejected, or the supplier does not complete the registration within the job's time limit (100 days) a `KO` will be generated, triggering the error flow. Then these steps will be run:
 
-    1. **Unregister TicketBAI** will clean up all registration processes and entitlements. You will be able to re-register the party later.
-    2. **Set State to Rejected** labels the silo entry so you know the registration was rejected (due to timeout or incorrect documentation).
+    1. **Unregister supplier with TicketBAI** will clean up all registration processes and entitlements. You will be able to re-register the party later.
+    2. **Set state to Rejected** labels the silo entry so you know the registration was rejected (due to timeout or incorrect documentation).
 
 
 
@@ -358,9 +358,9 @@ Unregistering a supplier is essentially revoking their invoice issuing privilege
         In [Console](https://console.invopop.com) create a new workflow and select [Empty Party workflow](https://console.invopop.com/redirect/workflows/new?template=empty-party) in the template selector, then add the following steps:
 
         1. **Unregister supplier** - Revokes invoice issuing authorization by the corresponding Basque tax authority.
-        2. **Set State** - Select `void` to label the supplier accordingly.
+        2. **Set state** - Select `void` to label the supplier accordingly.
 
-        In the Error Handling section, add the **Set State** action and select `Error`.
+        In the Error Handling section, add the **Set state** action and select `Error`.
 
       </Tab>
     </Tabs>

--- a/guides/es-ticketbai.mdx
+++ b/guides/es-ticketbai.mdx
@@ -84,20 +84,20 @@ No further configuration is required.
 
         The new workflow will need to perform these steps:
 
-        - **Add Sequential Code** - chose the "dynamic" sequence option and set a name.
-        - **Set State** - to "Processing".
-        - **Sign Envelope** - this step signs the TicketBAI document, preventing further modifications.
-        - **Generate TicketBAI (Spain)** - this step generates the TicketBAI XML document.
-        - **Send TicketBAI (Spain)** - will take the previously generate XML document, and send to the appropriate gateway.
+        - **Add sequential code** - chose the "dynamic" sequence option and set a name.
+        - **Set state** - to "Processing".
+        - **Sign envelope** - this step signs the TicketBAI document, preventing further modifications.
+        - **Generate TicketBAI XML** - this step generates the TicketBAI XML document.
+        - **Send invoice to TicketBAI** - will take the previously generate XML document, and send to the appropriate gateway.
         - **Generate PDF** - configure as required, the PDF will use the QR code generated in the previous step. After this step, you may want to add a webhook or similar.
-        - **Set State** - to "Sent".
+        - **Set state** - to "Sent".
 
 
-        Finally, in the Error Handling area, add the **Set State** action and select `Error`.
+        Finally, in the Error Handling area, add the **Set state** action and select `Error`.
 
         Add any additional steps you may need, and save the new workflow.
         <Tip>
-          Invoices must be signed before processing with TicketBAI, be sure to add the _Sign Envelope_ step.
+          Invoices must be signed before processing with TicketBAI, be sure to add the _Sign envelope_ step.
         </Tip>
 
       </Tab>
@@ -106,7 +106,7 @@ No further configuration is required.
     <Warning>
       If in the unlikely scenario a document is rejected, you will need to try and
       correct the error inside a new document and resend. As documents are all
-      chained together in the _Generate TicketBAI_ step, modifications are not
+      chained together in the _Generate TicketBAI XML_ step, modifications are not
       permitted.
     </Warning>
 
@@ -244,8 +244,8 @@ Different from a credit note or a corrective, canceling an invoice doesn't produ
         We recommend adding the following steps:
 
         1. **Cancel invoice** - Cancels the TicketBAI document.
-        2. **Set State** - select _Void_ in the step configuration. This will set the state of the invoice to `Void`.
-        3. In the Error Handling area, **Set State** - select `Error` in the step configuration.
+        2. **Set state** - select _Void_ in the step configuration. This will set the state of the invoice to `Void`.
+        3. In the Error Handling area, **Set state** - select `Error` in the step configuration.
 
         Add any additional steps you may need, and save the new workflow.
       </Tab>

--- a/guides/es-ticketbai.mdx
+++ b/guides/es-ticketbai.mdx
@@ -84,11 +84,11 @@ No further configuration is required.
 
         The new workflow will need to perform these steps:
 
-        - **Add sequential code** - chose the "dynamic" sequence option and set a name.
+        - **Add sequential code** - choose the "dynamic" sequence option and set a name.
         - **Set state** - to "Processing".
         - **Sign envelope** - this step signs the TicketBAI document, preventing further modifications.
         - **Generate TicketBAI XML** - this step generates the TicketBAI XML document.
-        - **Send invoice to TicketBAI** - will take the previously generate XML document, and send to the appropriate gateway.
+        - **Send invoice to TicketBAI** - will take the previously generated XML document, and send to the appropriate gateway.
         - **Generate PDF** - configure as required, the PDF will use the QR code generated in the previous step. After this step, you may want to add a webhook or similar.
         - **Set state** - to "Sent".
 

--- a/guides/es-verifactu-supplier.mdx
+++ b/guides/es-verifactu-supplier.mdx
@@ -69,15 +69,15 @@ This guide will...
         The new workflow will need to perform the following steps:
 
         1. **Register supplier** - will generate a unique URL and add it into a `url` key value within the `meta` property. You would add a webhook after this step to notify the supplier.
-        2. **Set State** — select "Processing".
+        2. **Set state** — select "Processing".
         3. **Wait for supplier registration** - waits for the supplier to upload the required documents (signed agreement and ID). The supplier will be entitled to issue invoices through VERI\*FACTU immediately after the documents are uploaded.
-        4. **Set State** — select "Registered".
+        4. **Set state** — select "Registered".
         5. **Wait for supplier approval** - In live environments, Invopop will review the documents provided by the supplier in less than 72 hours. In sandbox, you can configure the workflow step to accept or reject providers. Open rejection the workflow will error with a `KO` and the reason for rejection can be reviewed in the Supplier or in the executed job. The supplier's invoice issuing entitlement will be revoked immediately.
-        6. **Set State** — select "Registered"
+        6. **Set state** — select "Registered"
 
         Finally, in the Error Handling area, add the following steps:
 
-        1. **Set State** — select `Rejected`.
+        1. **Set state** — select `Rejected`.
         2. **Unregister supplier** - will clear the registration attempt allowing you to re-register them later.
 
         Add any additional steps you may need, and save the new workflow.
@@ -196,17 +196,17 @@ The process is best explained looking at the workflow steps:
     </Frame>
 
     1. **Register supplier** will generate a unique URL and add it into a `url` key value within the `meta` property. You would add a webhook after this step to notify the supplier.
-    2. **Set State to Processing** labels the silo entry so you know it's in process of registration.
+    2. **Set state to Processing** labels the silo entry so you know it's in process of registration.
     3. **Wait for supplier registration** waits for the supplier to upload the required documents (signed agreement and ID). The supplier will be entitled to issue invoices through VERI\*FACTU immediately after the documents are uploaded.
-    4. **Set State to Registered** labels the silo entry so you know registration is complete.
+    4. **Set state to Registered** labels the silo entry so you know registration is complete.
     5. **Wait for supplier approval** In live environments, Invopop will review the documents provided by the supplier in less than 72 hours. In sandbox, you can configure the workflow step to accept or reject providers. Open rejection the workflow will error with a `KO` and the reason for rejection can be reviewed in the Supplier or in the executed job. The supplier's invoice issuing entitlement will be revoked immediately.
 
     <Note>In sandbox "Wait for supplier approval" can be configured to accept or reject suppliers.</Note>
 
       **Error flow:** if the supplier's documentation is rejected, or the supplier does not complete the registration within the job's time limit (100 days) a `KO` will be generated, triggering the error flow. Then these steps will be run:
 
-    1. **Unregister VERI\*FACTU** will clean up all registration processes and entitlements. You will be able to re-register the party later.
-    2. **Set State to Rejected** labels the silo entry so you know the registration was rejected (due to timeout or incorrect documentation).
+    1. **Unregister supplier from VERI\*FACTU** will clean up all registration processes and entitlements. You will be able to re-register the party later.
+    2. **Set state to Rejected** labels the silo entry so you know the registration was rejected (due to timeout or incorrect documentation).
 
 
 
@@ -388,9 +388,9 @@ Unregistering a supplier is essentially revoking their invoice issuing priviledg
         In [Console](https://console.invopop.com) create a new workflow and select [Empty Party workflow](https://console.invopop.com/redirect/workflows/new?template=empty-party) in the template selector, then add the following steps:
 
         1. **Unregister supplier** - Revokes invoice issuing authorization by the AEAT.
-        2. **Set State** - Select `void` to label the supplier accordingly.
+        2. **Set state** - Select `void` to label the supplier accordingly.
 
-        In the Error Handling section, add the **Set State** action and select `Error`.
+        In the Error Handling section, add the **Set state** action and select `Error`.
 
       </Tab>
     </Tabs>

--- a/guides/es-verifactu.mdx
+++ b/guides/es-verifactu.mdx
@@ -59,12 +59,12 @@ Add a new workflow to your workspace for issuing invoices. You can start with th
   <Tab title="Build from scratch">
     In [Console](https://console.invopop.com) create a new workflow and select [Empty Invoice workflow](https://console.invopop.com/redirect/workflows/new?template=empty-invoice) in the template selector, then add the following steps:
 
-    1. **Sign Envelope** - Signs the VERI\*FACTU document.
+    1. **Sign envelope** - Signs the VERI\*FACTU document.
     2. **Generate XML** - Creates the XML document and adds it to the chain. View it in the `Files` section.
     3. **Issue invoice** - Submits the XML to AEAT and returns the response.
     4. **Generate PDF** - Creates the PDF invoice with the required QR code.
 
-    In the Error Handling section, add the **Set State** action and select `Error`.
+    In the Error Handling section, add the **Set state** action and select `Error`.
 
   </Tab>
 </Tabs>
@@ -291,8 +291,8 @@ Different from a credit note or a corrective, canceling an invoice doesn't produ
         We recommend adding the following steps:
 
         1. **Cancel invoice** - Cancels the VERI\*FACTU document.
-        2. **Set State** - select _Void_ in the step configuration. This will set the state of the invoice to `Void`.
-        3. In the Error Handling area, **Set State** - select `Error` in the step configuration.
+        2. **Set state** - select _Void_ in the step configuration. This will set the state of the invoice to `Void`.
+        3. In the Error Handling area, **Set state** - select `Error` in the step configuration.
 
         Add any additional steps you may need, and save the new workflow.
       </Tab>

--- a/guides/fr-chorus-pro.mdx
+++ b/guides/fr-chorus-pro.mdx
@@ -88,7 +88,7 @@ After connecting, you'll see both UN/CEFACT CII and Chorus Pro listed in the Ena
 
         The new workflow performs a single step:
 
-        1. **Register a supplier for Chorus Pro**
+        1. **Register supplier with Chorus Pro**
 
         Add any additional steps you need such as error handling, and save the new workflow.
 
@@ -112,10 +112,10 @@ After connecting, you'll see both UN/CEFACT CII and Chorus Pro listed in the Ena
       <Tab title="Build from scratch">
         In [Console](https://console.invopop.com) create a new workflow and select [Empty Invoice workflow]() in the template selector. Add the following steps:
 
-        1. **Generate UN/CEFACT CII Invoice** - Select _Chorus Pro V1_ as the `Invoice Output Document Type`.
-        2. **Send an invoice to Chorus Pro**.
+        1. **Generate CII document** - Select _Chorus Pro V1_ as the `Invoice Output Document Type`.
+        2. **Send invoice to Chorus Pro**.
 
-        In the Error Handling section, add the **Set State** action and select `Error`.
+        In the Error Handling section, add the **Set state** action and select `Error`.
       </Tab>
     </Tabs>
     Keep the workflow ID at hand as you'll need it later.

--- a/guides/fr-pa-invoicing.mdx
+++ b/guides/fr-pa-invoicing.mdx
@@ -41,28 +41,28 @@ The **Record Invoice** step validates SIRENs and checks both parties against the
 ### How it works
 
 <Steps>
-  <Step title="Set State → processing">
+  <Step title="Set state → processing">
     Moves the invoice into a visible "in progress" state for operator dashboards.
   </Step>
-  <Step title="Add Signature">
+  <Step title="Sign envelope">
     Locks the GOBL envelope so downstream steps work against an immutable document.
   </Step>
   <Step title="Record Invoice">
     Validates SIRENs, checks both parties against the Annuaire, and stores the invoice in the local PA database.
   </Step>
-  <Step title="Generate UBL Document">
-    Produces a Peppol France CIUS UBL invoice or credit note. Swap for **Generate CII Document** if the receiver requires CII, or **Generate PDF (Factur-X)** for hybrid PDF.
+  <Step title="Generate UBL document">
+    Produces a Peppol France CIUS UBL invoice or credit note. Swap for **Generate CII document** if the receiver requires CII, or **Generate PDF (Factur-X)** for hybrid PDF.
   </Step>
-  <Step title="Send Peppol Document">
+  <Step title="Send Peppol document">
     Transmits the generated document to the receiver's PA over the Peppol network.
   </Step>
-  <Step title="Set State → sent">
+  <Step title="Set state → sent">
     Marks Peppol delivery as successful.
   </Step>
   <Step title="Forward Invoice to PPF">
     Generates the simplified F1 invoice and forwards it, along with the mandatory `200` _déposée_ status, to the PPF.
   </Step>
-  <Step title="Set State → completed">
+  <Step title="Set state → completed">
     Marks the full e-invoicing flow — Peppol delivery and PPF reporting — as complete.
   </Step>
 </Steps>
@@ -91,19 +91,19 @@ The receive workflow detects the inbound format, imports it into a GOBL document
 ### How it works
 
 <Steps>
-  <Step title="Import Peppol Document">
+  <Step title="Import Peppol document">
     Pulls the inbound payload from Peppol and branches on the detected format:
-    - `UBL` → **Import UBL Document** converts the UBL XML to GOBL.
-    - `CII` → **Import UN/CEFACT CII Document** converts the CII XML to GOBL.
-    - `PDF` → **Import PDF (Factur-X)** extracts the embedded CII and converts it to GOBL.
+    - `UBL` → **Import UBL document** converts the UBL XML to GOBL.
+    - `CII` → **Import CII document** converts the CII XML to GOBL.
+    - `PDF` → **Import Factur-X PDF** extracts the embedded CII and converts it to GOBL.
   </Step>
-  <Step title="Set Folder → expenses">
+  <Step title="Set folder → expenses">
     Files the invoice under the `Invoices · Expenses` folder so it lands in the right place for accounting workflows.
   </Step>
   <Step title="Record Invoice">
     Validates SIRENs, resolves your registered party as the customer (or supplier in self-billing flows), and guards against duplicate processing.
   </Step>
-  <Step title="Set State → registered">
+  <Step title="Set state → registered">
     Marks the incoming invoice as successfully received.
   </Step>
 </Steps>

--- a/guides/fr-pa-registration.mdx
+++ b/guides/fr-pa-registration.mdx
@@ -24,25 +24,25 @@ The Annuaire requires every entry to be receive-capable, so there is no send-onl
 </Frame>
 
 <Steps>
-  <Step title="Sign agreement for France">
+  <Step title="Sign PPF agreement">
     Generates the French PA mandate so the party can authorise Invopop to act on its behalf (`gov-fr.agreement.sign`).
   </Step>
-  <Step title="Set State → processing">
+  <Step title="Set state → processing">
     Moves the silo entry into a visible "in progress" state so operator dashboards reflect that registration is underway.
   </Step>
-  <Step title="Wait for French agreement upload">
+  <Step title="Wait for PPF agreement upload">
     Pauses until the signed agreement is uploaded and accepted (`gov-fr.agreement.wait.approval`).
   </Step>
-  <Step title="Set State → completed">
+  <Step title="Set state → completed">
     Marks the agreement step as completed before the directory and Peppol registrations run.
   </Step>
-  <Step title="Register Party in Directory">
+  <Step title="Register party in Directory">
     Submits the party's SIREN to the French Annuaire so other PAs can route invoices to it (`gov-fr.directory.register`).
   </Step>
-  <Step title="Register Peppol Party">
+  <Step title="Register party on Peppol">
     Publishes the party in SMP/SML with the `france` document group, enabling Peppol-level routing for sending and receiving.
   </Step>
-  <Step title="Set State → registered">
+  <Step title="Set state → registered">
     Marks the party as fully onboarded.
   </Step>
 </Steps>
@@ -70,7 +70,7 @@ Run the unregister workflow to revoke a party's registrations when it should no 
   <Step title="Unregister from Directory">
     Removes the party from the French Annuaire.
   </Step>
-  <Step title="Set State → void">
+  <Step title="Set state → void">
     Marks the party as unregistered.
   </Step>
 </Steps>

--- a/guides/fr-pa-reporting.mdx
+++ b/guides/fr-pa-reporting.mdx
@@ -40,19 +40,19 @@ The register workflow collects a signature (auto-approved in sandbox). Every inv
 ### How it works
 
 <Steps>
-  <Step title="Set State → processing">
+  <Step title="Set state → processing">
     Marks the silo entry as "Processing".
   </Step>
-  <Step title="Sign agreement">
+  <Step title="Sign PPF agreement">
     Generates a signature link for the supplier to sign.
   </Step>
-  <Step title="Wait for approval">
+  <Step title="Wait for PPF agreement upload">
     Pauses until the agreement is approved.
   </Step>
   <Step title="Register party for reporting">
     Enables the party for reporting,
   </Step>
-  <Step title="Set State → registered">
+  <Step title="Set state → registered">
     Marks the silo entry as "Registered".
   </Step>
 </Steps>
@@ -96,13 +96,13 @@ Wire this workflow as the default for both `bill/invoice` and `bill/payment` in 
 ### How it works
 
 <Steps>
-  <Step title="Set State → processing">
+  <Step title="Set state → processing">
     Marks the silo entry as "Processing".
   </Step>
   <Step title="Record document for reporting">
     Classifies the document (10.1 / 10.2 / 10.3 / 10.4) and stores it for the next report.
   </Step>
-  <Step title="Set State → recorded">
+  <Step title="Set state → recorded">
     Marks the silo entry as "Recorded".
   </Step>
 </Steps>
@@ -154,7 +154,7 @@ A separate workflow bundles the records for a closed reporting window into a sin
 ### How it works
 
 <Steps>
-  <Step title="Set State → processing">
+  <Step title="Set state → processing">
     Marks the silo entry as "Processing".
   </Step>
   <Step title="Generate document for reporting">
@@ -163,7 +163,7 @@ A separate workflow bundles the records for a closed reporting window into a sin
   <Step title="Send document for reporting">
     Submits the report to the PPF and waits for the acknowledgement.
   </Step>
-  <Step title="Set State → filed">
+  <Step title="Set state → filed">
     Marks the silo entry as "Filed".
   </Step>
 </Steps>
@@ -200,13 +200,13 @@ When a party should no longer be reported on, run the disable workflow. The part
 ### How it works
 
 <Steps>
-  <Step title="Set State → processing">
+  <Step title="Set state → processing">
     Marks the silo entry as "Processing".
   </Step>
-  <Step title="Disable Party for reporting">
+  <Step title="Disable party for reporting">
     Disables reporting for the party.
   </Step>
-  <Step title="Set State → Void">
+  <Step title="Set state → Void">
     Marks the silo entry as "Void".
   </Step>
 </Steps>

--- a/guides/fr-pa.mdx
+++ b/guides/fr-pa.mdx
@@ -58,15 +58,15 @@ You can query the Annuaire directly to check whether a party is registered befor
 
 #### How it works
 
-1. **Register Party for Approval** — submits the party details for Invopop review.
+1. **Register party for Peppol approval** — submits the party details for Invopop review.
 2. **Set state to Processing** — marks the party as awaiting approval.
-3. **Wait for Approval** — pauses until the party passes the approval check.
-4. **Register Party** — registers the party in the French Directory (`gov-fr.party.register`). This is the France-specific step added on top of the base Peppol flow.
-5. **Register Peppol Party** — registers the party on the Peppol network with the `france` document group, enabled for sending and receiving via SMP/SML/Peppol.
+3. **Wait for Peppol approval** — pauses until the party passes the approval check.
+4. **Register party in Directory** — registers the party in the French Directory (`gov-fr.party.register`). This is the France-specific step added on top of the base Peppol flow.
+5. **Register party on Peppol** — registers the party on the Peppol network with the `france` document group, enabled for sending and receiving via SMP/SML/Peppol.
 6. **Set state to Registered** — marks the party as fully onboarded.
 
 <Info>
-  If you want to understand the base Peppol onboarding this workflow is built on, see the [Peppol registration guide](/guides/peppol). The France PA workflow is the same flow plus the **Register Party (France)** step before the Peppol registration step.
+  If you want to understand the base Peppol onboarding this workflow is built on, see the [Peppol registration guide](/guides/peppol). The France PA workflow is the same flow plus the **Register party in Directory** step before the Peppol registration step.
 </Info>
 
 <Tabs>

--- a/guides/gr-iapr.mdx
+++ b/guides/gr-iapr.mdx
@@ -71,13 +71,13 @@ The ILYDA Greece app will send your invoices to the appropriate environment base
 
     In [Console](https://console.invopop.com) create a new workflow and select [Empty Invoice workflow](https://console.invopop.com/redirect/workflows/new?template=empty-invoice) in the template selector, then add the following steps:
 
-    1. **Set State** - to `Processing`.
-    2. **Add Sequential Code** - with dynamic sequences and a name like "IAPR Invoices".
-    3. **Sign Envelope**: The envelope must be signed before processing.
-    4. **Send to IAPR (via ILYDA)**.
-    5. **Set State** - to `Sent`.
+    1. **Set state** - to `Processing`.
+    2. **Add sequential code** - with dynamic sequences and a name like "IAPR Invoices".
+    3. **Sign envelope**: The envelope must be signed before processing.
+    4. **Send invoice to MyDATA**.
+    5. **Set state** - to `Sent`.
 
-    Finally, in the Error Handling area, add the **Set State** action and select `Error`.
+    Finally, in the Error Handling area, add the **Set state** action and select `Error`.
 
     Add any additional steps you may need, and save the new workflow.
   </Tab>

--- a/guides/it-sdi-receiving.mdx
+++ b/guides/it-sdi-receiving.mdx
@@ -62,11 +62,11 @@ Use this workflow to register a company to receive invoices through SDI.
 
     The new workflow will need to perform these steps:
 
-      1. **Set State**: Select `Processing` to mark the start of the registration.
-      2. **Register SDI Customer (Italy)**: This step registers the company as an invoice receiver through SDI. Make sure to select the `Production` environment to go live.
-      3. **Set State**: Once the registration is complete, select `Registered`.
+      1. **Set state**: Select `Processing` to mark the start of the registration.
+      2. **Register supplier with SDI**: This step registers the company as an invoice receiver through SDI. Make sure to select the `Production` environment to go live.
+      3. **Set state**: Once the registration is complete, select `Registered`.
 
-      In the **Error Handling** section, add a **Set State** step and choose `Error` to capture any issues during registration.
+      In the **Error Handling** section, add a **Set state** step and choose `Error` to capture any issues during registration.
 
       This minimal workflow is required to onboard a customer for SDI e-invoicing in Italy. You can extend it with notification steps, such as sending confirmation emails or updating external systems when registration succeeds or fails.
 
@@ -98,11 +98,11 @@ Use this workflow to import and process invoices received through SDI. This work
 
       In [Console](https://console.invopop.com), create a new workflow and choose [Empty Invoice workflow](https://console.invopop.com/redirect/workflows/new?template=empty-invoice) as the base. Then add the following steps:
 
-      1. **Import from SDI (Italy)**: Retrieves invoices in the FatturaPA format from SDI and converts them into GOBL. Set the environment to `Production` for real operations.
+      1. **Import invoice from SDI**: Retrieves invoices in the FatturaPA format from SDI and converts them into GOBL. Set the environment to `Production` for real operations.
       2. **Generate PDF**: Generates a visual representation of the invoice in Italian, using the specified locale (`it`), date format (`%Y-%m-%d`), and logo height (40px).
-      3. **Set State**: Marks the invoice as `Sent` once it's successfully processed.
+      3. **Set state**: Marks the invoice as `Sent` once it's successfully processed.
 
-      In the **Error Handling** section, add a **Set State** step with the state set to `Error` to capture and flag failed imports.
+      In the **Error Handling** section, add a **Set state** step with the state set to `Error` to capture and flag failed imports.
 
       This is the minimal workflow required to automate the reception and visualization of invoices received through SDI. You may expand it with additional steps such as storing a backup copy, notifying clients, or integrating the documents into an ERP system.
 

--- a/guides/it-sdi-sending.mdx
+++ b/guides/it-sdi-sending.mdx
@@ -62,12 +62,12 @@ SDI does not have a sandbox environment. When `sandbox` mode is selected, Invopo
 
       In [Console](https://console.invopop.com), create a new workflow and choose [Empty Invoice workflow](https://console.invopop.com/redirect/workflows/new?template=empty-invoice) as the base. Then add the following steps:
 
-        1. **Set State** - To `Processing`.
-        2. **Sign Envelope** - Signs the [GOBL](https://docs.gobl.org) document preventing further modifications.
-        3. **Send to SDI (Italy)** - Generates the FatturaPA XML and sends it to SDI. Upon success, the XML file is attached to the invoice entry. If `sandbox` is chosen as the environment, the simulated response from SDI must be set.
-        4. **Set State** - To `Sent`.
+        1. **Set state** - To `Processing`.
+        2. **Sign envelope** - Signs the [GOBL](https://docs.gobl.org) document preventing further modifications.
+        3. **Send invoice to SDI** - Generates the FatturaPA XML and sends it to SDI. Upon success, the XML file is attached to the invoice entry. If `sandbox` is chosen as the environment, the simulated response from SDI must be set.
+        4. **Set state** - To `Sent`.
 
-      In the **Error Handling** section, add a **Set State** step with the state set to `Error` to capture and flag failed imports.
+      In the **Error Handling** section, add a **Set state** step with the state set to `Error` to capture and flag failed imports.
 
       This is the minimal workflow with state handling required to automate the reception and visualization of invoices received through SDI. You may expand it with additional steps such as storing a backup copy, notifying clients, or integrating the documents into an ERP system.
 

--- a/guides/it-ticket.mdx
+++ b/guides/it-ticket.mdx
@@ -84,7 +84,7 @@ Follow these steps in the [Invopop Console](https://console.invopop.com).
 
       This worfkow is composed by a single step:
 
-      1. **Set State** - To `Registered`.
+      1. **Set state** - To `Registered`.
 
       Though you can customize it to suit your needs (adding a webhook, or an email notification after a supplier has been registered.)
 
@@ -128,9 +128,9 @@ Click the **Save** button.
 
     The new workflow will need to perform three steps:
 
-    - **Sign the Envelope**
-    - **Register the Issuer**
-    - **Set State** - select `Processing`.
+    - **Sign envelope**
+    - **Register supplier with AdE**
+    - **Set state** - select `Processing`.
 
     Add any additional steps you may need, and save the new workflow.
 
@@ -157,12 +157,12 @@ Click the **Save** button.
 
         The new workflow will need to perform three steps:
 
-        - **Add Sequential Code** - with dynamic sequences, and name like "Italian Smart Receipts".
-        - **Send a receipt to AdE**.
+        - **Add sequential code** - with dynamic sequences, and name like "Italian Smart Receipts".
+        - **Send receipt to AdE**.
         - **Generate PDF** - configured for your environment.
-        - **Set State** - to `Sent`.
+        - **Set state** - to `Sent`.
 
-        Finally, in the Error Handling area, add the **Set State** action and select `Error`.
+        Finally, in the Error Handling area, add the **Set state** action and select `Error`.
 
         Add any additional steps you may need, and save the new workflow.
 
@@ -196,10 +196,10 @@ Click the **Save** button.
 
         The new workflow will need to perform three steps:
 
-        - **Void a receipt in AdE**.
-        - **Set State** - to `Sent`.
+        - **Void receipt with AdE**.
+        - **Set state** - to `Sent`.
 
-        Finally, in the Error Handling area, add the **Set State** action and select `Error`.
+        Finally, in the Error Handling area, add the **Set state** action and select `Error`.
 
         Add any additional steps you may need, and save the new workflow.
 

--- a/guides/it-ticket.mdx
+++ b/guides/it-ticket.mdx
@@ -82,7 +82,7 @@ Follow these steps in the [Invopop Console](https://console.invopop.com).
 
       In [Console](https://console.invopop.com), create a new workflow and choose [Empty Party workflow](https://console.invopop.com/redirect/workflows/new?template=empty-party) as the base. Then name the workflow with a descriptive label such as "Smart Receipt Post-registration".
 
-      This worfkow is composed by a single step:
+      This workflow is composed of a single step:
 
       1. **Set state** - To `Registered`.
 

--- a/guides/mx-sat-issuing.mdx
+++ b/guides/mx-sat-issuing.mdx
@@ -87,7 +87,7 @@ Configure your Invopop workspace for CFDI invoicing by following these steps in 
 
       This workflow is composed by a single step:
 
-      1. **Set State** - To `Registered`.
+      1. **Set state** - To `Registered`.
 
       Though you can customize it to suit your needs (adding a webhook, or an email notification after a supplier has been registered.)
 
@@ -115,9 +115,9 @@ Configure your Invopop workspace for CFDI invoicing by following these steps in 
 
     The new workflow will need to perform these steps:
 
-      - **Sign the Envelope**
-      - **Register SAT Issuer**
-      - **Set State** - with configuration set to `Processing`.
+      - **Sign envelope**
+      - **Register supplier with SAT**
+      - **Set state** - with configuration set to `Processing`.
 
     Add any additional steps you may need, and save the new workflow.
 
@@ -153,13 +153,13 @@ Configure your Invopop workspace for CFDI invoicing by following these steps in 
 
         The new workflow will need to perform these steps:
 
-        - **Add Sequential Code:**  with dynamic sequences, and name like "SAT Invoices".
-        - **Sign Envelope:** - no configuration needed
-        - **Send to SAT (Mexico):** no configuration needed.
+        - **Add sequential code:**  with dynamic sequences, and name like "SAT Invoices".
+        - **Sign envelope:** - no configuration needed
+        - **Send invoice to SAT:** no configuration needed.
         - **Generate PDF** - Set according to your needs. Layout "Letter" and locale "es - Spanish" are recommended.
-        - **Set State** - to "sent".
+        - **Set state** - to "sent".
 
-        Finally, in the Error Handling area, add the **Set State** action and select `Error`.
+        Finally, in the Error Handling area, add the **Set state** action and select `Error`.
 
         Add any additional steps you may need, and save the new workflow.
 

--- a/guides/mx-sat-platform-reporting.mdx
+++ b/guides/mx-sat-platform-reporting.mdx
@@ -63,7 +63,7 @@ The action returns, and stores on the party:
 ### How it works
 
 <Steps>
-  <Step title="Set State → processing">
+  <Step title="Set state → processing">
     Marks the silo entry as "Processing".
   </Step>
   <Step title="Sign envelope">
@@ -72,7 +72,7 @@ The action returns, and stores on the party:
   <Step title="Register party for platform reporting">
     Enrolls the party, signs the portal URL, and stores the link + credentials on the party metadata.
   </Step>
-  <Step title="Set State → registered">
+  <Step title="Set state → registered">
     Marks the silo entry as "Registered".
   </Step>
 </Steps>
@@ -98,7 +98,7 @@ Recording is **idempotent on the invoice**: re-running the workflow for the same
 ### How it works
 
 <Steps>
-  <Step title="Set State → processing">
+  <Step title="Set state → processing">
     Marks the silo entry as "Processing".
   </Step>
   <Step title="Sign envelope">
@@ -107,7 +107,7 @@ Recording is **idempotent on the invoice**: re-running the workflow for the same
   <Step title="Record operation for reporting">
     Extracts the rule 2.9.21 fields and files the operation; errors if a required field is missing.
   </Step>
-  <Step title="Set State → sent">
+  <Step title="Set state → sent">
     Marks the silo entry as "Sent".
   </Step>
 </Steps>
@@ -150,13 +150,13 @@ When a party should no longer accept new operations, run `sat-mx.platforms.unreg
 ### How it works
 
 <Steps>
-  <Step title="Set State → processing">
+  <Step title="Set state → processing">
     Marks the silo entry as "Processing".
   </Step>
   <Step title="Unregister party from platform reporting">
     Stops accepting new operations; preserves portal access and history.
   </Step>
-  <Step title="Set State → void">
+  <Step title="Set state → void">
     Marks the silo entry as "Void".
   </Step>
 </Steps>

--- a/guides/mx-sat-receiving.mdx
+++ b/guides/mx-sat-receiving.mdx
@@ -95,10 +95,10 @@ Configure your Invopop workspace for receiving CFDI imports by following these s
 
     The workflow needs these steps:
 
-    1. **Import CFDI document** - Uses the SAT Mexico app to convert the CFDI XML to GOBL format.
-    2. **Set State** - To "received".
+    1. **Import CFDI from SAT** - Uses the SAT Mexico app to convert the CFDI XML to GOBL format.
+    2. **Set state** - To "received".
 
-    In the **Error Handling** section, add a **Set State** step and select `Error`.
+    In the **Error Handling** section, add a **Set state** step and select `Error`.
   </Tab>
 </Tabs>
 
@@ -120,13 +120,13 @@ Configure your Invopop workspace for receiving CFDI imports by following these s
     Download CFDIs from SAT via SW Sapien and dispatch import CFDI job.
     </Card>
 
-    After adding the template, open the **Bulk Import CFDIs via Efisco (Mexico)** step and set the **Import Workflow** field to the CFDI Conversion Workflow created in the previous step.
+    After adding the template, open the **Bulk import CFDIs from Efisco** step and set the **Import Workflow** field to the CFDI Conversion Workflow created in the previous step.
   </Tab>
   <Tab title="Code">
     Copy and paste into a new [Empty Party workflow](https://console.invopop.com/redirect/workflows/new?template=empty-party) code view.
     <ImportCFDI />
 
-    After pasting the code, switch to the form view, open the **Bulk Import CFDIs via Efisco (Mexico)** step and set the **Import Workflow** field to the CFDI Conversion Workflow created in the previous step.
+    After pasting the code, switch to the form view, open the **Bulk import CFDIs from Efisco** step and set the **Import Workflow** field to the CFDI Conversion Workflow created in the previous step.
   </Tab>
   <Tab title="Build from scratch">
     Before starting, review the [workflows guide](/guides/features/workflows) to understand the general setup process.
@@ -135,11 +135,11 @@ Configure your Invopop workspace for receiving CFDI imports by following these s
 
     The workflow needs a single step:
 
-    1. **Bulk Import CFDIs via Efisco (Mexico)** - Configure with:
+    1. **Bulk import CFDIs from Efisco** - Configure with:
        - **Document Type**: Select `Received` to import invoices received by the party.
        - **Import Workflow**: Select the CFDI Conversion Workflow created in the previous step.
 
-    In the **Error Handling** section, add a **Set State** step and select `Error`.
+    In the **Error Handling** section, add a **Set state** step and select `Error`.
   </Tab>
 </Tabs>
 
@@ -175,9 +175,9 @@ Configure your Invopop workspace for receiving CFDI imports by following these s
     1. **Subscribe to Periodic Import** - Uses the Cron app. Configure with:
        - **Workflow**: Select the bulk import CFDI workflow created in the previous step.
        - **Interval**: Select the desired frequency (for example, `daily`).
-    2. **Set State** - To "registered".
+    2. **Set state** - To "registered".
 
-    In the **Error Handling** section, add a **Set State** step and select `Error`.
+    In the **Error Handling** section, add a **Set state** step and select `Error`.
   </Tab>
 </Tabs>
 </Step>
@@ -202,10 +202,10 @@ Configure your Invopop workspace for receiving CFDI imports by following these s
 
     The workflow needs these steps:
 
-    1. **Set State** - To "processing".
-    2. **Register Efisco Party** - Initiates the registration of the party with SW Sapien's Efisco service.
+    1. **Set state** - To "processing".
+    2. **Register supplier with Efisco** - Initiates the registration of the party with SW Sapien's Efisco service.
 
-    In the **Error Handling** section, add a **Set State** step and select `Error`.
+    In the **Error Handling** section, add a **Set state** step and select `Error`.
   </Tab>
 </Tabs>
 </Step>

--- a/guides/pdf-invoice.mdx
+++ b/guides/pdf-invoice.mdx
@@ -49,11 +49,11 @@ Issuing PDF invoices with Invopop requires very little preparation. We assume th
   <Tab title="Build from scratch">
     In [Console](https://console.invopop.com) create a new workflow and select [Empty Invoice workflow](https://console.invopop.com/redirect/workflows/new?template=empty-invoice) in the template selector, then add the following steps:
 
-1. **Add Sequential Code** - select the **dynamic** sequence option and set the name.
-2. **Sign Envelope** - signs the [GOBL](https://docs.gobl.org) document, preventing further changes.
+1. **Add sequential code** - select the **dynamic** sequence option and set the name.
+2. **Sign envelope** - signs the [GOBL](https://docs.gobl.org) document, preventing further changes.
 3. **Generate PDF** - configure the logo and language according to your needs.
 
-Finally, in the Error Handling area, add the **Set State** action and select status `Error`.
+Finally, in the Error Handling area, add the **Set state** action and select status `Error`.
 
 <Frame caption="Example of the expected workflow">
 

--- a/guides/peppol.mdx
+++ b/guides/peppol.mdx
@@ -81,13 +81,13 @@ Skip this step if you only want to _receive_ invoices via Peppol.
   <Tab title="Build from scratch">
     Use the [Console](https://console.invopop.com/) to build a [workflow](/guides/features/workflows) of the Invoice type. Include these essential steps:
 
-    1. **Set State** - to `Processing`.
-    2. **Sign Envelope** - Signs the [GOBL](https://docs.gobl.org) document (can be substituted with `Add Sequential Code` with the `Sign Document` option enabled)
+    1. **Set state** - to `Processing`.
+    2. **Sign envelope** - Signs the [GOBL](https://docs.gobl.org) document (can be substituted with `Add sequential code` with the `Sign Document` option enabled)
     3. **Generate UBL document** - Converts the [GOBL](https://docs.gobl.org) document to a Peppol BIS Billing UBL 3.0 document and attaches it to the original invoice entry.
     4. **Send Peppol document** - Sends the generated XML attachment through the Peppol network
-    5. **Set State** - to `Sent`.
+    5. **Set state** - to `Sent`.
 
-    Finally, in the Error Handling area, add the **Set State** action and select `Error`.
+    Finally, in the Error Handling area, add the **Set state** action and select `Error`.
   </Tab>
 </Tabs>
 </Step>
@@ -107,13 +107,13 @@ Skip this step if you only want to _receive_ invoices via Peppol.
   </Tab>
   <Tab title="Build from scratch">
     In [Console](https://console.invopop.com) create a new workflow and select [Empty Invoice workflow](https://console.invopop.com/redirect/workflows/new?template=empty-invoice) in the template selector, then add the following steps:
-    1. **Import Peppol Document** - Add two conditions with codes UBL and CII to handle both formats.
-       - **Import UBL Document** - Add this to the condition with UBL.
-       - **Import CII Document** - Add this to the condition with CII.
-    2. **Set State** - to `Registered`.
+    1. **Import Peppol document** - Add two conditions with codes UBL and CII to handle both formats.
+       - **Import UBL document** - Add this to the condition with UBL.
+       - **Import CII document** - Add this to the condition with CII.
+    2. **Set state** - to `Registered`.
     3. **Send Webhook** (optional) - let your services know a Peppol document was received.
 
-    Finally, in the Error Handling area, add the **Set State** action and select `Error`.
+    Finally, in the Error Handling area, add the **Set state** action and select `Error`.
   </Tab>
 </Tabs>
 </Step>
@@ -146,13 +146,13 @@ This workflow onboards companies (Peppol participants) to Invopop before they ca
 
       This workflow is composed by these steps:
 
-      1. **Register for Approval** - This generates a link to the registration wizard where proof of ownership will be collected.
-      2. **Set State** - select `Processing`.
-      3. **Wait for Approval** - Invopop will validate the company identity and ownership. This can take up to 72 hours.
-      4. **Register Peppol Party** - Complete the normal registration process after approval.
-      5. **Set State** - select `Registered`.
+      1. **Register party for Peppol approval** - This generates a link to the registration wizard where proof of ownership will be collected.
+      2. **Set state** - select `Processing`.
+      3. **Wait for Peppol approval** - Invopop will validate the company identity and ownership. This can take up to 72 hours.
+      4. **Register party on Peppol** - Complete the normal registration process after approval.
+      5. **Set state** - select `Registered`.
 
-      Finally, in the Error Handling area, add the **Set State** action and select `Error`.
+      Finally, in the Error Handling area, add the **Set state** action and select `Error`.
 
 
   </Tab>
@@ -355,7 +355,7 @@ In most cases, Participant IDs are based on VAT numbers or local business identi
 Note that some countries support multiple schemes. For example, Belgium uses `0208` (KBO/BCE number) as the preferred default, but some entities are registered under `9925` (VAT number). When sending invoices, if you get a "receiver not found" error, the recipient may be registered under an alternative scheme. See the [Belgium FAQ](/faq/belgium) for details.
 </Accordion>
 
-<Accordion title="When registering a supplier we get an error: 'XXXX:XXXXXXXXX is already registered' on the Register Peppol Party step">
+<Accordion title="When registering a supplier we get an error: 'XXXX:XXXXXXXXX is already registered' on the Register party on Peppol step">
 This is because because a supplier with the stated participant ID has already been registered in your workspace.
 </Accordion>
 

--- a/guides/pl-ksef.mdx
+++ b/guides/pl-ksef.mdx
@@ -107,7 +107,7 @@ This workflow signs the GOBL document, converts it to FA(3) XML, and submits it 
     2. **Add sequential code** - Add the desired sequence for your invoices
     3. **Sign envelope** - Signs the [GOBL](https://docs.gobl.org) document preventing further modifications
     4. **Generate FA(3) XML** - Generates the FA(3) XML
-    5. **Send FA(3) XML to KSeF** - Sends the FA(3) XML to KSeF
+    5. **Send invoice to KSeF** - Sends the FA(3) XML to KSeF
     6. **Set state** - To `Sent`
 
     In the **Error handling** section, add a **Set state** step with the state set to `Error` to capture and flag failed submissions.
@@ -128,7 +128,7 @@ This workflow registers a supplier in KSeF so you can issue invoices on their be
   />
 </Frame>
 
-In **Sandbox** the **Register Party in KSeF** step allows you to configure the environment:
+In **Sandbox** the **Register supplier with KSeF** step allows you to configure the environment:
 
 - **Test**: Self-signed certificate generated automatically, no manual steps required.
 - **Demo**: Requires manual certificate generation from the demo portal.
@@ -147,7 +147,7 @@ In **live workspaces** no configuration is available, all suppliers are register
     Copy and paste into a new [Empty Party workflow](https://console.invopop.com/redirect/workflows/new?template=empty-party) code view.
 
     <Note>
-      The template uses test mode by default (for sandbox). To use demo mode in sandbox, add `"config": {"environment": "demo"}` to the **Register for KSeF** step. In Invopop production, the workflow automatically targets the KSeF production environment.
+      The template uses test mode by default (for sandbox). To use demo mode in sandbox, add `"config": {"environment": "demo"}` to the **Register supplier with KSeF** step. In Invopop production, the workflow automatically targets the KSeF production environment.
     </Note>
 
     <PartyRegistrationSendWorkflow />
@@ -160,7 +160,7 @@ In **live workspaces** no configuration is available, all suppliers are register
     The new workflow will need to perform these steps:
 
     1. **Set state** - To `Processing`
-    2. **Register party in KSeF (Poland)** - Registers the party with KSeF and generates a registration link. Configure with your chosen environment (test, demo, or production).
+    2. **Register supplier with KSeF** - Registers the party with KSeF and generates a registration link. Configure with your chosen environment (test, demo, or production).
     3. **Wait for KSeF certificate upload** - Waits for the supplier to generate and upload their KSeF certificate (automatically skipped in test mode)
     4. **Set state** - To `Registered`
 
@@ -222,7 +222,7 @@ This workflow signs the GOBL document, converts it to FA(3) XML, and submits it 
     2. **Add sequential code** - Add the desired sequence for your invoices
     3. **Sign envelope** - Signs the [GOBL](https://docs.gobl.org) document preventing further modifications
     4. **Generate FA(3) XML** - Generates the FA(3) XML
-    5. **Send FA(3) XML to KSeF** - Sends the FA(3) XML to KSeF
+    5. **Send invoice to KSeF** - Sends the FA(3) XML to KSeF
     6. **Set state** - To `Sent`
 
     In the **Error handling** section, add a **Set state** step with the state set to `Error` to capture and flag failed submissions.
@@ -325,7 +325,7 @@ This workflow registers a supplier in KSeF and subscribes them to periodic invoi
   />
 </Frame>
 
-In **Sandbox** the **Register Party in KSeF** step allows you to configure the environment:
+In **Sandbox** the **Register supplier with KSeF** step allows you to configure the environment:
 
 - **Test**: Self-signed certificate generated automatically, no manual steps required.
 - **Demo**: Requires manual certificate generation from the demo portal.
@@ -344,7 +344,7 @@ In **live workspaces** no configuration is available, all suppliers are register
     Copy and paste into a new [Empty Party workflow](https://console.invopop.com/redirect/workflows/new?template=empty-party) code view.
 
     <Note>
-      The template uses test mode by default (for sandbox). To use demo mode in sandbox, add `"config": {"environment": "demo"}` to the **Register for KSeF** step. In Invopop production, the workflow automatically targets the KSeF production environment.
+      The template uses test mode by default (for sandbox). To use demo mode in sandbox, add `"config": {"environment": "demo"}` to the **Register supplier with KSeF** step. In Invopop production, the workflow automatically targets the KSeF production environment.
     </Note>
 
     <PartyRegistrationReceiveWorkflow />
@@ -357,7 +357,7 @@ In **live workspaces** no configuration is available, all suppliers are register
     The new workflow will need to perform these steps:
 
     1. **Set state** - To `Processing`
-    2. **Register party in KSeF (Poland)** - Registers the party with KSeF and generates a registration link. Configure with your chosen environment (test, demo, or production).
+    2. **Register supplier with KSeF** - Registers the party with KSeF and generates a registration link. Configure with your chosen environment (test, demo, or production).
     3. **Wait for KSeF certificate upload** - Waits for the supplier to generate and upload their KSeF certificate (automatically skipped in test mode)
     4. **Subscribe to periodic KSeF sync** - Uses the [Cron app](/apps/cron) to schedule periodic execution of the sync workflow. Configure with the sync workflow and your preferred interval.
     5. **Set state** - To `Registered`
@@ -489,7 +489,7 @@ In Console, go to the supplier entry → **Meta** tab → click the **gov-pl.inv
 <Badge color="green">Third-party companies</Badge> (white label)<br />
 In Console, go to the supplier entry → **Meta** tab → click the **gov-pl.invopop.com** link to launch the registration wizard.
 
-Add a webhook after the **Register Party in KSeF** step to receive the `siloEntryId`.
+Add a webhook after the **Register supplier with KSeF** step to receive the `siloEntryId`.
 
     Use the [Fetch an Entry endpoint](/api-ref/silo/entries/fetch-an-entry) to get the registration link from the `meta` object:
 

--- a/guides/pt-at.mdx
+++ b/guides/pt-at.mdx
@@ -87,7 +87,7 @@ All of the following steps must be carried out from the [Invopop Console](https:
 
       This worfkow is composed by a single step:
 
-      1. **Set State** - To `Registered`.
+      1. **Set state** - To `Registered`.
 
       Though you can customize it to suit your needs (adding a webhook, or an email notification after a supplier has been registered.)
 
@@ -122,11 +122,11 @@ All of the following steps must be carried out from the [Invopop Console](https:
 
       The new workflow will need to perform three steps:
 
-      - **Set State** - with configuration set to `Processing`.
-      - **Sign the Envelope**
-      - **Register AT Issuer (Portugal)**
+      - **Set state** - with configuration set to `Processing`.
+      - **Sign envelope**
+      - **Register supplier with AT**
 
-       Finally, in the Error Handling area, add the **Set State** action and select `Error`.
+       Finally, in the Error Handling area, add the **Set state** action and select `Error`.
 
       Add any additional steps you may need, and save the new workflow.
 
@@ -157,14 +157,14 @@ All of the following steps must be carried out from the [Invopop Console](https:
 
           The new workflow will need to perform these steps:
 
-          1. **Set State** - to `Processing`.
-          2. **Record for SAF-T reporting (Portugal)** - No configuration required.
-          3. **Send to the AT (Portugal)** - No configuration required.
+          1. **Set state** - to `Processing`.
+          2. **Record document for SAF-T** - No configuration required.
+          3. **Send document to AT** - No configuration required.
           4. **Generate PDF (Original)** - Portuguese - A4 - Title badge: "Original".
           5. **Generate PDF (Duplicate)** - Portuguese - A4 - Title badge: "Duplicado" - Flag as duplicate
-          7. **Set State** to `Sent`.
+          7. **Set state** to `Sent`.
 
-          Finally, in the Error Handling area, add the **Set State** action and select `Error`.
+          Finally, in the Error Handling area, add the **Set state** action and select `Error`.
 
           Add any additional steps you may need, and save the new workflow.
       </Tab>
@@ -194,14 +194,14 @@ All of the following steps must be carried out from the [Invopop Console](https:
 
           The new workflow will need to perform these steps:
 
-          1. **Set State** - to `Processing`.
-          2. **Cancel SAF-T record (Portugal)** - No configuration required.
-          3. **Send to the AT (Portugal)** - No configuration required.
-          4. **Set State** to `Void`.
+          1. **Set state** - to `Processing`.
+          2. **Cancel SAF-T record** - No configuration required.
+          3. **Send document to AT** - No configuration required.
+          4. **Set state** to `Void`.
           5. **Generate PDF (Original)** - Portuguese - A4 - Title badge: "Original".
           6. **Generate PDF (Duplicate)** - Portuguese - A4 - Title badge: "Duplicado" - Flag as duplicate
 
-          Finally, in the Error Handling area, add the **Set State** action and select `Error`.
+          Finally, in the Error Handling area, add the **Set state** action and select `Error`.
 
           Add any additional steps you may need, and save the new workflow.
       </Tab>
@@ -231,15 +231,15 @@ All of the following steps must be carried out from the [Invopop Console](https:
 
           The new workflow will need to perform these steps:
 
-          1. **Set State** - to `Processing`.
-          2. **Record for SAF-T reporting (Portugal)** - No configuration required.
-          3. **Send to the AT (Portugal)** - No configuration required.
+          1. **Set state** - to `Processing`.
+          2. **Record document for SAF-T** - No configuration required.
+          3. **Send document to AT** - No configuration required.
           4. **Generate PDF (Original)** - Portuguese - A4 - Title badge: "Original".
           5. **Generate PDF (Duplicate)** - Portuguese - A4 - Title badge: "Duplicado" - Flag as duplicate.
           6. **Generate PDF (Triplicate)** - Portuguese - A4 - Title badge: "Triplicado" - Flag as duplicate. Only required if you plan to issue Global Transport Guides (GT).
-          7. **Set State** to `Sent`.
+          7. **Set state** to `Sent`.
 
-          Finally, in the Error Handling area, add the **Set State** action and select `Error`.
+          Finally, in the Error Handling area, add the **Set state** action and select `Error`.
 
           Add any additional steps you may need, and save the new workflow.
       </Tab>
@@ -274,14 +274,14 @@ All of the following steps must be carried out from the [Invopop Console](https:
 
           The new workflow will need to perform these steps:
 
-          1. **Set State** - to `Processing`.
-          2. **Cancel SAF-T record (Portugal)** - No configuration required.
-          3. **Send to the AT (Portugal)** - No configuration required.
-          4. **Set State** to `Void`.
+          1. **Set state** - to `Processing`.
+          2. **Cancel SAF-T record** - No configuration required.
+          3. **Send document to AT** - No configuration required.
+          4. **Set state** to `Void`.
           5. **Generate PDF (Original)** - Portuguese - A4 - Title badge: "Original".
           6. **Generate PDF (Duplicate)** - Portuguese - A4 - Title badge: "Duplicado" - Flag as duplicate
 
-          Finally, in the Error Handling area, add the **Set State** action and select `Error`.
+          Finally, in the Error Handling area, add the **Set state** action and select `Error`.
 
           Add any additional steps you may need, and save the new workflow.
       </Tab>
@@ -311,13 +311,13 @@ All of the following steps must be carried out from the [Invopop Console](https:
 
           The new workflow will need to perform these steps:
 
-          1. **Set State** - to `Processing`.
-          2. **Record for SAF-T reporting (Portugal)** - No configuration required.
+          1. **Set state** - to `Processing`.
+          2. **Record document for SAF-T** - No configuration required.
           3. **Generate PDF (Original)** - Portuguese - A4 - Title badge: "Original".
           4. **Generate PDF (Duplicate)** - Portuguese - A4 - Title badge: "Duplicado" - Flag as duplicate
-          5. **Set State** to `Sent`.
+          5. **Set state** to `Sent`.
 
-          Finally, in the Error Handling area, add the **Set State** action and select `Error`.
+          Finally, in the Error Handling area, add the **Set state** action and select `Error`.
 
           Add any additional steps you may need, and save the new workflow.
       </Tab>
@@ -347,13 +347,13 @@ All of the following steps must be carried out from the [Invopop Console](https:
 
           The new workflow will need to perform these steps:
 
-          1. **Set State** - to `Processing`.
-          2. **Cancel SAF-T record (Portugal)** - No configuration required.
-          3. **Set State** to `Void`.
+          1. **Set state** - to `Processing`.
+          2. **Cancel SAF-T record** - No configuration required.
+          3. **Set state** to `Void`.
           4. **Generate PDF (Original)** - Portuguese - A4 - Title badge: "Original".
           5. **Generate PDF (Duplicate)** - Portuguese - A4 - Title badge: "Duplicado" - Flag as duplicate
 
-          Finally, in the Error Handling area, add the **Set State** action and select `Error`.
+          Finally, in the Error Handling area, add the **Set state** action and select `Error`.
 
           Add any additional steps you may need, and save the new workflow.
       </Tab>
@@ -457,7 +457,7 @@ When you register series through the Supplier Portal, you're asked to provide a 
 
 #### Sequence Assignment
 
-Unlike other countries, Portugal regulations do not allow pre-assigning sequence numbers to documents. The sequence number (_i.e._, the document's `code` property) is automatically assigned during the **Record for SAF-T reporting (Portugal)** step in your workflow, following AT regulations. This is why you'll find no `sequence` step in Portugal workflow templates and you should not add one.
+Unlike other countries, Portugal regulations do not allow pre-assigning sequence numbers to documents. The sequence number (_i.e._, the document's `code` property) is automatically assigned during the **Record document for SAF-T** step in your workflow, following AT regulations. This is why you'll find no `sequence` step in Portugal workflow templates and you should not add one.
 
 #### Series type
 
@@ -555,20 +555,20 @@ The workflow templates provided in this guide enable both reporting mechanisms.
 
 #### Real-time Reporting
 
-The **Send to the AT (Portugal)** step uses the AT's webservice to submit each document to the tax authority immediately after it is recorded.
+The **Send document to AT** step uses the AT's webservice to submit each document to the tax authority immediately after it is recorded.
 
 This step is optional. If you prefer to report documents only via SAF-T PT reports, you can remove it from your workflows.
 
 <Info>
-  The **Send to the AT (Portugal)** step requires the supplier to have the appropriate AT user permissions (`WFA` for invoices, `WDT` for transport documents) as described in the "Obtain the Supplier's AT Credentials" section above.
+  The **Send document to AT** step requires the supplier to have the appropriate AT user permissions (`WFA` for invoices, `WDT` for transport documents) as described in the "Obtain the Supplier's AT Credentials" section above.
 </Info>
 
 #### SAF-T PT Reporting
 
-SAF-T PT reports allow you to submit documents to the AT in batch format. The **Record for SAF-T reporting (Portugal)** step takes care of recording the documents for this purpose.
+SAF-T PT reports allow you to submit documents to the AT in batch format. The **Record document for SAF-T** step takes care of recording the documents for this purpose.
 
 <Info>
-  The **Record for SAF-T reporting (Portugal)** step is required in all workflows, regardless of whether you also use real-time reporting. The AT may request SAF-T PT reports for audit purposes at any time, so all documents must be properly recorded.
+  The **Record document for SAF-T** step is required in all workflows, regardless of whether you also use real-time reporting. The AT may request SAF-T PT reports for audit purposes at any time, so all documents must be properly recorded.
 </Info>
 
 To generate a SAF-T PT report, a supplier can follow these steps:

--- a/guides/pt-at.mdx
+++ b/guides/pt-at.mdx
@@ -85,7 +85,7 @@ All of the following steps must be carried out from the [Invopop Console](https:
 
       In [Console](https://console.invopop.com), create a new workflow and choose [Empty Party workflow](https://console.invopop.com/redirect/workflows/new?template=empty-party) as the base. Then name the workflow with a descriptive label such as "PT-AT Post-registration workflow".
 
-      This worfkow is composed by a single step:
+      This workflow is composed by a single step:
 
       1. **Set state** - To `Registered`.
 

--- a/guides/related-docs.mdx
+++ b/guides/related-docs.mdx
@@ -22,7 +22,7 @@ Upload a supplier to Invopop. You can either use your own UUID or leave it blank
 </Step>
 
 <Step title="Sign the supplier">
-The supplier must be signed for the linked invoice to appear. Send the supplier to a "contacts" workflow with the `Sign Envelope` step. For further information on workflows check the [docs](/guides/features/workflows).
+The supplier must be signed for the linked invoice to appear. Send the supplier to a "contacts" workflow with the `Sign envelope` step. For further information on workflows check the [docs](/guides/features/workflows).
 </Step>
 
 <Step title="Link the invoice">

--- a/guides/series.mdx
+++ b/guides/series.mdx
@@ -111,11 +111,11 @@ Response:
 
 ## Using Series in Workflows
 
-The most common way to use series is through the **Add Sequential Code** step in your workflows. This step automatically generates the next number in the sequence and adds it to your document.
+The most common way to use series is through the **Add sequential code** step in your workflows. This step automatically generates the next number in the sequence and adds it to your document.
 
 ### Dynamic vs. Static Series
 
-When configuring the **Add Sequential Code** step, you can choose between:
+When configuring the **Add sequential code** step, you can choose between:
 
 - **Dynamic Series**: Creates a new series automatically if one doesn't exist with the specified name. This is useful when you want the workflow to handle series creation automatically.
 - **Static Series**: Uses an existing series that you've already created. Select the series from a dropdown of available series.
@@ -123,14 +123,14 @@ When configuring the **Add Sequential Code** step, you can choose between:
 ### Adding a Sequential Code Step
 
 1. In your workflow, click **+ Add step**.
-2. Search for or select **Add Sequential Code**.
+2. Search for or select **Add sequential code**.
 3. Choose either **Dynamic** or **Static** series mode.
 4. If using **Dynamic**, enter a name for the series (e.g., "Invoice").
 5. If using **Static**, select an existing series from the dropdown.
 6. Configure additional options if needed (such as signing the document).
 
 <Note>
-The **Add Sequential Code** step uses the `sequence.enumerate` provider. When using dynamic series, the step will create a new series with default settings (padding: 6, start: 1) if one doesn't exist.
+The **Add sequential code** step uses the `sequence.enumerate` provider. When using dynamic series, the step will create a new series with default settings (padding: 6, start: 1) if one doesn't exist.
 </Note>
 
 ### Passing a Series ID via Job Arguments
@@ -138,7 +138,7 @@ The **Add Sequential Code** step uses the `sequence.enumerate` provider. When us
 If you need to specify which series to use at runtime — rather than hardcoding it in the workflow configuration — you can pass a `sequence-series-id` argument when creating a job. This is useful when different documents in the same workflow should use different pre-created series.
 
 <Note>
-Your workflow must still include an **Add Sequential Code** step for this argument to take effect. When `sequence-series-id` is provided, the series configuration defined in the step (whether dynamic or static) will be ignored — only the series referenced by the argument will be used.
+Your workflow must still include an **Add sequential code** step for this argument to take effect. When `sequence-series-id` is provided, the series configuration defined in the step (whether dynamic or static) will be ignored — only the series referenced by the argument will be used.
 </Note>
 
 To use this feature, include the series UUID in the job's `args` map with the key `sequence-series-id` when calling the [Create a Job](/api-ref/transform/jobs/create-a-job-post) endpoint:
@@ -155,7 +155,7 @@ To use this feature, include the series UUID in the job's `args` map with the ke
 
 When `sequence-series-id` is provided:
 
-- The workflow must contain an **Add Sequential Code** step — the argument does not add the step for you, it only determines which series the existing step will use.
+- The workflow must contain an **Add sequential code** step — the argument does not add the step for you, it only determines which series the existing step will use.
 - The step's own series configuration (both dynamic and static) is **ignored** in favor of the series specified by the argument.
 - The value must be a valid UUID referencing an existing series created via the API or Console.
 - If the series does not exist, the task will fail with a `"sequence not found"` error — no series will be auto-created.

--- a/guides/stripe.mdx
+++ b/guides/stripe.mdx
@@ -104,10 +104,10 @@ To create a new workflow click on **Create New Workflow** in the sidebar menu. Y
   <Frame>
     ![stripe import](/assets/guides/stripe-import.png)
   </Frame>
-  1. Add the **Import data from Stripe** step as the first step of the workflow.
+  1. Add the **Import invoice from Stripe** step as the first step of the workflow.
   2. Configure the workflow according to your local regulations. You can copy _the Basic PDF workflow_ example below and modify it later for your local needs.
 
-  Finally, in the Error Handling area, add the **Set State** action and select "Error" in the State dropdown.
+  Finally, in the Error Handling area, add the **Set state** action and select "Error" in the State dropdown.
 </Tab>
 </Tabs>
 </Step>
@@ -166,7 +166,7 @@ If an invoice fails, it is usually one of two cases:
   ![stripe retry invoice](/assets/guides/stripe-retry-import.png)
 </Frame>
 
-2. The invoice was imported into Invopop but submission to the tax authority failed. Correct the invoice in Invopop and re-run a workflow that omits the **Import data from Stripe** step to avoid reimporting the original data. Typical causes include missing required fields or invalid field formats.
+2. The invoice was imported into Invopop but submission to the tax authority failed. Correct the invoice in Invopop and re-run a workflow that omits the **Import invoice from Stripe** step to avoid reimporting the original data. Typical causes include missing required fields or invalid field formats.
 
 <Frame caption="Incorrect invoice details">
   ![stripe retry invoice](/assets/guides/stripe-invoice-wrong-details.png)

--- a/guides/workflows.mdx
+++ b/guides/workflows.mdx
@@ -182,7 +182,7 @@ Any step that causes an error (`KO`) from which the job can't recover, and is no
 
 If your step conditions displays a **This step contains deprecated conditions** warning, your workflow will continue working normally, but we recommend updating your workflow so that you can modify it without unexpected behavior.
 
-Steps under deprecated conditions will display with a warning symbol ⚠️ with the label "Go to [action name]". Click on the menu button `...` and select "Replace", and then select the replacement action from the sidebar. So, for example, if the deprecated step is labelled "Go to Set State", replace this step with "Set State" and choose the same configuration as the original step (which you should find further down within the same workflow).
+Steps under deprecated conditions will display with a warning symbol ⚠️ with the label "Go to [action name]". Click on the menu button `...` and select "Replace", and then select the replacement action from the sidebar. So, for example, if the deprecated step is labelled "Go to Set state", replace this step with "Set state" and choose the same configuration as the original step (which you should find further down within the same workflow).
 
 Once all deprecated steps are replaced, locate the the referenced action(s) and delete.
 </Accordion>


### PR DESCRIPTION
Renames workflow action **display names** across documentation to match the new action naming. Action **codes** (e.g. `gov-es.ticketbai.send`, `email.send`) are untouched, and `/snippets/` is excluded — those regenerate from the workflow source repo.

## Scope
61 files across `guides/`, `apps/`, `console/`, and `get-started/`. Pure renames (413 insertions / 413 deletions). Examples:

- `Set State` → `Set state`, `Sign Envelope` / `Add Signature` → `Sign envelope`
- `Send to SAT (Mexico)` → `Send invoice to SAT`, `Register SAT Issuer` → `Register supplier with SAT`
- `Generate TicketBAI (Spain)` → `Generate TicketBAI XML`, `Send TicketBAI` → `Send invoice to TicketBAI`
- `Send NF-e (Brazil)` → `Send NF-e to SEFAZ`, `Send NFS-e (Brazil)` → `Send NFS-e to Prefeitura`
- `Send to IAPR (via ILYDA)` → `Send invoice to MyDATA`
- Country-suffix variants (`(Mexico)`, `(Italy)`, `(Spain)`, …) dropped where the new name has none.
- Names that did not change (`Generate PDF`, `Generate FatturaPA`, `Generate Facturae XML`, SII record steps, `Unregister supplier from Peppol`, …) were left as-is.

## Intentionally left unchanged
- `Create a Job` **API-endpoint** links (point at the REST operation page, not the workflow step).
- `"Sync with Chargebee"` as a suggested *workflow name* the user types in the Chargebee guide.
- `Unregister VERI*FACTU supplier` accordion (FAQ heading, not an action label).
- A few custom/paraphrased step labels with no canonical old name (`Subscribe to Periodic Import`, shortened NO VERI*FACTU labels, some FR custom card labels).

🤖 Generated with [Claude Code](https://claude.com/claude-code)