### PR TITLE
Fix invalid FR billing mode

### DIFF
--- a/guides/fr-pa-invoicing.mdx
+++ b/guides/fr-pa-invoicing.mdx
@@ -82,15 +82,15 @@ Mandatory on every flux 2 and flux 10 B2B invoice and set in GOBL under `tax.ext
 |---|---|
 | `B1` `S1` `M1` | Standard submission (*dépôt d'une facture*) |
 | `B2` `S2` `M2` | Already-paid invoice | 
-| `B3` `S3` `M3` | Final invoice after down payment | 
+| `-`  `S3` `-`  | Final invoice after down payment | 
 | `B4` `S4` `M4` | Subcontractor invoice (payment delegation) | 
-| `B5` `S5` `M5` | Co-contractor invoice | 
-| `B6` `S6` `M6` | VAT already collected via e-reporting |
-| `B7` `S7` `M7` | Invoice issued after payment already reported via e-reporting |
+| `-`  `S5` `-`  | Co-contractor invoice | 
+| `-`  `S6` `-`  | VAT already collected via e-reporting |
+| `B7` `S7` `-`  | Invoice issued after payment already reported via e-reporting |
+| `B8` `S8` `M8` | Multi-vendor invoice |
+
 
 The full list of billing-mode codes is documented in the [`fr-ctc-flow2-v1` addon reference](https://docs.gobl.org/addons/fr-ctc-flow2-v1).
-
-Suffix `7` covers invoices issued after the sale was already cashed in and reported through [e-reporting](/guides/fr-pa-reporting). For example, a company requesting a B2B invoice after paying a restaurant bill. Marking it `S7`/`B7` tells the PPF not to count the VAT a second time.
 
 Suffix `1` is the ordinary case — a plain invoice submitted for payment. Left unset, the add-on defaults the mode to `M1` (`M2` when fully paid) — pin the prefix that matches the nature of the operation, as the [example invoices](/guides/fr-pa-invoicing#example-invoices) do.
 

--- a/guides/fr-pa-invoicing.mdx
+++ b/guides/fr-pa-invoicing.mdx
@@ -78,17 +78,16 @@ Switching formats is a workflow configuration away rather than a data-model chan
 
 Mandatory on every flux 2 and flux 10 B2B invoice and set in GOBL under `tax.ext.fr-ctc-billing-mode`. The prefix carries the nature of the operation: `B` goods (*biens*), `S` services, `M` mixed, plus a suffix for the payment context.
 
-| Goods/Services/Mixed | Payment context |
-|---|---|
-| `B1` `S1` `M1` | Standard submission (*dépôt d'une facture*) |
-| `B2` `S2` `M2` | Already-paid invoice | 
-| `-`  `S3` `-`  | Final invoice after down payment | 
-| `B4` `S4` `M4` | Subcontractor invoice (payment delegation) | 
-| `-`  `S5` `-`  | Co-contractor invoice | 
-| `-`  `S6` `-`  | VAT already collected via e-reporting |
-| `B7` `S7` `-`  | Invoice issued after payment already reported via e-reporting |
-| `B8` `S8` `M8` | Multi-vendor invoice |
-
+| Goods | Services | Mixed | Payment context |
+|---|---|---|---|
+| `B1`  | `S1`     | `M1`  | Standard submission (*dépôt d'une facture*) |
+| `B2`  | `S2`     | `M2`  | Already-paid invoice |
+| —     | `S3`     | —     | Subcontracting with direct payment (B2G only) |
+| `B4`  | `S4`     | `M4`  | Final invoice after a down payment |
+| —     | `S5`     | —     | Subcontractor invoice |
+| —     | `S6`     | —     | Co-contractor invoice |
+| `B7`  | `S7`     | —     | VAT already collected via e-reporting |
+| `B8`  | `S8`     | `M8`  | Multi-vendor invoice |
 
 The full list of billing-mode codes is documented in the [`fr-ctc-flow2-v1` addon reference](https://docs.gobl.org/addons/fr-ctc-flow2-v1).
 


### PR DESCRIPTION
Valid billing modes: 


Code | Description
-- | --
B1 | Submission of an invoice for goods
S1 | Submission of an invoice for services
M1 | Submission of a combined invoice (delivery of goods and services that are not ancillary to one another)
B2 | Submission of an invoice for goods that has already been paid
S2 | Submission of an invoice for services that has already been paid
M2 | Submission of a combined invoice that has already been paid
S3 | Submission of a request for payment of subcontracting services with direct payment (B2G only; restriction cannot be verified)
B4 | Submission of a final invoice (after a down payment) for goods
S4 | Submission of a final invoice (after a down payment) for services
M4 | Submission of a final duplicate invoice (after a down payment)
S5 | Submission by a subcontractor of an invoice for services
S6 | Submission by a co-contractor of an invoice for services rendered
B7 | Submission of an invoice for goods that were subject to e-reporting (VAT already collected)
S7 | Submission of an invoice for services rendered that were subject to e-reporting (VAT already collected)
B8 | Submission of a multi-vendor invoice for goods
S8 | Submission of a multi-vendor invoice for services
M8 | Submission of a duplicate multi-vendor invoice containing individual invoices that are not all Sx or Bx

