### PR TITLE
Document flow10 e-reporting custom fields in Chargebee France guide

### DIFF
--- a/guides/chargebee.mdx
+++ b/guides/chargebee.mdx
@@ -437,6 +437,15 @@ Use the custom fields below to control this. Set the **Peppol inbox** to target 
 | SIREN | `gobl-customer-identity-SIREN` | `cf_gobl_customer_identity_SIREN` | `123456789` |
 | SIRET | `gobl-customer-identity-SIRET` | `cf_gobl_customer_identity_SIRET` | `12345678900011` |
 
+#### E-reporting transaction fields
+
+The e-reporting path applies the `fr-ctc-flow10-v1` addon, which defines two invoice tax extensions. By default, the addon sets the billing mode to `M1` — or `M2` when the invoice is fully paid — and the B2C transaction category to `TNT1`. Use the custom fields below to override these defaults:
+
+| Field | Metadata key | Custom field key | Example |
+| ----- | ------------ | ---------------- | ------- |
+| Billing mode | `gobl-tax-fr-ctc-billing-mode` | `cf_gobl_tax_fr_ctc_billing_mode` | `S1` |
+| B2C transaction category | `gobl-tax-fr-ctc-flow10-b2c-category` | `cf_gobl_tax_fr_ctc_flow10_b2c_category` | `TPS1` |
+
 ---
 
 ## Retriggering Invoices


### PR DESCRIPTION
Add the fr-ctc-flow10-v1 invoice tax extensions (billing mode and B2C transaction category) to the France section of the Chargebee guide, so users know the Chargebee custom field / metadata keys and the addon defaults they override.

🤖 Generated with [Claude Code](https://claude.com/claude-code)