### PR TITLE
Trim FR 210 Refusée reason codes to the supported set

### DIFF
--- a/guides/fr-pa-status.mdx
+++ b/guides/fr-pa-status.mdx
@@ -288,7 +288,6 @@ Codes `206`, `207`, `208` and `210` require at least one `reason` on the line, a
     | Reason code | French | English |
     |---|---|---|
     | `TRANSAC_INC` <Badge color="green" size="sm">⚹</Badge> | Transaction inconnue | Unknown transaction |
-    | `COORD_BANC_ERR` | Erreur de coordonnées bancaires | Incorrect bank details |
     | `TX_TVA_ERR` | Taux de TVA erroné | Incorrect VAT rate |
     | `MONTANTTOTAL_ERR` | Montant total erroné | Incorrect total amount |
     | `CALCUL_ERR` | Erreur de calcul de la facture | Invoice calculation error |
@@ -300,17 +299,7 @@ Codes `206`, `207`, `208` and `210` require at least one `reason` on the line, a
     | `DOUBLE_FACT` | Double facture | Double invoicing |
     | `CMD_ERR` | N° de commande incorrect ou manquant | Incorrect or missing order number |
     | `ADR_ERR` | Adresse de facturation électronique erronée | Incorrect electronic billing address |
-    | `SIRET_ERR` | SIRET erroné ou absent | Incorrect or missing SIRET |
-    | `CODE_ROUTAGE_ERR` | CODE_ROUTAGE absent ou erroné | Missing or incorrect routing code |
     | `REF_CT_ABSENT` | Référence contractuelle nécessaire | Contractual reference required |
-    | `REF_ERR` | Référence incorrecte | Incorrect reference |
-    | `PU_ERR` | Prix unitaires incorrects | Incorrect unit prices |
-    | `REM_ERR` | Remise erronée | Incorrect discount |
-    | `QTE_ERR` | Quantité facturée incorrecte | Incorrect invoiced quantity |
-    | `ART_ERR` | Article facturé incorrect | Incorrect invoiced item |
-    | `MODPAI_ERR` | Modalités de paiement incorrectes | Incorrect payment terms |
-    | `QUALITE_ERR` | Qualité d'article livré incorrecte | Incorrect quality of delivered item |
-    | `LIVR_INCOMP` | Problème de livraison | Delivery problem |
   </Accordion>
 </AccordionGroup>
 


### PR DESCRIPTION
Fix the `210` Refusée reason table in the France PA lifecycle guide, which listed 24 codes (mistakenly copied from the `206` bucket). Reduce it to the 13 codes actually allowed by `BR-FR-CDV-CL-09`, as enforced by the `fr-ctc-flow6` addon (`bill_status.go` rule `21`).

Changes:
- Remove `COORD_BANC_ERR`, `SIRET_ERR`, `CODE_ROUTAGE_ERR`, `REF_ERR`, `PU_ERR`, `REM_ERR`, `QTE_ERR`, `ART_ERR`, `MODPAI_ERR`, `QUALITE_ERR`, `LIVR_INCOMP` from the `210` table

🤖 Generated with [Claude Code](https://claude.com/claude-code)