### PR TITLE
Add self-billing to France PA invoicing guide

### DIFF
--- a/guides/fr-pa-invoicing.mdx
+++ b/guides/fr-pa-invoicing.mdx
@@ -125,10 +125,10 @@ The receive workflow detects the inbound format, imports it into a GOBL document
 
 In self-billing (_also called autofacturation_), the **customer**, rather than the supplier, creates and issues the invoice on the supplier's behalf. The buyer's platform acts as the sending PA and triggers the flow 1 reporting to the PPF, while the supplier's platform receives the invoice.
 
-Invopop covers self-billing with the **same send and receive workflows described above**. The only difference is on the document, which uses the `self-billed` tag. 
+Invopop covers self-billing with the **same send and receive workflows described above**. The only difference is on the document, which carries the `self-billed` tag.
 
 <Note>
-Check [GOBL docs](https://docs.gobl.org/addons/fr-ctc-flow2-v1#standard-self-billed) for futher information on how `fr-ctc-flow2-v1` handles the self-billed tag.
+Unlike most Peppol countries, France does not treat self-billing as a document type of its own: it is a standard invoice with the `untdid-document-type` extension set to `389`. The [`fr-ctc-flow2-v1`](https://docs.gobl.org/addons/fr-ctc-flow2-v1#standard-self-billed) add-on derives that code from the `self-billed` tag automatically, so you never set it yourself.
 </Note>
 
 The parties keep their natural roles, the vendor remains the `supplier`, and the buyer the `customer`. When Invopop detects the tag, it acts on behalf of the customer and adjusts the flow automatically:

--- a/guides/fr-pa-invoicing.mdx
+++ b/guides/fr-pa-invoicing.mdx
@@ -121,6 +121,36 @@ The receive workflow detects the inbound format, imports it into a GOBL document
   </Tab>
 </Tabs>
 
+## Self-billing
+
+In self-billing (_also called autofacturation_), the **customer**, rather than the supplier, creates and issues the invoice on the supplier's behalf. The buyer's platform acts as the sending PA and triggers the flow 1 reporting to the PPF, while the supplier's platform receives the invoice.
+
+Invopop covers self-billing with the **same send and receive workflows described above**. The only difference is on the document, which uses the `self-billed` tag. 
+
+<Note>
+Check [GOBL docs](https://docs.gobl.org/addons/fr-ctc-flow2-v1#standard-self-billed) for futher information on how `fr-ctc-flow2-v1` handles the self-billed tag.
+</Note>
+
+The parties keep their natural roles, the vendor remains the `supplier`, and the buyer the `customer`. When Invopop detects the tag, it acts on behalf of the customer and adjusts the flow automatically:
+
+- The **customer**, rather than the supplier, is validated as the registered party.
+- The invoice is delivered over Peppol to the **supplier's** PA.
+- The invoice is recorded and forwarded to the PPF as a self-billed invoice.
+
+France also requires the _autofacturation_ note on the invoice, which appears as a `legal` note, as shown in the [example](#example-invoices) below.
+
+### Step by step
+
+How each step of the self-billing use case maps to an action in Invopop, on both the buyer (sending) and supplier (receiving) side. Statuses are built and exchanged as described in the [status guide](/guides/fr-pa-status).
+
+| Step | Actor | In Invopop |
+|---|---|---|
+| 1 | Buyer | Creates a GOBL invoice tagged `self-billed`. |
+| 2 | Buyer's PA | The buyer's [send workflow](#sending) generates the UBL, CII, or Factur-X document and transmits it as normal. The mandatory `200` Déposée status is emitted automatically once the PPF accepts flow 1. |
+| 3 | Seller's PA | The seller's [receive workflow](#receiving) imports the invoice and records it, resolving the seller's registered party as the `supplier`. |
+| 4 | Seller | Upon reception of payment, the seller builds a `bill.Payment` referencing the invoice, sends it to the customer and forwards it to the PPF. |
+| 5 | Buyer | The buyer's receive workflow imports the inbound CDAR and records it against the invoice. |
+
 ## Example invoices
 
 Each example below pairs a hand-authored minimal GOBL invoice with the built version produced by `gobl build`. Paste either into the [GOBL builder](https://build.gobl.org) to preview the document, or use the minimal version as a starting point for your own integration.

--- a/guides/fr-pa-invoicing.mdx
+++ b/guides/fr-pa-invoicing.mdx
@@ -128,7 +128,7 @@ In self-billing (_also called autofacturation_), the **customer**, rather than t
 Invopop covers self-billing with the **same send and receive workflows described above**. The only difference is on the document, which carries the `self-billed` tag.
 
 <Note>
-Unlike most Peppol countries, France does not treat self-billing as a document type of its own: it is a standard invoice with the `untdid-document-type` extension set to `389`. The [`fr-ctc-flow2-v1`](https://docs.gobl.org/addons/fr-ctc-flow2-v1#standard-self-billed) add-on derives that code from the `self-billed` tag automatically, so you never set it yourself.
+France does not treat self-billing as a document type of its own: it is a standard invoice with the `untdid-document-type` extension set to `389`. The [`fr-ctc-flow2-v1`](https://docs.gobl.org/addons/fr-ctc-flow2-v1#standard-self-billed) add-on derives that code from the `self-billed` tag automatically, so you never set it yourself.
 </Note>
 
 The parties keep their natural roles, the vendor remains the `supplier`, and the buyer the `customer`. When Invopop detects the tag, it acts on behalf of the customer and adjusts the flow automatically:

--- a/snippets/faqs/fr/leaves/pa/invoicing.mdx
+++ b/snippets/faqs/fr/leaves/pa/invoicing.mdx
@@ -5,3 +5,7 @@
   <Accordion title="What GOBL addons are required for France PA?">
     The base [`fr-fec-v3`](https://docs.gobl.org/regimes/fr) regime plus the EN 16931 profile. For Peppol delivery, `peppol-bis-v3`. The forthcoming `fr-ctc-flow10-v1` addon covers e-reporting payloads — separate from the e-invoicing flow.
   </Accordion>
+
+  <Accordion title="Is a self-billed invoice a different document type in France?">
+    No. Most Peppol countries treat self-billing as a document type of its own, but France models it as a **standard invoice** with the `untdid-document-type` extension set to `389`. In GOBL you never set the code yourself: add the `self-billed` tag and the [`fr-ctc-flow2-v1`](https://docs.gobl.org/addons/fr-ctc-flow2-v1#standard-self-billed) add-on applies it automatically. See [Self-billing](/guides/fr-pa-invoicing#self-billing) for the full flow.
+  </Accordion>

--- a/snippets/invoices/fr/pa-accordion.mdx
+++ b/snippets/invoices/fr/pa-accordion.mdx
@@ -61,12 +61,12 @@ import International from '/snippets/invoices/fr/pa-b2b-international.mdx';
 
 	<Accordion title="PA self-billed invoice">
 
-		A self-billed invoice ("autofacturation") — the buyer issues the invoice on the supplier's behalf under an invoicing mandate and sends it through the standard [send workflow](/guides/fr-pa-invoicing#sending). See [Self-billing](/guides/fr-pa-invoicing#self-billing) for the full flow.
+		A self-billed invoice (_autofacturation_): buyer issues the invoice on the supplier's behalf and sends it through the [send workflow](/guides/fr-pa-invoicing#sending). See [Self-billing](/guides/fr-pa-invoicing#self-billing) for the full flow.
 
 		Notice:
 
-		- the `self-billed` tag sets `untdid-document-type` to `389` (self-billed invoice) at build time — you never set the code yourself,
-		- the parties keep their natural roles: the vendor is the `supplier` and the issuing buyer is the `customer` — Invopop detects the tag and routes the invoice to the supplier instead,
+		- the `self-billed` tag sets `untdid-document-type` to `389` (self-billed invoice),
+		- the parties keep their natural roles: the vendor is the `supplier` and the issuing buyer is the `customer`. Invopop detects the tag and routes the invoice to the supplier instead,
 		- the mandatory "Autofacturation" mention travels as a `legal` note.
 
 		<CodeGroup>

--- a/snippets/invoices/fr/pa-accordion.mdx
+++ b/snippets/invoices/fr/pa-accordion.mdx
@@ -4,6 +4,8 @@ import CreditNoteMin from '/snippets/invoices/fr/pa-credit-note.min.mdx';
 import CreditNote from '/snippets/invoices/fr/pa-credit-note.mdx';
 import AdvanceMin from '/snippets/invoices/fr/pa-advance.min.mdx';
 import Advance from '/snippets/invoices/fr/pa-advance.mdx';
+import SelfBilledMin from '/snippets/invoices/fr/pa-self-billed.min.mdx';
+import SelfBilled from '/snippets/invoices/fr/pa-self-billed.mdx';
 import InternationalMin from '/snippets/invoices/fr/pa-b2b-international.min.mdx';
 import International from '/snippets/invoices/fr/pa-b2b-international.mdx';
 
@@ -54,6 +56,22 @@ import International from '/snippets/invoices/fr/pa-b2b-international.mdx';
 		<CodeGroup>
 			<AdvanceMin />
 			<Advance />
+		</CodeGroup>
+	</Accordion>
+
+	<Accordion title="PA self-billed invoice">
+
+		A self-billed invoice ("autofacturation") — the buyer issues the invoice on the supplier's behalf under an invoicing mandate and sends it through the standard [send workflow](/guides/fr-pa-invoicing#sending). See [Self-billing](/guides/fr-pa-invoicing#self-billing) for the full flow.
+
+		Notice:
+
+		- the `self-billed` tag sets `untdid-document-type` to `389` (self-billed invoice) at build time — you never set the code yourself,
+		- the parties keep their natural roles: the vendor is the `supplier` and the issuing buyer is the `customer` — Invopop detects the tag and routes the invoice to the supplier instead,
+		- the mandatory "Autofacturation" mention travels as a `legal` note.
+
+		<CodeGroup>
+			<SelfBilledMin />
+			<SelfBilled />
 		</CodeGroup>
 	</Accordion>
 

--- a/snippets/invoices/fr/pa-self-billed.mdx
+++ b/snippets/invoices/fr/pa-self-billed.mdx
@@ -10,76 +10,51 @@
 		"self-billed"
 	],
 	"type": "standard",
-	"series": "AF",
-	"code": "2024-00007",
-	"issue_date": "2024-06-13",
+	"code": "17",
+	"issue_date": "2026-07-13",
 	"currency": "EUR",
 	"tax": {
 		"rounding": "currency",
 		"ext": {
-			"fr-ctc-billing-mode": "B7",
+			"fr-ctc-billing-mode": "M1",
 			"untdid-document-type": "389"
 		}
 	},
 	"supplier": {
-		"name": "Fournisseur Example SARL",
+		"name": "Test supplier",
 		"tax_id": {
 			"country": "FR",
-			"code": "44732829320"
+			"code": "82874367109"
 		},
 		"identities": [
 			{
 				"scope": "legal",
 				"type": "SIREN",
-				"code": "732829320",
+				"code": "874367109",
 				"ext": {
 					"iso-scheme-id": "0002"
 				}
+			}
+		],
+		"people": [
+			{
+				"name": {
+					"given": "Test supplier",
+					"surname": "Invopop"
+				},
+				"role": "test",
+				"identities": [
+					{
+						"code": "test"
+					}
+				]
 			}
 		],
 		"inboxes": [
 			{
 				"key": "peppol",
 				"scheme": "0225",
-				"code": "732829320"
-			}
-		],
-		"addresses": [
-			{
-				"num": "123",
-				"street": "Rue de la Paix",
-				"locality": "Paris",
-				"code": "75001",
-				"country": "FR"
-			}
-		],
-		"emails": [
-			{
-				"addr": "facturation@fournisseur.fr"
-			}
-		]
-	},
-	"customer": {
-		"name": "Client Example SAS",
-		"tax_id": {
-			"country": "FR",
-			"code": "39356000000"
-		},
-		"identities": [
-			{
-				"scope": "legal",
-				"type": "SIREN",
-				"code": "356000000",
-				"ext": {
-					"iso-scheme-id": "0002"
-				}
-			}
-		],
-		"inboxes": [
-			{
-				"key": "peppol",
-				"scheme": "0225",
-				"code": "356000000"
+				"code": "874367109"
 			}
 		],
 		"addresses": [
@@ -93,7 +68,59 @@
 		],
 		"emails": [
 			{
-				"addr": "comptabilite@client.fr"
+				"addr": "test@gmail.com"
+			}
+		]
+	},
+	"customer": {
+		"name": "Camille Moreau",
+		"tax_id": {
+			"country": "FR",
+			"code": "86874117109"
+		},
+		"identities": [
+			{
+				"scope": "legal",
+				"type": "SIREN",
+				"code": "874117109",
+				"ext": {
+					"iso-scheme-id": "0002"
+				}
+			}
+		],
+		"people": [
+			{
+				"name": {
+					"given": "Camille",
+					"surname": "Moreau"
+				},
+				"role": "test",
+				"identities": [
+					{
+						"code": "test"
+					}
+				]
+			}
+		],
+		"inboxes": [
+			{
+				"key": "peppol",
+				"scheme": "0225",
+				"code": "874117109"
+			}
+		],
+		"addresses": [
+			{
+				"street": "Rue de l'Université",
+				"locality": "Paris",
+				"region": "Paris",
+				"code": "75007",
+				"country": "FR"
+			}
+		],
+		"emails": [
+			{
+				"addr": "test@gmail.com"
 			}
 		]
 	},

--- a/snippets/invoices/fr/pa-self-billed.mdx
+++ b/snippets/invoices/fr/pa-self-billed.mdx
@@ -159,7 +159,7 @@
 			"key": "credit-transfer",
 			"credit_transfer": [
 				{
-					"iban": "FR7630006000011234567890189",
+					"iban": "FR0000000000099999999999999",
 					"name": "Fournisseur Example SARL"
 				}
 			],

--- a/snippets/invoices/fr/pa-self-billed.mdx
+++ b/snippets/invoices/fr/pa-self-billed.mdx
@@ -1,0 +1,202 @@
+```json Built version
+{
+	"$schema": "https://gobl.org/draft-0/bill/invoice",
+	"$regime": "FR",
+	"$addons": [
+		"eu-en16931-v2017",
+		"fr-ctc-flow2-v1"
+	],
+	"$tags": [
+		"self-billed"
+	],
+	"type": "standard",
+	"series": "AF",
+	"code": "2024-00007",
+	"issue_date": "2024-06-13",
+	"currency": "EUR",
+	"tax": {
+		"rounding": "currency",
+		"ext": {
+			"fr-ctc-billing-mode": "B7",
+			"untdid-document-type": "389"
+		}
+	},
+	"supplier": {
+		"name": "Fournisseur Example SARL",
+		"tax_id": {
+			"country": "FR",
+			"code": "44732829320"
+		},
+		"identities": [
+			{
+				"scope": "legal",
+				"type": "SIREN",
+				"code": "732829320",
+				"ext": {
+					"iso-scheme-id": "0002"
+				}
+			}
+		],
+		"inboxes": [
+			{
+				"key": "peppol",
+				"scheme": "0225",
+				"code": "732829320"
+			}
+		],
+		"addresses": [
+			{
+				"num": "123",
+				"street": "Rue de la Paix",
+				"locality": "Paris",
+				"code": "75001",
+				"country": "FR"
+			}
+		],
+		"emails": [
+			{
+				"addr": "facturation@fournisseur.fr"
+			}
+		]
+	},
+	"customer": {
+		"name": "Client Example SAS",
+		"tax_id": {
+			"country": "FR",
+			"code": "39356000000"
+		},
+		"identities": [
+			{
+				"scope": "legal",
+				"type": "SIREN",
+				"code": "356000000",
+				"ext": {
+					"iso-scheme-id": "0002"
+				}
+			}
+		],
+		"inboxes": [
+			{
+				"key": "peppol",
+				"scheme": "0225",
+				"code": "356000000"
+			}
+		],
+		"addresses": [
+			{
+				"num": "456",
+				"street": "Avenue des Champs-Elysees",
+				"locality": "Paris",
+				"code": "75008",
+				"country": "FR"
+			}
+		],
+		"emails": [
+			{
+				"addr": "comptabilite@client.fr"
+			}
+		]
+	},
+	"lines": [
+		{
+			"i": 1,
+			"quantity": "10",
+			"item": {
+				"name": "Services de conseil",
+				"price": "100.00",
+				"unit": "h"
+			},
+			"sum": "1000.00",
+			"taxes": [
+				{
+					"cat": "VAT",
+					"key": "standard",
+					"rate": "general",
+					"percent": "20%",
+					"ext": {
+						"untdid-tax-category": "S"
+					}
+				}
+			],
+			"total": "1000.00"
+		}
+	],
+	"ordering": {
+		"code": "PO-2024-001"
+	},
+	"payment": {
+		"terms": {
+			"notes": "Paiement a 30 jours"
+		},
+		"instructions": {
+			"key": "credit-transfer",
+			"credit_transfer": [
+				{
+					"iban": "FR7630006000011234567890189",
+					"name": "Fournisseur Example SARL"
+				}
+			],
+			"ext": {
+				"untdid-payment-means": "30"
+			}
+		}
+	},
+	"totals": {
+		"sum": "1000.00",
+		"total": "1000.00",
+		"taxes": {
+			"categories": [
+				{
+					"code": "VAT",
+					"rates": [
+						{
+							"key": "standard",
+							"ext": {
+								"untdid-tax-category": "S"
+							},
+							"base": "1000.00",
+							"percent": "20%",
+							"amount": "200.00"
+						}
+					],
+					"amount": "200.00"
+				}
+			],
+			"sum": "200.00"
+		},
+		"tax": "200.00",
+		"total_with_tax": "1200.00",
+		"payable": "1200.00"
+	},
+	"notes": [
+		{
+			"key": "legal",
+			"text": "Autofacturation",
+			"ext": {
+				"untdid-text-subject": "ABY"
+			}
+		},
+		{
+			"key": "payment",
+			"text": "Une penalite fixe de 40 EUR sera appliquee en cas de retard de paiement.",
+			"ext": {
+				"untdid-text-subject": "PMT"
+			}
+		},
+		{
+			"key": "payment-method",
+			"text": "Des penalites de retard s'appliquent conformement a nos conditions generales de vente.",
+			"ext": {
+				"untdid-text-subject": "PMD"
+			}
+		},
+		{
+			"key": "payment-term",
+			"text": "Aucun escompte n'est offert pour paiement anticipe.",
+			"ext": {
+				"untdid-text-subject": "AAB"
+			}
+		}
+	]
+}
+```

--- a/snippets/invoices/fr/pa-self-billed.min.mdx
+++ b/snippets/invoices/fr/pa-self-billed.min.mdx
@@ -9,72 +9,48 @@
         "self-billed"
     ],
     "type": "standard",
-    "series": "AF",
-    "code": "2024-00007",
-    "issue_date": "2024-06-13",
+    "code": "17",
+    "issue_date": "2026-07-13",
     "currency": "EUR",
     "tax": {
         "ext": {
-            "fr-ctc-billing-mode": "B7"
+            "fr-ctc-billing-mode": "M1"
         }
     },
     "supplier": {
-        "name": "Fournisseur Example SARL",
+        "name": "Test supplier",
         "tax_id": {
             "country": "FR",
-            "code": "732829320"
+            "code": "82874367109"
         },
         "identities": [
             {
                 "type": "SIREN",
-                "code": "732829320",
+                "code": "874367109",
                 "ext": {
                     "iso-scheme-id": "0002"
                 }
+            }
+        ],
+        "people": [
+            {
+                "name": {
+                    "given": "Test supplier",
+                    "surname": "Invopop"
+                },
+                "role": "test",
+                "identities": [
+                    {
+                        "code": "test"
+                    }
+                ]
             }
         ],
         "inboxes": [
             {
                 "key": "peppol",
                 "scheme": "0225",
-                "code": "732829320"
-            }
-        ],
-        "addresses": [
-            {
-                "num": "123",
-                "street": "Rue de la Paix",
-                "locality": "Paris",
-                "code": "75001",
-                "country": "FR"
-            }
-        ],
-        "emails": [
-            {
-                "addr": "facturation@fournisseur.fr"
-            }
-        ]
-    },
-    "customer": {
-        "name": "Client Example SAS",
-        "tax_id": {
-            "country": "FR",
-            "code": "356000000"
-        },
-        "identities": [
-            {
-                "type": "SIREN",
-                "code": "356000000",
-                "ext": {
-                    "iso-scheme-id": "0002"
-                }
-            }
-        ],
-        "inboxes": [
-            {
-                "key": "peppol",
-                "scheme": "0225",
-                "code": "356000000"
+                "code": "874367109"
             }
         ],
         "addresses": [
@@ -88,7 +64,58 @@
         ],
         "emails": [
             {
-                "addr": "comptabilite@client.fr"
+                "addr": "test@gmail.com"
+            }
+        ]
+    },
+    "customer": {
+        "name": "Camille Moreau",
+        "tax_id": {
+            "country": "FR",
+            "code": "86874117109"
+        },
+        "identities": [
+            {
+                "type": "SIREN",
+                "code": "874117109",
+                "ext": {
+                    "iso-scheme-id": "0002"
+                }
+            }
+        ],
+        "people": [
+            {
+                "name": {
+                    "given": "Camille",
+                    "surname": "Moreau"
+                },
+                "role": "test",
+                "identities": [
+                    {
+                        "code": "test"
+                    }
+                ]
+            }
+        ],
+        "inboxes": [
+            {
+                "key": "peppol",
+                "scheme": "0225",
+                "code": "874117109"
+            }
+        ],
+        "addresses": [
+            {
+                "street": "Rue de l'Université",
+                "locality": "Paris",
+                "region": "Paris",
+                "code": "75007",
+                "country": "FR"
+            }
+        ],
+        "emails": [
+            {
+                "addr": "test@gmail.com"
             }
         ]
     },
@@ -103,13 +130,28 @@
             "taxes": [
                 {
                     "cat": "VAT",
-                    "rate": "standard"
+                    "key": "standard",
+                    "rate": "general"
                 }
             ]
         }
     ],
     "ordering": {
         "code": "PO-2024-001"
+    },
+    "payment": {
+        "terms": {
+            "notes": "Paiement a 30 jours"
+        },
+        "instructions": {
+            "key": "credit-transfer",
+            "credit_transfer": [
+                {
+                    "iban": "FR0000000000099999999999999",
+                    "name": "Fournisseur Example SARL"
+                }
+            ]
+        }
     },
     "notes": [
         {
@@ -137,20 +179,6 @@
                 "untdid-text-subject": "AAB"
             }
         }
-    ],
-    "payment": {
-        "instructions": {
-            "key": "credit-transfer",
-            "credit_transfer": [
-                {
-                    "iban": "FR7630006000011234567890189",
-                    "name": "Fournisseur Example SARL"
-                }
-            ]
-        },
-        "terms": {
-            "detail": "Paiement a 30 jours"
-        }
-    }
+    ]
 }
 ```

--- a/snippets/invoices/fr/pa-self-billed.min.mdx
+++ b/snippets/invoices/fr/pa-self-billed.min.mdx
@@ -1,0 +1,156 @@
+```json PA Self-Billed Invoice
+{
+    "$schema": "https://gobl.org/draft-0/bill/invoice",
+    "$regime": "FR",
+    "$addons": [
+        "fr-ctc-flow2-v1"
+    ],
+    "$tags": [
+        "self-billed"
+    ],
+    "type": "standard",
+    "series": "AF",
+    "code": "2024-00007",
+    "issue_date": "2024-06-13",
+    "currency": "EUR",
+    "tax": {
+        "ext": {
+            "fr-ctc-billing-mode": "B7"
+        }
+    },
+    "supplier": {
+        "name": "Fournisseur Example SARL",
+        "tax_id": {
+            "country": "FR",
+            "code": "732829320"
+        },
+        "identities": [
+            {
+                "type": "SIREN",
+                "code": "732829320",
+                "ext": {
+                    "iso-scheme-id": "0002"
+                }
+            }
+        ],
+        "inboxes": [
+            {
+                "key": "peppol",
+                "scheme": "0225",
+                "code": "732829320"
+            }
+        ],
+        "addresses": [
+            {
+                "num": "123",
+                "street": "Rue de la Paix",
+                "locality": "Paris",
+                "code": "75001",
+                "country": "FR"
+            }
+        ],
+        "emails": [
+            {
+                "addr": "facturation@fournisseur.fr"
+            }
+        ]
+    },
+    "customer": {
+        "name": "Client Example SAS",
+        "tax_id": {
+            "country": "FR",
+            "code": "356000000"
+        },
+        "identities": [
+            {
+                "type": "SIREN",
+                "code": "356000000",
+                "ext": {
+                    "iso-scheme-id": "0002"
+                }
+            }
+        ],
+        "inboxes": [
+            {
+                "key": "peppol",
+                "scheme": "0225",
+                "code": "356000000"
+            }
+        ],
+        "addresses": [
+            {
+                "num": "456",
+                "street": "Avenue des Champs-Elysees",
+                "locality": "Paris",
+                "code": "75008",
+                "country": "FR"
+            }
+        ],
+        "emails": [
+            {
+                "addr": "comptabilite@client.fr"
+            }
+        ]
+    },
+    "lines": [
+        {
+            "quantity": "10",
+            "item": {
+                "name": "Services de conseil",
+                "price": "100.00",
+                "unit": "h"
+            },
+            "taxes": [
+                {
+                    "cat": "VAT",
+                    "rate": "standard"
+                }
+            ]
+        }
+    ],
+    "ordering": {
+        "code": "PO-2024-001"
+    },
+    "notes": [
+        {
+            "key": "legal",
+            "text": "Autofacturation"
+        },
+        {
+            "key": "payment",
+            "text": "Une penalite fixe de 40 EUR sera appliquee en cas de retard de paiement.",
+            "ext": {
+                "untdid-text-subject": "PMT"
+            }
+        },
+        {
+            "key": "payment-method",
+            "text": "Des penalites de retard s'appliquent conformement a nos conditions generales de vente.",
+            "ext": {
+                "untdid-text-subject": "PMD"
+            }
+        },
+        {
+            "key": "payment-term",
+            "text": "Aucun escompte n'est offert pour paiement anticipe.",
+            "ext": {
+                "untdid-text-subject": "AAB"
+            }
+        }
+    ],
+    "payment": {
+        "instructions": {
+            "key": "credit-transfer",
+            "credit_transfer": [
+                {
+                    "iban": "FR7630006000011234567890189",
+                    "name": "Fournisseur Example SARL"
+                }
+            ]
+        },
+        "terms": {
+            "detail": "Paiement a 30 jours"
+        }
+    }
+}
+```


### PR DESCRIPTION
Add self-billing (autofacturation) docs to the France PA invoicing guide (APP-637).

Changes:
- New "Self-billing" section in the FR PA invoicing guide: how the `self-billed` tag inverts the flow, plus a step-by-step table
- New self-billed GOBL example pair (`self-billed` tag → `untdid-document-type` 389), added to the PA examples accordion

🤖 Generated with [Claude Code](https://claude.com/claude-code)