### PR TITLE
Remove declaración responsable references from the SII guide

### DIFF
--- a/guides/es-sii-supplier.mdx
+++ b/guides/es-sii-supplier.mdx
@@ -390,16 +390,6 @@ Unregistering a supplier is essentially revoking their invoice issuing privilege
 
 <AccordionGroup>
 
-  <Accordion title="SII self certification process">
-    There is no official certification for SII from the AEAT (the Spanish tax agency). Instead, each developer, company, or provider that implements an invoicing software must provide an electronically signed declaration where they certify that their system meets all the requirements established in the regulations. This document is binding and must be kept available for the Tax Authority.
-
-    The AEAT requires that this declaration be available and always visible within the system itself, and it must include certain control elements such as the installation number, issuer data, software version, and system ID.
-
-    If you are a white label user of Invopop (you issue invoices in the name of third parties), you are required to display a link to this "declaración responsable" in your software. Here is [the template from the AEAT](https://sede.agenciatributaria.gob.es/static_files/Sede/Tema/IVA/SII/EjemplosDeclaracionResponsable(V0.5.1).pdf), and our own for your reference: [Declaración responsable SII - Invopop](https://drive.google.com/file/d/1IR2EuavoEi8E3hlAM4u-XTIFbalxxKzj/view). Some of our customers have asked us if it is necessary to mention Invopop in their _declaración responable_. It is not required, but we appreciate it.
-  </Accordion>
-  <Accordion title="SII representation agreement">
-    [Declaración responsable SII - Invopop](https://drive.google.com/file/d/1IR2EuavoEi8E3hlAM4u-XTIFbalxxKzj/view) (PDF)
-  </Accordion>
   <Accordion title="Valid digital signatures for the SII's Supplier Agreement PDF">
     Digital signatures rely on certificates, but not all certificates serve as proof of identity. The Spanish Tax Agency (AEAT) accepts only qualified certificates—those issued by an authority that has verified the holder's identity in advance.
 


### PR DESCRIPTION
Remove the declaración responsable content from the SII supplier guide — surfaced by Pylon #5143, where a customer noticed both the SII and VERI*FACTU supplier guides pointed to the same declaración responsable document.

Internal confirmation from Luis Coll: the declaración responsable is a self-certification requirement specific to VERI*FACTU (RD 1007/2023). There's no AEAT equivalent for SII; its only documentary requirements are the ones already covered in the onboarding process. The SII guide had reused the VERI*FACTU content by mistake.

Changes:
- Remove the "SII self certification process" and "SII representation agreement" accordions from `guides/es-sii-supplier.mdx`
- Leave the VERI*FACTU guide (`guides/es-verifactu-supplier.mdx`) and `compliance/spain.mdx` untouched — the declaración responsable content is correct there

🤖 Generated with [Claude Code](https://claude.com/claude-code)
