### PR TITLE
Add create-country-guide and create-app-page authoring skills

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,7 +30,7 @@ Supporting directories:
 - `assets/` — images, logos, diagrams referenced from MDX.
 - `scripts/` — small shell scripts that maintain `snippets/faqs/` (`fill-empty-faqs.sh`).
 - `gobl-build.sh`, `gobl-unbuild.rb` — GOBL invoice example tooling (see below).
-- `skills/` — packaged authoring skills (currently `manage-faqs` and `mermaid-style`). Read the skill's `SKILL.md` before doing the work it covers. Use `mermaid-style` whenever you add or edit a `mermaid` diagram in an `.mdx` page so the brand palette stays consistent.
+- `skills/` — packaged authoring skills (currently `manage-faqs`, `mermaid-style`, `create-country-guide`, and `create-app-page`). Read the skill's `SKILL.md` before doing the work it covers. Use `mermaid-style` whenever you add or edit a `mermaid` diagram in an `.mdx` page so the brand palette stays consistent. Use `create-country-guide` when adding or restructuring guides for a country/regime, and `create-app-page` when adding or restructuring a page under `apps/`.
 
 ## Navigation (`docs.json`)
 

--- a/skills/create-app-page/SKILL.md
+++ b/skills/create-app-page/SKILL.md
@@ -1,0 +1,260 @@
+---
+name: create-app-page
+description: Create a new app page under apps/ (country connector, utility, format, or integration app). Use whenever adding an Invopop app to the docs, restructuring an app page, or updating its actions/workflows/documents tabs — covers the Tabs shell, apps/index.mdx card, and docs.json registration.
+---
+
+# Creating app pages
+
+An app page is a **catalogue/reference page**: what the app is, the workflow actions it exposes, the workflow templates available, and the GOBL documents it consumes. Tutorials live in `guides/` — the app page links to them. Every app page (except `index.mdx` and partner stubs) is a single `<Tabs>` shell with a fixed tab set plus a footer. There are no configuration/settings sections and no screenshots on app pages.
+
+Reference implementations, newest first: `apps/france.mdx` (preferred country app), `apps/saudi-arabia.mdx` (smaller second reference), `apps/sat-mexico.mdx` (fullest snippet wiring), `apps/spain.mdx` (umbrella multi-regime), `apps/chargebee.mdx` (integration), `apps/pdf-generator.mdx` / `apps/email.mdx` (utility), `apps/index.mdx` (directory).
+
+## File naming
+
+`apps/<slug>.mdx` → `/apps/<slug>`:
+
+- **Country umbrella app (preferred for new country apps)**: `<country>.mdx` — `france.mdx`, `poland.mdx`, `argentina.mdx`, `saudi-arabia.mdx`, `spain.mdx`. Invopop is moving to one app per country grouping several regimes.
+- Regime-specific app (legacy direction, still valid when the system name is the brand): `<regime>-<country>.mdx` — `verifactu-spain.mdx`, `dian-colombia.mdx`, `sdi-italy.mdx`, `at-portugal.mdx`.
+- Utility / format / integration: `<vendor-or-function>.mdx` — `pdf-generator.mdx`, `email.mdx`, `chargebee.mdx`, `peppol.mdx`.
+
+Renames get a `docs.json` `redirects` entry (e.g. `/apps/ksef-poland` → `/apps/poland`).
+
+## Frontmatter
+
+Four fields, `mode: wide` mandatory (the two-column header and tab layout depend on it):
+
+```yaml
+---
+title: "DIAN Colombia"
+description: "Submit invoices to the Colombian DIAN system."
+keywords: ['colombia', 'dian', 'co']
+mode: wide
+---
+```
+
+- `title` — the app's display name as it appears in Console. Brand punctuation literal (`VERI*FACTU Spain`) — no escaping in frontmatter.
+- `description` — one imperative sentence; **reused verbatim as the card body in `apps/index.mdx`**, so write it to stand alone.
+- `keywords` — lowercase: country name, regime/system acronyms, format names, ISO-2 code.
+- No `icon`, no `sidebarTitle` (only `index.mdx` uses `sidebarTitle: "Discover"`).
+
+## Page shell
+
+Tab order is fixed: **Description → (Limitations) → Actions → Workflows → Documents → (API Endpoints)**.
+
+```
+imports…
+<Tabs>
+	<Tab title="Description">   ← header Columns + prose + Key features + ## FAQ
+	<Tab title="Limitations">   ← optional: capability/status table
+	<Tab title="Actions">       ← workflow actions the app exposes
+	<Tab title="Workflows">     ← workflow templates as accordions
+	<Tab title="Documents">     ← GOBL party/invoice examples
+</Tabs>
+---
+<CountryResources />
+<Card title="Participate in our community" icon="forumbee" … >
+```
+
+Indent tab bodies with hard tabs (one per nesting level); markdown inside a `<Tab>` must be indented to render — the indented `## FAQ` still becomes a real H2/anchor.
+
+### Description tab
+
+Two-column header: guide cards left, metadata table right.
+
+```mdx
+	<Tab title="Description">
+		<Columns cols="2">
+			<div class="flex flex-col grow items-center justify-center">
+				<Card title="Register suppliers" icon="https://assets.invopop.com/apps/dian-colombia/icon.svg"
+				  href="/guides/co-dian-supplier" horizontal>
+				  Supplier registration guide ›
+				</Card>
+				<Card title="Issue invoices" icon="https://assets.invopop.com/apps/dian-colombia/icon.svg"
+				  href="/guides/co-dian" horizontal>
+				  Issuing guide ›
+				</Card>
+			</div>
+
+				|           |                                        |
+				|-----------|----------------------------------------|
+				| Developer | [Invopop](https://invopop.com)         |
+				| Category  | Government                             |
+				| Scope     | B2B, B2C                               |
+				| Country   | [Colombia](/compliance/colombia)       |
+		</Columns>
+```
+
+- The **empty header row is deliberate** — `styles.css` hides it. Don't drop it.
+- `Category` must match the app's `docs.json` group name (Network / Government / Notify / Format / Document / Storage / Automation / Integrations).
+- `Scope` = `B2B` / `B2C` / `B2G` comma-joined; format and integration apps drop `Scope` and `Country`. Optional `System` row for the authority platform (`| System | FATOORA (ZATCA) |`).
+- Card body text uses `›` (not `→`): `Supplier registration guide ›`, `View guide ›`.
+- Country umbrella apps use the flag as icon: `https://assets.invopop.com/flags/<cc>.svg`.
+
+Then, in order:
+
+1. **2–4 paragraphs of prose** — what the authority/system is (outbound link, local-language name in italics), whether e-invoicing is mandatory and on what model, how Invopop simplifies it, and any partner/PSP disclosure ("Invopop has partnered with [Plemsi](https://plemsi.com) to issue invoices in Colombia…").
+2. **`#### Key features`** — `**Bold label:** Sentence.` bullets. Near-universal first item: `**Workflow automation:**`.
+3. **Guide pointer** — newest shape is a middot-joined list: `Check out the guides below to get started:` then `- [Registration](/guides/fr-pa-registration) · [Invoicing](/guides/fr-pa-invoicing) · [Reporting](/guides/fr-pa-reporting)`.
+4. **`## FAQ`** — always last in the tab, the only `##` on the page:
+
+```mdx
+	## FAQ
+
+	<FAQ />
+
+	More answers in our [Colombia FAQ](/faq/colombia) section
+```
+
+### Limitations tab (optional)
+
+Only where scope is incomplete. Capability table with badges — green `Available`, blue `Beta`, yellow `In development`:
+
+```mdx
+		| Capability | Status | Notes |
+		|---|---|---|
+		| Annuaire registration | <Badge color="green">Available</Badge> | Self-serve KYC in development |
+		| E-reporting (Flow 10) | <Badge color="yellow">In development</Badge> | Add-on not yet released |
+```
+
+### Actions tab
+
+Lead-in: `The following workflow actions will be available once you install and enable this app:` — then one horizontal `<Card>` per action. **Title = the exact action name in the Console step picker.**
+
+```mdx
+		<Card title="Send invoice to SDI" icon="https://assets.invopop.com/apps/sdi-italy/icon.svg" horizontal>
+		 <div class="pop-count"><Icon icon="https://assets.invopop.com/icons/pops.svg" /> 3</div>
+		 Issue GOBL invoices in the Italian SDI using the FatturaPA format.
+		</Card>
+```
+
+- The `pop-count` div is the step's credit cost (absolutely positioned by `styles.css`). **Omit it entirely for zero-cost actions** (register, wait, cancel, import).
+- Card bodies may embed essential input/output in prose (`Generates a unique URL in the \`meta\` property…`). No settings tables or parameter lists — the workflow JSON's `config` and the guides carry configuration detail.
+- Many actions → cluster them under plain-text label lines (`Registration`, `Clearance & Reporting`), not headings.
+
+### Workflows tab
+
+`<AccordionGroup>` of `<Accordion title="<App> <verb phrase>">` (e.g. "PA send invoice", "SAT Mexico register supplier"), each containing the workflow snippet component. Newest style groups by object type under plain-text labels and omits lead-in and template links:
+
+```mdx
+		Invoice workflows
+		<AccordionGroup>
+			<Accordion title="PA send invoice">
+				<PaSendInvoiceWorkflow />
+			</Accordion>
+		</AccordionGroup>
+
+		Party workflows
+		<AccordionGroup>
+			<Accordion title="PA register party">
+				<PaRegisterWorkflow />
+			</Accordion>
+		</AccordionGroup>
+```
+
+Only add `[Add to my workspace →](https://console.invopop.com/redirect/workflows/new?template=<slug>)` if the template slug is verified to exist in Console — it 404s silently otherwise. Utility apps with no templates replace this tab with prose about where the step fits (see `email.mdx`), or omit it.
+
+### Documents tab
+
+Party examples first (one-line explanation of the regime-specific identity fields above each snippet), then the invoice accordion, then a closing pointer:
+
+```mdx
+	<Tab title="Documents">
+		<AccordionGroup>
+			<Accordion title="SAT Mexico supplier">
+				An RFC with the `mx-cfdi-fiscal-regime` extension and the registered postal code (Lugar de Expedición).
+				<Supplier />
+			</Accordion>
+			<Accordion title="SAT Mexico customer">
+				…
+				<Customer />
+			</Accordion>
+		</AccordionGroup>
+
+		<InvoiceAccordion />
+
+		Copy and paste these documents into the [GOBL builder](https://build.gobl.org) in order to preview and verify them.
+	</Tab>
+```
+
+### Footer
+
+After `</Tabs>`, a `---`, the country resources snippet, and the community card:
+
+```mdx
+<Card title="Participate in our community"
+  icon="forumbee"
+  href="https://community.invopop.com"
+  arrow="true"
+  horizontal
+>
+  Ask and answer questions about the <X> app →
+</Card>
+```
+
+Use `forumbee` (not the older `square-question`).
+
+## Archetypes
+
+| | Country connector | Utility (PDF, Email, Slack, Drive, Cron) | Format (UBL, CII, Facturae) | Integration (Chargebee, Stripe) |
+|---|---|---|---|---|
+| Tabs | Description, [Limitations], Actions, Workflows, Documents | Description, Actions, [Workflows] | Description, Actions, Documents | Description, Actions, Workflows |
+| Metadata rows | Developer, Category, Scope, Country | Developer, Category | Developer, Category | Developer, Category |
+| `## FAQ` | Yes | No | No | No |
+| `<CountryResources />` | Yes | No | No | No |
+| Documents tab | Parties + invoice examples | — | Invoice examples only | — |
+
+Partner apps not yet self-serve get a stub: frontmatter + a single `<Note>` with a `mailto:` (see `netsuite.mdx`).
+
+## Snippet wiring
+
+Imports right after frontmatter — workflows → invoices/documents → parties → resources table → FAQ:
+
+```mdx
+import RegisterSupplier from '/snippets/workflows/mx/sat-register-supplier.mdx';
+import IssueInvoice from '/snippets/workflows/mx/sat-issue-invoice.mdx';
+import Supplier from '/snippets/parties/mx/supplier.mdx';
+import Customer from '/snippets/parties/mx/customer.mdx';
+import InvoiceAccordion from '/snippets/invoices/mx/accordion.mdx';
+import MexicoResources from '/snippets/tables/mexico-resources.mdx';
+import FAQ from '/snippets/faqs/mx/composers/app-sat.mdx';
+```
+
+- App pages import the workflow **content** snippet (`<name>.mdx`, the fenced JSON) and render it bare (`<IssueInvoice />`). They do **not** use `<WorkflowDiagram>` or the `-data.mdx` exports — that pairing is for guides. If you touch a workflow JSON, still sync both files of the pair (see `skills/create-country-guide/SKILL.md`).
+- FAQ composer: always exactly one, aliased `FAQ`, at `/snippets/faqs/<cc>/composers/app-<regime>.mdx` where `<regime>` is the *system* name. **Read `skills/manage-faqs/SKILL.md` before creating it**, and register the page in that skill's registry table. App composers are task-organised (Invoicing → Supplier → Receiving → Reporting), plain-text task headings, no compliance leaf.
+- Resources table: add the new app to the `Apps` row of `snippets/tables/<country>-resources.mdx`.
+- `snippets/coverage/` is for compliance pages, not apps.
+
+## Icons
+
+No `assets/` references — every icon is an absolute CDN URL:
+
+- App icon: `https://assets.invopop.com/apps/<app-id>/icon.svg`. **The CDN app-id often differs from the page slug** (`zatca` for saudi-arabia, `at-pt` for at-portugal) — verify against an existing usage rather than deriving; some legacy apps use `logo.svg`.
+- Country flags: `https://assets.invopop.com/flags/<cc>.svg`.
+- Credits: `https://assets.invopop.com/icons/pops.svg`; GOBL: `https://assets.invopop.com/icons/gobl.svg`.
+
+## Registration (three places, keep in sync)
+
+1. **`docs.json`** — Apps tab, add the slug to the matching group's `pages`, alphabetical within the group. Groups and icons: Network `chart-network`, Government `building-columns`, Notify `bullhorn`, Format `code-compare`, Document `file`, Storage `garage-car`, Automation `clock`, Integrations `plug`.
+2. **`apps/index.mdx`** — add a horizontal `<Card>` in the same category block, alphabetical: `title` = page title, body = page `description` verbatim, `icon` = app SVG or flag, `href` = `/apps/<slug>`.
+3. **Country resources table** — `Apps` row entry (country apps only).
+
+Plus the `app-<regime>` FAQ composer and, if renaming, a `redirects` entry.
+
+## Checklist: adding a new app page
+
+1. Create `apps/<slug>.mdx` with `mode: wide` frontmatter and the Tabs shell for the right archetype.
+2. Wire snippets: workflow content snippets, parties, invoice accordion, resources table, FAQ composer (create per `skills/manage-faqs/SKILL.md` if new).
+3. Register in `docs.json` (group `pages`) and `apps/index.mdx` (category card).
+4. Update `snippets/tables/<country>-resources.mdx` Apps row (country apps).
+5. Cross-link from the country's guides and compliance page.
+6. Validate: cold `mint dev`, `mint broken-links`.
+
+## Gotchas
+
+- `mode: wide` missing → the two-column header collapses.
+- Drop the empty metadata-table header row → stray empty header renders.
+- `Category` cell diverging from the docs.json group name (the `portal.mdx` "Utility" bug).
+- Escape `VERI\*FACTU` in body prose and Card *bodies*; literal `VERI*FACTU` in JSX prop strings and frontmatter.
+- `class` strings (`flex flex-col …`, `pop-count`) must stay static literals — Mintlify only compiles static Tailwind classes.
+- Built-in components (`Badge`, `Icon`, `Note`, `Accordion`) need no import.
+- Legacy patterns not to copy: `icon: "transporter-empty"` frontmatter, redundant `sidebarTitle`, `square-question` community icon, `####` headings in the Actions tab, `.png` app icons.

--- a/skills/create-country-guide/SKILL.md
+++ b/skills/create-country-guide/SKILL.md
@@ -1,0 +1,242 @@
+---
+name: create-country-guide
+description: Create a new country guide (supplier registration + issuing invoices pair) under guides/. Use whenever adding e-invoicing docs for a new country or regime, splitting an existing guide, or restructuring a country's guide family — covers page skeletons, workflow snippet pairs, FAQ wiring, and docs.json registration.
+---
+
+# Creating country guides
+
+A country's docs ship as a **guide family**: one supplier registration guide plus one issuing/invoicing guide per regime (split established in #498), optionally extended with receiving, reporting, or status guides. Guides are tutorials — the paired `apps/` page is the catalogue/reference. Reference implementations, newest first: `guides/sa-zatca-*.mdx`, `guides/fr-pa-*.mdx` (large families), and the canonical two-page shape in `guides/co-dian.mdx` + `guides/co-dian-supplier.mdx` (also `pt-at`, `pl-ksef`, `gr-iapr`, `br-dfe`). Don't copy the older Spain pages (`es-verifactu*`) — they predate the current pattern.
+
+## File naming
+
+Flat files in `guides/`, slug `<iso2>-<regime>[-<task>].mdx`:
+
+- Issuing guide: bare `<iso2>-<regime>.mdx` (`co-dian.mdx`, `pl-ksef.mdx`) — or explicit task when the family has several flows (`mx-sat-issuing.mdx`, `it-sdi-sending.mdx`, `fr-pa-invoicing.mdx`, `sa-zatca-clearance-reporting.mdx`).
+- Supplier guide: `<iso2>-<regime>-supplier.mdx` (or `-registration` in the newest families: `fr-pa-registration.mdx`, `sa-zatca-registration.mdx`).
+- Other tasks: `-receiving`, `-reporting`, `-status`, `-lookup`.
+- Family hub: when a family has ≥3 pages, the bare slug becomes an overview page (`fr-pa.mdx`, sidebarTitle "Overview") with one horizontal `<Card>` per child guide.
+- Peppol-only countries get a single page: `<iso2>-peppol.mdx` (`be-peppol.mdx`, `no-peppol.mdx`).
+
+Don't copy the outliers `ar-arca-suppliers.mdx` (plural) or `de-ubl.mdx` (format name as regime).
+
+## Frontmatter
+
+```yaml
+---
+title: "DIAN issuing invoices guide"
+sidebarTitle: "Issuing invoices"
+description: Issue invoices and credit notes in Colombia through the DIAN.
+---
+```
+
+- Sentence case; brand casing preserved (`VERI*FACTU`, `TicketBAI`, `KSeF`, `myDATA`). **No backslash escaping in frontmatter** — only in MDX body text.
+- Title patterns: `"<REGIME> issuing invoices guide"` / `"<REGIME> supplier registration guide"`; the newest generation drops "guide" (`"Invoicing in France"`, `"ZATCA supplier registration in Saudi Arabia"`). Either is fine; be consistent within a family.
+- `sidebarTitle` is a small closed enum — reuse verbatim: `Supplier registration`, `Issuing invoices`, `Receiving invoices`, `Reporting`, `Registration`, `Invoicing`, `Status`, `Clearance & reporting`, `Overview`.
+- `icon` only on pages that sit directly in the nav without a flag-bearing group (e.g. `be-peppol.mdx` sets `https://assets.invopop.com/flags/be.svg`). Guides inside a country group must **not** set `icon` — the group carries the flag.
+
+## Issuing guide skeleton
+
+```
+[frontmatter]
+[imports — see Snippet wiring]
+
+## Introduction        <- what the regime is, who runs it, partner disclosure, companion-guide link
+[sandbox/live table]
+## Prerequisites       <- bullets; FIRST bullet is always the registered supplier + link
+## Setup               <- <Info> handoff to supplier guide, then <Steps>, one <Step> per workflow to create
+## Running             <- (or "## Send an invoice") upload entry → run job, with API links
+### <sub-flows>        <- Cancel a document, Import received invoices, …
+[## Example invoices]  <- <ExampleAccordion />
+## FAQ
+<FAQ />
+
+More available in our [<Country> FAQ](/faq/<country>) section
+
+---
+
+<CountryResources />
+
+<Card title="Participate in our community"
+  icon="forumbee"
+  href="https://community.invopop.com"
+  arrow="true"
+  horizontal
+>
+  Ask and answer questions about invoicing in <Country> →
+</Card>
+```
+
+No "Next steps" section, no `<CardGroup>` — the FAQ + resources + community card trio is the closer on every guide.
+
+Stock idioms:
+
+- Companion link in the intro: `For onboarding suppliers with the DIAN and Plemsi, see the companion guide: [Colombia: Supplier registration](/guides/co-dian-supplier).`
+- Sandbox/live table right after the intro, with a literal `-` first header cell:
+
+  ```mdx
+  | - | Sandbox | Live |
+  |---|---|---|
+  | **Supplier** | Pre-enabled test supplier with tax ID `177472438` | Registered supplier required |
+  | **Environment** | myDATA test | myDATA production |
+  ```
+
+- Prerequisites first bullet: `- **A registered supplier**: follow the [AT supplier registration guide](/guides/pt-at-supplier) to connect the AT Portugal app, register the supplier, and register their document series before issuing.`
+- Before `<Steps>`: `All of the following steps must be carried out from the [Invopop Console](https://console.invopop.com).`
+- Optional step: `<Info>You can skip this step if you don't plan to issue invoices.</Info>`
+- Recommended API flow: `<Info>The recommended approach for running jobs is to perform two steps: first upload the document to the [silo](/api-ref/silo/entries/create-an-entry-put), then [create a job](/api-ref/transform/jobs/create-a-job-post).</Info>`
+- Optional enrichment from the newest guides: a `### How it works` heading with a purely descriptive `<Steps>` (one `<Step>` per workflow step, no user action) before the workflow block — see `guides/sa-zatca-clearance-reporting.mdx`.
+
+## Supplier guide skeleton
+
+```
+## Introduction            <- regime + partner; handoff: "Once a supplier is registered, continue with
+                              the companion guide: [<Country>: Issuing invoices](/guides/<slug>)."
+[sandbox/live table]
+## Prerequisites           <- data/credentials to collect from the supplier
+## Setup                   <- <Steps>: "Connect the <X> app" → registration workflow →
+                              post-registration workflow → "Configure the <X> app"
+## Register a supplier     <- <Steps>: upload party → run workflow → complete wizard → wait for approval
+[## Register a supplier via the API]
+[## Unregister a supplier] <- own Card+Tabs workflow block, <Warning> about re-onboarding
+[## <domain extras>]       <- Series management, Legal information, credentials, …
+[handoff sentence]
+## FAQ + footer trio
+```
+
+Differences vs the issuing guide:
+
+- Setup opens with the app connection as prose+bold, not screenshots-first:
+  `1. Navigate to **Configuration** → **Apps**` / `2. Find **Poland** in the app discovery list` / `3. Click **Connect** to activate`.
+- Workflow templates are party-based: `Copy and paste into a new [Empty Party workflow](https://console.invopop.com/redirect/workflows/new?template=empty-party) code view.`
+- Imports `/snippets/parties/<cc>/supplier.mdx` (or a party accordion), not invoice examples.
+- FAQ composer is `guide-<regime>-supplier.mdx`.
+- Registration wizard walkthroughs are `<Steps>` with one `<Frame>` screenshot per screen.
+- Closing handoff: `At this point, you're ready to start sending invoices on behalf of the supplier. Head over to the [DIAN issuing invoices guide](/guides/co-dian) to continue.`
+
+## The workflow block (most repeated shape)
+
+Every workflow a guide asks the reader to create uses this Card + Tabs pair:
+
+```mdx
+<Card iconType="duotone" title="KSeF send invoice workflow" icon="code-branch" href="https://console.invopop.com/redirect/workflows/new?template=pl-send" horizontal>
+  Add to my workspace →
+</Card>
+<Tabs>
+  <Tab title="Workflow">
+    <WorkflowDiagram workflow={plSendWorkflow} />
+  </Tab>
+  <Tab title="Code">
+    Copy and paste into a new [Empty Invoice workflow](https://console.invopop.com/redirect/workflows/new?template=empty-invoice) code view.
+
+    <SendInvoiceWorkflow />
+  </Tab>
+</Tabs>
+```
+
+- Tab titles are always exactly `"Workflow"` and `"Code"`.
+- **Never use workflow screenshots** — diagrams render from JSON (#505).
+- Starter templates by schema: `empty-invoice`, `empty-party`, `empty-payment`, `empty-delivery`, `empty-status`.
+- The `?template=<slug>` on the Card is registered server-side in Console, **not in this repo** — verify the slug exists (`grep -ho 'template=[a-z0-9-]*' guides/*.mdx | sort -u` lists known ones) rather than inventing it. Omit the Card if there's no template.
+
+## Snippet wiring
+
+Import block right after frontmatter — plain snippet imports first, then the component, then workflow data exports (`guides/es-verifactu.mdx:8-18` shape):
+
+```mdx
+import WorkflowExample from '/snippets/workflows/co/dian-invoice.mdx';
+import ExampleAccordion from '/snippets/invoices/co/accordion.mdx';
+import Supplier from '/snippets/parties/co/supplier.mdx';
+import ColombiaResources from '/snippets/tables/colombia-resources.mdx';
+import FAQ from '/snippets/faqs/co/composers/guide-dian-invoicing.mdx';
+import { WorkflowDiagram } from '/snippets/components/workflow.jsx';
+import { coDianInvoiceWorkflow } from '/snippets/workflows/co/dian-invoice-data.mdx';
+```
+
+Naming: FAQ composer → always `FAQ`; resources table → `<Country>Resources`; example accordion → `ExampleAccordion`; workflow JSON snippet → descriptive PascalCase (`SendInvoiceWorkflow`, `RegisterWorkflow`). Country-prefix component names when a page composes several countries.
+
+### Workflow snippet pairs
+
+Each workflow lives as a **pair** under `snippets/workflows/<cc>/`:
+
+- `<name>.mdx` — frontmatter (`title`, `description`, `countryCode`, `appId`, `schema`) + one fenced ` ```json ` block. Rendered in the Code tab.
+- `<name>-data.mdx` — **only** `export const <export>Workflow = {…};`, nothing else. No frontmatter, no markdown — mixing content compiles to an `undefined` stub on a cold build and silently kills the section (warm `mint dev` masks it).
+- Export name = globally unique camelCase of `<dir>-<basename>` + `Workflow`: `co/dian-invoice-data.mdx` ⇒ `coDianInvoiceWorkflow`; acronyms camelCased (`Nfse`, not `NFSe`). Never `workflow`.
+- Import without aliasing — `{ x as y }` double-declares in Mintlify's inlining.
+- **When updating the JSON, paste it into both files** — they must stay in sync.
+- If the workflow uses an app new to `<WorkflowDiagram>`, add its provider key to `providerIcons` in `snippets/components/workflow.jsx` (longest-prefix match; static `className` literals only).
+
+### Invoice / party examples
+
+- `snippets/invoices/<cc>/` holds `.min.mdx` (hand-authored) + `.mdx` (built by `./gobl-build.sh`) pairs. **Edit only `.min.mdx`, then rebuild** — never hand-edit the built file. Requires the `gobl` CLI.
+- Guides import a per-regime **accordion composer** (`snippets/invoices/<cc>/accordion.mdx` for single-regime countries; `<regime>-accordion.mdx` for multi-regime) that wraps each scenario's min+built pair in `<CodeGroup>` inside an `<Accordion>`.
+- `snippets/parties/<cc>/` — single files (`supplier.mdx`, `customer.mdx`), no min/built pairing; validate with `gobl build` when editing.
+- Same pairing exists in `snippets/payments/`, `snippets/deliveries/`, `snippets/documents/` for non-invoice flows (Portugal uses `snippets/documents/pt/accordion.mdx`).
+
+### FAQ composer
+
+Every guide imports exactly one composer: `/snippets/faqs/<cc>/composers/guide-<regime>-<task>.mdx` (task ∈ invoicing | supplier | receiving | reporting). **Read `skills/manage-faqs/SKILL.md` before creating leaves or composers**, and register the new consumer page in that skill's registry table. Page usage is always:
+
+```mdx
+## FAQ
+
+<FAQ />
+
+More available in our [Colombia FAQ](/faq/colombia) section
+```
+
+### Resources table
+
+`snippets/tables/<full-country-name>-resources.mdx` — an `<AccordionGroup>` with one flag-emoji-titled `<Accordion>` wrapping a two-column table (Compliance / Apps / Guides / FAQ / GOBL rows). Create it for a new country; **add every new guide to the country's `Guides` row**.
+
+## Screenshots
+
+- Path: `/assets/guides/<iso2>-<regime>-<topic>[-<n>].png`.
+- `<Frame caption="…"><img width="600" src="/assets/guides/…" alt="…" /></Frame>` — explicit pixel `width` tuned to the crop, `alt` always present, `caption` optional.
+- Use screenshots for Console UI and hosted wizard screens only — never for workflows.
+- Console UI labels in prose are bolded (`**Invoices**`, `**Run Workflow**`); buttons may use `<kbd>Save</kbd>`.
+
+## docs.json registration
+
+Guides live in the Guides tab under the `Countries` group, one flag-icon group per country, **supplier guide first**:
+
+```json
+{
+  "group": "Colombia",
+  "icon": "https://assets.invopop.com/flags/co.svg",
+  "pages": [
+    "/guides/co-dian-supplier",
+    "/guides/co-dian"
+  ]
+}
+```
+
+- Countries alphabetical by English name; within a country: supplier → issuing → receiving → reporting.
+- Multi-regime countries nest a regime sub-group **without an icon** (see Spain/France/Italy in `docs.json`). Group labels use raw `VERI*FACTU` — no escaping in JSON.
+- Single-page Peppol countries are bare strings in the Countries list, carrying the flag in page frontmatter instead.
+- "Coming soon" countries append `?coming-soon` to the flag icon URL (dimmed via `styles.css`).
+- When renaming/moving a page, add a `redirects` entry (or use `mint rename OLD NEW`). When splitting, prefer keeping the existing slug for one half so no redirect is needed (#498 did this).
+
+## Cross-linking
+
+Root-relative page slugs, never file paths. Compliance/FAQ/timelines use the **full country name** (`/compliance/spain`, `/faq/colombia`); snippets use **ISO-2** (`snippets/invoices/co/`). Stock API links: `[Create an entry](/api-ref/silo/entries/create-an-entry-put)`, `[Create a job](/api-ref/transform/jobs/create-a-job-post)`. GOBL docs are absolute (`https://docs.gobl.org/regimes/pl`, `…/addons/es-verifactu-v1`).
+
+## Checklist: adding a new country/regime
+
+1. Create the guide pair: `guides/<iso2>-<regime>-supplier.mdx` + `guides/<iso2>-<regime>.mdx` (plus receiving/reporting if the regime has those flows).
+2. Author workflow snippet pairs under `snippets/workflows/<cc>/` (both files each, unique exports).
+3. Author GOBL examples: `snippets/parties/<cc>/{supplier,customer}.mdx`, `snippets/invoices/<cc>/*.min.mdx` + `accordion.mdx`, run `./gobl-build.sh`.
+4. Create FAQ leaves + `guide-<regime>-invoicing.mdx` / `guide-<regime>-supplier.mdx` composers per `skills/manage-faqs/SKILL.md`; update its manifest and registry.
+5. Create or update `snippets/tables/<country>-resources.mdx` (Guides row).
+6. Register both pages in `docs.json` under Countries (flag SVG icon, supplier first, alphabetical placement).
+7. Cross-link: companion links between the pair, links from `apps/<app>.mdx` and `compliance/<country>.mdx`, community card country name.
+8. Add screenshots to `assets/guides/` if the flow has Console/wizard steps.
+9. Validate: `mint dev` **from a cold start** (to catch broken workflow data snippets), `mint broken-links`.
+
+## Gotchas
+
+- Escape `VERI\*FACTU` in MDX body text and headings only — not in frontmatter, JSX prop strings, or `docs.json`.
+- Sentence case in `<Step title="…">` props — Title Case in old Spain guides is a bug, not a pattern.
+- Workflow data snippets: export-only file, unique export name, no import aliasing, keep the pair in sync (all four break silently otherwise).
+- Never hand-edit built `snippets/invoices/**/<name>.mdx`; `./gobl-build.sh` overwrites them.
+- `mint broken-links` is the only automated validation — there's no test suite.
+- Develop on a branch, never on `main`.


### PR DESCRIPTION
## What changed

Two new packaged skills under `skills/`, reverse-engineered from the existing pages:

- **`skills/create-country-guide/SKILL.md`** — how to add a country/regime guide family: the post-#498 supplier + issuing page pair (with `co-dian`/`pt-at`/`pl-ksef` as the canonical shape), full page skeletons and stock idioms, the workflow Card + Workflow/Code Tabs block, workflow `.mdx`/`-data.mdx` pair constraints, GOBL example and FAQ composer wiring, screenshot conventions, `docs.json` registration rules, an end-to-end new-country checklist, and the known gotchas.
- **`skills/create-app-page/SKILL.md`** — how to add an app page: the fixed `<Tabs>` shell (Description → Limitations → Actions → Workflows → Documents) with `mode: wide`, tab-by-tab canonical excerpts, an archetype table (country connector vs utility vs format vs integration), icon CDN conventions, the three registration points that must stay in sync (`docs.json`, `apps/index.mdx`, country resources table), and gotchas.

Also registers both skills in the `skills/` bullet of `CLAUDE.md`.

## Why

New country and app docs should follow the newest conventions (#498 supplier split, #504 apps restructure, #505 JSON workflow diagrams) rather than whichever legacy page an author happens to copy. These skills capture the current preferred pattern, name the reference pages to copy from, and flag the legacy shapes to avoid.

## Notes for reviewers

- Docs-only change: no page content, nav, or snippets touched.
- All verbatim excerpts quoted in the skills were spot-checked against the current files (`guides/pl-ksef.mdx`, `apps/france.mdx`, `apps/dian-colombia.mdx`, `apps/sdi-italy.mdx`, `snippets/workflows/es/verifactu-invoice-data.mdx`).
- Worth a skim by whoever wrote the most recent country docs (Saudi Arabia / France PA) to confirm the "newest pattern" calls match intent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)