### PR TITLE
Rebuild FR GOBL example fixtures with gobl v0.503.0

### DIFF
--- a/snippets/examples/fr/states/201-issued.mdx
+++ b/snippets/examples/fr/states/201-issued.mdx
@@ -79,7 +79,10 @@
 				"type": "380",
 				"issue_date": "2026-06-19",
 				"series": "INV",
-				"code": "2026-0042"
+				"code": "2026-0042",
+				"ext": {
+					"untdid-document-type": "380"
+				}
 			},
 			"ext": {
 				"fr-ctc-flow6-status": "201"

--- a/snippets/examples/fr/states/201-issued.mdx
+++ b/snippets/examples/fr/states/201-issued.mdx
@@ -76,7 +76,6 @@
 			"key": "issued",
 			"date": "2026-06-19",
 			"doc": {
-				"type": "380",
 				"issue_date": "2026-06-19",
 				"series": "INV",
 				"code": "2026-0042",

--- a/snippets/examples/fr/states/201-issued.min.mdx
+++ b/snippets/examples/fr/states/201-issued.min.mdx
@@ -58,7 +58,9 @@ description: "GOBL bill/status example for French CTC lifecycle code 201 (Issued
         "series": "INV",
         "code": "2026-0042",
         "issue_date": "2026-06-19",
-        "type": "380"
+        "ext": {
+          "untdid-document-type": "380"
+        }
       }
     }
   ]

--- a/snippets/examples/fr/states/202-acknowledged.mdx
+++ b/snippets/examples/fr/states/202-acknowledged.mdx
@@ -76,7 +76,6 @@
 			"key": "acknowledged",
 			"date": "2026-06-19",
 			"doc": {
-				"type": "380",
 				"issue_date": "2026-06-19",
 				"series": "INV",
 				"code": "2026-0042",

--- a/snippets/examples/fr/states/202-acknowledged.mdx
+++ b/snippets/examples/fr/states/202-acknowledged.mdx
@@ -79,7 +79,10 @@
 				"type": "380",
 				"issue_date": "2026-06-19",
 				"series": "INV",
-				"code": "2026-0042"
+				"code": "2026-0042",
+				"ext": {
+					"untdid-document-type": "380"
+				}
 			},
 			"ext": {
 				"fr-ctc-flow6-status": "202"

--- a/snippets/examples/fr/states/202-acknowledged.min.mdx
+++ b/snippets/examples/fr/states/202-acknowledged.min.mdx
@@ -58,7 +58,9 @@ description: "GOBL bill/status example for French CTC lifecycle code 202 (Receiv
         "series": "INV",
         "code": "2026-0042",
         "issue_date": "2026-06-19",
-        "type": "380"
+        "ext": {
+          "untdid-document-type": "380"
+        }
       }
     }
   ]

--- a/snippets/examples/fr/states/203-made-available.mdx
+++ b/snippets/examples/fr/states/203-made-available.mdx
@@ -79,7 +79,10 @@
 				"type": "380",
 				"issue_date": "2026-06-19",
 				"series": "INV",
-				"code": "2026-0042"
+				"code": "2026-0042",
+				"ext": {
+					"untdid-document-type": "380"
+				}
 			},
 			"ext": {
 				"fr-ctc-flow6-status": "203"

--- a/snippets/examples/fr/states/203-made-available.mdx
+++ b/snippets/examples/fr/states/203-made-available.mdx
@@ -76,7 +76,6 @@
 			"key": "other",
 			"date": "2026-06-19",
 			"doc": {
-				"type": "380",
 				"issue_date": "2026-06-19",
 				"series": "INV",
 				"code": "2026-0042",

--- a/snippets/examples/fr/states/203-made-available.min.mdx
+++ b/snippets/examples/fr/states/203-made-available.min.mdx
@@ -58,7 +58,9 @@ description: "GOBL bill/status example for French CTC lifecycle code 203 (Made a
         "series": "INV",
         "code": "2026-0042",
         "issue_date": "2026-06-19",
-        "type": "380"
+        "ext": {
+          "untdid-document-type": "380"
+        }
       }
     }
   ]

--- a/snippets/examples/fr/states/204-taken-into-account.mdx
+++ b/snippets/examples/fr/states/204-taken-into-account.mdx
@@ -76,7 +76,6 @@
 			"key": "processing",
 			"date": "2026-06-19",
 			"doc": {
-				"type": "380",
 				"issue_date": "2026-06-19",
 				"series": "INV",
 				"code": "2026-0042",

--- a/snippets/examples/fr/states/204-taken-into-account.mdx
+++ b/snippets/examples/fr/states/204-taken-into-account.mdx
@@ -79,7 +79,10 @@
 				"type": "380",
 				"issue_date": "2026-06-19",
 				"series": "INV",
-				"code": "2026-0042"
+				"code": "2026-0042",
+				"ext": {
+					"untdid-document-type": "380"
+				}
 			},
 			"ext": {
 				"fr-ctc-flow6-status": "204"

--- a/snippets/examples/fr/states/204-taken-into-account.min.mdx
+++ b/snippets/examples/fr/states/204-taken-into-account.min.mdx
@@ -58,7 +58,9 @@ description: "GOBL bill/status example for French CTC lifecycle code 204 (Taken 
         "series": "INV",
         "code": "2026-0042",
         "issue_date": "2026-06-19",
-        "type": "380"
+        "ext": {
+          "untdid-document-type": "380"
+        }
       }
     }
   ]

--- a/snippets/examples/fr/states/205-approved.mdx
+++ b/snippets/examples/fr/states/205-approved.mdx
@@ -79,7 +79,10 @@
 				"type": "380",
 				"issue_date": "2026-06-19",
 				"series": "INV",
-				"code": "2026-0042"
+				"code": "2026-0042",
+				"ext": {
+					"untdid-document-type": "380"
+				}
 			},
 			"ext": {
 				"fr-ctc-flow6-status": "205"

--- a/snippets/examples/fr/states/205-approved.mdx
+++ b/snippets/examples/fr/states/205-approved.mdx
@@ -76,7 +76,6 @@
 			"key": "accepted",
 			"date": "2026-06-19",
 			"doc": {
-				"type": "380",
 				"issue_date": "2026-06-19",
 				"series": "INV",
 				"code": "2026-0042",

--- a/snippets/examples/fr/states/205-approved.min.mdx
+++ b/snippets/examples/fr/states/205-approved.min.mdx
@@ -58,7 +58,9 @@ description: "GOBL bill/status example for French CTC lifecycle code 205 (Approv
         "series": "INV",
         "code": "2026-0042",
         "issue_date": "2026-06-19",
-        "type": "380"
+        "ext": {
+          "untdid-document-type": "380"
+        }
       }
     }
   ]

--- a/snippets/examples/fr/states/206-partially-approved.mdx
+++ b/snippets/examples/fr/states/206-partially-approved.mdx
@@ -79,7 +79,10 @@
 				"type": "380",
 				"issue_date": "2026-06-19",
 				"series": "INV",
-				"code": "2026-0042"
+				"code": "2026-0042",
+				"ext": {
+					"untdid-document-type": "380"
+				}
 			},
 			"reasons": [
 				{

--- a/snippets/examples/fr/states/206-partially-approved.mdx
+++ b/snippets/examples/fr/states/206-partially-approved.mdx
@@ -76,7 +76,6 @@
 			"key": "rejected",
 			"date": "2026-06-19",
 			"doc": {
-				"type": "380",
 				"issue_date": "2026-06-19",
 				"series": "INV",
 				"code": "2026-0042",

--- a/snippets/examples/fr/states/206-partially-approved.min.mdx
+++ b/snippets/examples/fr/states/206-partially-approved.min.mdx
@@ -58,7 +58,9 @@ description: "GOBL bill/status example for French CTC lifecycle code 206 (Partia
         "series": "INV",
         "code": "2026-0042",
         "issue_date": "2026-06-19",
-        "type": "380"
+        "ext": {
+          "untdid-document-type": "380"
+        }
       },
       "ext": {
         "fr-ctc-flow6-status": "206"

--- a/snippets/examples/fr/states/207-in-dispute.mdx
+++ b/snippets/examples/fr/states/207-in-dispute.mdx
@@ -79,7 +79,10 @@
 				"type": "380",
 				"issue_date": "2026-06-19",
 				"series": "INV",
-				"code": "2026-0042"
+				"code": "2026-0042",
+				"ext": {
+					"untdid-document-type": "380"
+				}
 			},
 			"reasons": [
 				{

--- a/snippets/examples/fr/states/207-in-dispute.mdx
+++ b/snippets/examples/fr/states/207-in-dispute.mdx
@@ -76,7 +76,6 @@
 			"key": "rejected",
 			"date": "2026-06-19",
 			"doc": {
-				"type": "380",
 				"issue_date": "2026-06-19",
 				"series": "INV",
 				"code": "2026-0042",

--- a/snippets/examples/fr/states/207-in-dispute.min.mdx
+++ b/snippets/examples/fr/states/207-in-dispute.min.mdx
@@ -58,7 +58,9 @@ description: "GOBL bill/status example for French CTC lifecycle code 207 (In dis
         "series": "INV",
         "code": "2026-0042",
         "issue_date": "2026-06-19",
-        "type": "380"
+        "ext": {
+          "untdid-document-type": "380"
+        }
       },
       "ext": {
         "fr-ctc-flow6-status": "207"

--- a/snippets/examples/fr/states/208-suspended.mdx
+++ b/snippets/examples/fr/states/208-suspended.mdx
@@ -79,7 +79,10 @@
 				"type": "380",
 				"issue_date": "2026-06-19",
 				"series": "INV",
-				"code": "2026-0042"
+				"code": "2026-0042",
+				"ext": {
+					"untdid-document-type": "380"
+				}
 			},
 			"reasons": [
 				{

--- a/snippets/examples/fr/states/208-suspended.mdx
+++ b/snippets/examples/fr/states/208-suspended.mdx
@@ -76,7 +76,6 @@
 			"key": "querying",
 			"date": "2026-06-19",
 			"doc": {
-				"type": "380",
 				"issue_date": "2026-06-19",
 				"series": "INV",
 				"code": "2026-0042",

--- a/snippets/examples/fr/states/208-suspended.min.mdx
+++ b/snippets/examples/fr/states/208-suspended.min.mdx
@@ -58,7 +58,9 @@ description: "GOBL bill/status example for French CTC lifecycle code 208 (Suspen
         "series": "INV",
         "code": "2026-0042",
         "issue_date": "2026-06-19",
-        "type": "380"
+        "ext": {
+          "untdid-document-type": "380"
+        }
       },
       "reasons": [
         {

--- a/snippets/examples/fr/states/209-completed.mdx
+++ b/snippets/examples/fr/states/209-completed.mdx
@@ -79,7 +79,10 @@
 				"type": "380",
 				"issue_date": "2026-06-19",
 				"series": "INV",
-				"code": "2026-0042"
+				"code": "2026-0042",
+				"ext": {
+					"untdid-document-type": "380"
+				}
 			},
 			"description": "Coordonnées bancaires du bénéficiaire fournies",
 			"reasons": [

--- a/snippets/examples/fr/states/209-completed.mdx
+++ b/snippets/examples/fr/states/209-completed.mdx
@@ -76,7 +76,6 @@
 			"key": "other",
 			"date": "2026-06-19",
 			"doc": {
-				"type": "380",
 				"issue_date": "2026-06-19",
 				"series": "INV",
 				"code": "2026-0042",

--- a/snippets/examples/fr/states/209-completed.min.mdx
+++ b/snippets/examples/fr/states/209-completed.min.mdx
@@ -58,7 +58,9 @@ description: "GOBL bill/status example for French CTC lifecycle code 209 (Comple
         "series": "INV",
         "code": "2026-0042",
         "issue_date": "2026-06-19",
-        "type": "380"
+        "ext": {
+          "untdid-document-type": "380"
+        }
       },
       "description": "Coordonnées bancaires du bénéficiaire fournies",
       "reasons": [

--- a/snippets/examples/fr/states/210-refused.mdx
+++ b/snippets/examples/fr/states/210-refused.mdx
@@ -79,7 +79,10 @@
 				"type": "380",
 				"issue_date": "2026-06-19",
 				"series": "INV",
-				"code": "2026-0042"
+				"code": "2026-0042",
+				"ext": {
+					"untdid-document-type": "380"
+				}
 			},
 			"reasons": [
 				{

--- a/snippets/examples/fr/states/210-refused.mdx
+++ b/snippets/examples/fr/states/210-refused.mdx
@@ -76,7 +76,6 @@
 			"key": "rejected",
 			"date": "2026-06-19",
 			"doc": {
-				"type": "380",
 				"issue_date": "2026-06-19",
 				"series": "INV",
 				"code": "2026-0042",

--- a/snippets/examples/fr/states/210-refused.min.mdx
+++ b/snippets/examples/fr/states/210-refused.min.mdx
@@ -58,7 +58,9 @@ description: "GOBL bill/status example for French CTC lifecycle code 210 (Reject
         "series": "INV",
         "code": "2026-0042",
         "issue_date": "2026-06-19",
-        "type": "380"
+        "ext": {
+          "untdid-document-type": "380"
+        }
       },
       "reasons": [
         {

--- a/snippets/examples/fr/states/211-payment-advice.mdx
+++ b/snippets/examples/fr/states/211-payment-advice.mdx
@@ -43,7 +43,7 @@
 			}
 		],
 		"ext": {
-			"fr-ctc-flow6-role": "BY"
+			"fr-ctc-flow6-role": "SE"
 		}
 	},
 	"customer": {
@@ -74,7 +74,7 @@
 			}
 		],
 		"ext": {
-			"fr-ctc-flow6-role": "SE"
+			"fr-ctc-flow6-role": "BY"
 		}
 	},
 	"lines": [
@@ -84,7 +84,10 @@
 				"type": "380",
 				"issue_date": "2026-06-19",
 				"series": "INV",
-				"code": "2026-0042"
+				"code": "2026-0042",
+				"ext": {
+					"untdid-document-type": "380"
+				}
 			},
 			"amount": "120.00",
 			"tax": {

--- a/snippets/examples/fr/states/211-payment-advice.mdx
+++ b/snippets/examples/fr/states/211-payment-advice.mdx
@@ -81,7 +81,6 @@
 		{
 			"i": 1,
 			"document": {
-				"type": "380",
 				"issue_date": "2026-06-19",
 				"series": "INV",
 				"code": "2026-0042",

--- a/snippets/examples/fr/states/211-payment-advice.min.mdx
+++ b/snippets/examples/fr/states/211-payment-advice.min.mdx
@@ -66,7 +66,9 @@ description: "GOBL bill/payment example for French CTC lifecycle code 211 (Payme
         "series": "INV",
         "code": "2026-0042",
         "issue_date": "2026-06-19",
-        "type": "380"
+        "ext": {
+          "untdid-document-type": "380"
+        }
       },
       "tax": {
         "categories": [

--- a/snippets/examples/fr/states/212-payment-receipt.mdx
+++ b/snippets/examples/fr/states/212-payment-receipt.mdx
@@ -81,7 +81,6 @@
 		{
 			"i": 1,
 			"document": {
-				"type": "380",
 				"issue_date": "2026-06-19",
 				"series": "INV",
 				"code": "2026-0042",

--- a/snippets/examples/fr/states/212-payment-receipt.mdx
+++ b/snippets/examples/fr/states/212-payment-receipt.mdx
@@ -84,7 +84,10 @@
 				"type": "380",
 				"issue_date": "2026-06-19",
 				"series": "INV",
-				"code": "2026-0042"
+				"code": "2026-0042",
+				"ext": {
+					"untdid-document-type": "380"
+				}
 			},
 			"amount": "120.00",
 			"tax": {

--- a/snippets/examples/fr/states/212-payment-receipt.min.mdx
+++ b/snippets/examples/fr/states/212-payment-receipt.min.mdx
@@ -66,7 +66,9 @@ description: "GOBL bill/payment example for French CTC lifecycle code 212 (Payme
         "series": "INV",
         "code": "2026-0042",
         "issue_date": "2026-06-19",
-        "type": "380"
+        "ext": {
+          "untdid-document-type": "380"
+        }
       },
       "tax": {
         "categories": [


### PR DESCRIPTION
## Summary
- Recompiled the France GOBL example fixtures (`snippets/invoices/fr`, `snippets/payments/fr`, `snippets/examples/fr/states`) against the latest gobl core (v0.503.0) per `gobl-build.sh`.
- Only the reporting-record examples in `snippets/examples/fr/states/*.mdx` changed; the invoice and payment fixtures rebuilt identical to what was already committed.

## What changed
- All 12 flow6 lifecycle examples now include a computed `untdid-document-type` extension on the referenced document (derived from its `type` field), which the new gobl version started calculating for documents referenced from other envelopes (previously only computed for the enclosing document itself).
- `211-payment-advice.mdx`: the `fr-ctc-flow6-v1` addon now assigns the `SE`/`BY` roles to supplier/customer the other way round for payment advice messages — this is upstream addon behavior in gobl v0.503.0, not a local edit.

## Test plan
- [x] `./gobl-build.sh` logic rerun scoped to the `fr` fixtures — 34/34 processed with no errors
- [x] `mint broken-links` — no broken links (pre-existing unrelated OpenAPI schema warning, not introduced by this change)
- [x] Verified rebuild output is deterministic (built twice, byte-identical)

🤖 Generated with [Claude Code](https://claude.com/claude-code)