### PR TITLE
Add France dashboard reading sections to PA guides

### DIFF
--- a/guides/fr-pa-invoicing.mdx
+++ b/guides/fr-pa-invoicing.mdx
@@ -146,9 +146,9 @@ How each step of the self-billing use case maps to an action in Invopop, on both
 
 The France dashboard's **E-Invoicing Flow 2** tab lists every invoice the workspace has sent or received, newest first. In the Console, open the **Apps** view, select the **France** app, and switch to the **E-Invoicing Flow 2** tab.
 
-Each row shows the **Invoice code** (the invoice number), the **Supplier** and **Customer SIREN**, the **PPF status** of the mandatory F1 copy, the **Role** (Sender when you issued the invoice, Receiver when it arrived from a counterparty), the **Issue date**, the **Owner SIREN** (the registered party the invoice belongs to), the document **Type** (standard, self-billed, corrected, credit note, …), and the **Invoice ID** (the GOBL document UUID).
+Each row shows the Invoice code, the Supplier and Customer SIREN, the PPF status of the mandatory F1 copy, the Role (Sender when you issued the invoice, Receiver when it arrived from a counterparty), the Silo entry that holds the invoice document, the Issue date, the Owner SIREN (the registered party the invoice belongs to), the document Type (standard, self-billed, corrected, credit note, …), and the Invoice ID.
 
-The **PPF status** column tracks the copy forwarded to the tax authority:
+The PPF status column tracks the copy forwarded to the tax authority:
 
 | PPF status | Meaning |
 |---|---|
@@ -157,10 +157,9 @@ The **PPF status** column tracks the copy forwarded to the tax authority:
 | <Badge color="green">Accepted</Badge> | The PPF accepted the document. |
 | <Badge color="red">Rejected</Badge> | The PPF rejected the document. |
 
-Click options on this tab:
-
-* **Clicking the Invoice code link** jumps to the **E-Invoicing Flow 6** tab filtered to that invoice's [lifecycle statuses](/guides/fr-pa-status#reading-submitted-statuses).
-* **Clicking the Invoice ID** copies the document UUID to the clipboard.
+<Note>
+Clicking the Invoice code looks up all associated statuses on the **E-Invoicing Flow 6** tab, filtered by the Invoice ID.
+</Note>
 
 Filter the table by **Supplier SIREN**, **Customer SIREN**, **Invoice code**, or **Invoice ID**.
 

--- a/guides/fr-pa-invoicing.mdx
+++ b/guides/fr-pa-invoicing.mdx
@@ -22,6 +22,7 @@ This guide walks through how to implement e-invoicing obligations in France:
 * [Receiving](#receiving): detecting the inbound format, importing it into GOBL, and recording it against your registered party.
 * [Invoice formats](#invoice-formats): UBL, CII, and Factur-X and how to choose between them.
 * [Self-billing](#self-billing): how *autofacturation* maps onto the same send and receive workflows using the `self-billed` tag.
+* [Reading submitted invoices](#reading-submitted-invoices): follow every sent and received invoice, and its PPF state, from the France dashboard.
 * [Example invoices](#example-invoices): minimal GOBL documents and their built versions, ready to paste into the GOBL builder.
 
 ## Workflows
@@ -140,6 +141,28 @@ How each step of the self-billing use case maps to an action in Invopop, on both
 | 3 | Seller's PA | The seller's [receive workflow](#receiving) imports the invoice and records it, resolving the seller's registered party as the `supplier`. |
 | 4 | Seller | Upon reception of payment, the seller builds a `bill.Payment` referencing the invoice, sends it to the customer and forwards it to the PPF. |
 | 5 | Buyer | The buyer's receive workflow imports the inbound CDAR and records it against the invoice. |
+
+## Reading submitted invoices
+
+The France dashboard's **E-Invoicing Flow 2** tab lists every invoice the workspace has sent or received, newest first. In the Console, open the **Apps** view, select the **France** app, and switch to the **E-Invoicing Flow 2** tab.
+
+Each row shows the **Invoice code** (the invoice number), the **Supplier** and **Customer SIREN**, the **PPF status** of the mandatory F1 copy, the **Role** (Sender when you issued the invoice, Receiver when it arrived from a counterparty), the **Issue date**, the **Owner SIREN** (the registered party the invoice belongs to), the document **Type** (standard, self-billed, corrected, credit note, …), and the **Invoice ID** (the GOBL document UUID).
+
+The **PPF status** column tracks the copy forwarded to the tax authority:
+
+| PPF status | Meaning |
+|---|---|
+| <Badge color="gray">Ready</Badge> | Recorded on the platform; nothing sent to the PPF yet. |
+| <Badge color="orange">Pending</Badge> | Sent; awaiting the PPF business acknowledgement. |
+| <Badge color="green">Accepted</Badge> | The PPF accepted the document. |
+| <Badge color="red">Rejected</Badge> | The PPF rejected the document. |
+
+Click options on this tab:
+
+* **Clicking the Invoice code link** jumps to the **E-Invoicing Flow 6** tab filtered to that invoice's [lifecycle statuses](/guides/fr-pa-status#reading-submitted-statuses).
+* **Clicking the Invoice ID** copies the document UUID to the clipboard.
+
+Filter the table by **Supplier SIREN**, **Customer SIREN**, **Invoice code**, or **Invoice ID**.
 
 ## Example invoices
 

--- a/guides/fr-pa-registration.mdx
+++ b/guides/fr-pa-registration.mdx
@@ -152,6 +152,28 @@ If a SIREN's Annuaire line is already held by another Plateforme Agréée (PA), 
   </Tab>
 </Tabs>
 
+## Reading parties registrations
+
+The France dashboard's **Parties** tab shows the registration state of every SIREN in the workspace, one row per party. In the Console, open the **Apps** view and select the **France** app. The dashboard opens on this tab.
+
+Each row carries the party's **Name**, its number of Annuaire **Directory entries**, the **SIREN**, the registration **State**, the **Silo entry** that holds the party, whether **Reporting** is enabled, the **VAT regime** selected at registration, and the date the approval was **Decided**.
+
+| State | Meaning |
+|---|---|
+| <Badge color="yellow">Pending</Badge> | The registration workflow has started but the signed mandate has not been submitted yet. |
+| <Badge color="blue">Submitted</Badge> | The mandate and identity document are under approval review. |
+| <Badge color="green">Approved</Badge> | The party is registered: its Annuaire line is live and published on Peppol. |
+| <Badge color="red">Rejected</Badge> | The submission was declined during review. |
+
+A check mark in the **Reporting** column means the party is also [registered for e-reporting](/guides/fr-pa-reporting); a dash marks a party registered only for e-invoicing. The **VAT regime** pill shows the [cadence](/guides/fr-pa-reporting#picking-a-vat-regime-at-supplier-registration) its reports follow.
+
+Click options on this tab:
+
+* **Clicking a row** opens a side panel with the party's Annuaire lines: one block per directory entry with its **Endpoint** (the electronic address), the registered **Name**, and the **Silo entry id**. Every value has a copy button, and the silo entry id also links out to the entry in the Console. Lines that have been unregistered appear greyed out.
+* **Clicking the Silo entry value** copies the party's full silo entry ID to the clipboard.
+
+Filter the table by **SIREN**, **State**, or whether **Reporting** is enabled.
+
 ## FAQ
 
 <FAQ />

--- a/guides/fr-pa-registration.mdx
+++ b/guides/fr-pa-registration.mdx
@@ -156,7 +156,7 @@ If a SIREN's Annuaire line is already held by another Plateforme Agréée (PA), 
 
 The France dashboard's **Parties** tab shows the registration state of every SIREN in the workspace, one row per party. In the Console, open the **Apps** view and select the **France** app. The dashboard opens on this tab.
 
-Each row carries the party's **Name**, its number of Annuaire **Directory entries**, the **SIREN**, the registration **State**, the **Silo entry** that holds the party, whether **Reporting** is enabled, the **VAT regime** selected at registration, and the date the approval was **Decided**.
+Each row carries the party's Name, its number of Annuaire entries, the SIREN, the registration State, the Silo entry that holds the party, whether Reporting is enabled, the VAT regime selected at registration, and the date the approval was Decided.
 
 | State | Meaning |
 |---|---|
@@ -165,12 +165,11 @@ Each row carries the party's **Name**, its number of Annuaire **Directory entrie
 | <Badge color="green">Approved</Badge> | The party is registered: its Annuaire line is live and published on Peppol. |
 | <Badge color="red">Rejected</Badge> | The submission was declined during review. |
 
-A check mark in the **Reporting** column means the party is also [registered for e-reporting](/guides/fr-pa-reporting); a dash marks a party registered only for e-invoicing. The **VAT regime** pill shows the [cadence](/guides/fr-pa-reporting#picking-a-vat-regime-at-supplier-registration) its reports follow.
+A check mark in the Reporting column means the party is also [registered for e-reporting](/guides/fr-pa-reporting); a dash marks a party registered only for e-invoicing. The VAT regime pill shows the [cadence](/guides/fr-pa-reporting#picking-a-vat-regime-at-supplier-registration) its reports follow.
 
-Click options on this tab:
-
-* **Clicking a row** opens a side panel with the party's Annuaire lines: one block per directory entry with its **Endpoint** (the electronic address), the registered **Name**, and the **Silo entry id**. Every value has a copy button, and the silo entry id also links out to the entry in the Console. Lines that have been unregistered appear greyed out.
-* **Clicking the Silo entry value** copies the party's full silo entry ID to the clipboard.
+<Note>
+Clicking a row opens a side panel with the party's Annuaire lines: one block per directory entry with its Endpoint (the electronic address), the registered Name, and the Silo entry id. Every value has a copy button. Lines that have been unregistered appear greyed out and carry a **Disabled at** row with their deactivation date.
+</Note>
 
 Filter the table by **SIREN**, **State**, or whether **Reporting** is enabled.
 

--- a/guides/fr-pa-reporting.mdx
+++ b/guides/fr-pa-reporting.mdx
@@ -141,6 +141,42 @@ For multiple suppliers (whitelabel use cases) where different suppliers have dif
 
 The cadence must match the regime registered with the tax office. If in doubt, check with your local accountant.
 
+## Reading submitted reports
+
+The France dashboard's **Transactions Flow 8 / 9** tab lists every document submitted for e-reporting. In the Console, open the **Apps** view, select the **France** app, and switch to the **Transactions Flow 8 / 9** tab.
+
+The tab shows one sub-flow at a time: the **Flow type** filter is always active, defaults to International B2B invoices (`10.1`), and switches between the four [sub-flows](#sub-flows). It can be changed but not cleared.
+
+Each row shows the **Document code** and **Document date**, when it was **Recorded**, whether a report already covers it (**Generated report**), the **Supplier SIREN**, the **Flow type**, the **Role** (Seller or Buyer; domestic B2C rows carry no role), the **Silo entry**, and the amounts the report will carry: **Currency**, **Taxable total**, **Tax total (EUR)**, **Amount (EUR)**, and **FX rate**, plus the counterparty identification and, on B2C rows, the category code.
+
+Click options on this tab:
+
+* The **Generated report** column shows a check mark once a Flux 10 report covers the row; **clicking the magnifier** next to it opens the [Reporting Flow 10 tab](#reading-generated-reports) filtered to that report. A dash means the row is still waiting for its reporting window to close.
+* **Clicking the Silo entry value** copies the recorded document's full silo entry ID to the clipboard.
+
+Filter the table by **Document code**, **Supplier SIREN**, **Flow type**, **Role**, or the **Recorded** date range (with This month, Last month, This quarter, Last quarter, and custom presets).
+
+## Reading generated reports
+
+The **Reporting Flow 10** tab lists the generated Flux 10 XML reports, one row per report.
+
+Each row shows the **Reporting period** the report covers, the **Role** of the stream (Seller, Buyer, or B2C), the **Kind** (Transactions for invoice data, Payments for payment data), the **SIREN**, the submission **Status**, the report **Sequence** number, the PPF **Ack ref**, the **Submitted at** and **Generated at** timestamps, and the **Period ID**.
+
+| Status | Meaning |
+|---|---|
+| <Badge color="gray">Generated</Badge> | The XML is built but not yet sent. |
+| <Badge color="blue">Submitted</Badge> | Sent to the PPF; awaiting acknowledgement. |
+| <Badge color="green">Filed</Badge> | Acknowledged by the PPF. |
+| <Badge color="red">Rejected</Badge> | The PPF rejected the report. |
+
+Click options on this tab:
+
+* **Clicking the Reporting period link** goes back to the [Transactions tab](#reading-submitted-reports) filtered to the documents behind the report: its SIREN, role, and B2B flow type (`10.1` for transaction reports, `10.2` for payment reports). Flip the Flow type chip to `10.3` or `10.4` to see the B2C streams instead.
+* **Clicking Download** fetches the exact XML submitted to the PPF, the same payload the [`/xml` endpoint](#reading-whats-filed) returns.
+* **Clicking the Period ID** copies the reporting period's ID, the same value the [read endpoints](#reading-whats-filed) take as `period_id`.
+
+Filter the table by **SIREN**, **Period ID**, **Generated at**, the **Reporting period** window, **Kind**, or **Role**.
+
 ## Reading what's filed
 
 Four read endpoints expose submission status and the raw report XML, all scoped to the party's silo entry id:

--- a/guides/fr-pa-reporting.mdx
+++ b/guides/fr-pa-reporting.mdx
@@ -141,26 +141,25 @@ For multiple suppliers (whitelabel use cases) where different suppliers have dif
 
 The cadence must match the regime registered with the tax office. If in doubt, check with your local accountant.
 
-## Reading submitted reports
+## Reading submitted transactions
 
 The France dashboard's **Transactions Flow 8 / 9** tab lists every document submitted for e-reporting. In the Console, open the **Apps** view, select the **France** app, and switch to the **Transactions Flow 8 / 9** tab.
 
-The tab shows one sub-flow at a time: the **Flow type** filter is always active, defaults to International B2B invoices (`10.1`), and switches between the four [sub-flows](#sub-flows). It can be changed but not cleared.
+The tab shows one sub-flow at a time: the Flow type filter is always active, defaults to International B2B invoices (`10.1`), and switches between the four [sub-flows](#sub-flows). It can be changed but not cleared.
 
-Each row shows the **Document code** and **Document date**, when it was **Recorded**, whether a report already covers it (**Generated report**), the **Supplier SIREN**, the **Flow type**, the **Role** (Seller or Buyer; domestic B2C rows carry no role), the **Silo entry**, and the amounts the report will carry: **Currency**, **Taxable total**, **Tax total (EUR)**, **Amount (EUR)**, and **FX rate**, plus the counterparty identification and, on B2C rows, the category code.
+Each row shows the Document code and Document date, when it was Recorded, whether a report already covers it (Generated report), the Supplier SIREN, the *low type, the Role (Seller or Buyer; domestic B2C rows carry no role), the Silo entry, and the amounts the report will carry: Currency, Taxable total, Tax total (EUR), Amount (EUR), and FX rate, plus the counterparty identification and, on B2C rows, the category code.
 
-Click options on this tab:
+<Note>
+Clicking on the Generated report column opens the [Reporting Flow 10 tab](#reading-generated-reports) filtered to that report. A dash means the row is still waiting for its reporting window to close.
+</Note>
 
-* The **Generated report** column shows a check mark once a Flux 10 report covers the row; **clicking the magnifier** next to it opens the [Reporting Flow 10 tab](#reading-generated-reports) filtered to that report. A dash means the row is still waiting for its reporting window to close.
-* **Clicking the Silo entry value** copies the recorded document's full silo entry ID to the clipboard.
-
-Filter the table by **Document code**, **Supplier SIREN**, **Flow type**, **Role**, or the **Recorded** date range (with This month, Last month, This quarter, Last quarter, and custom presets).
+Filter the table by **Document code**, **Supplier SIREN**, **Flow type**, or the **Recorded** date range.
 
 ## Reading generated reports
 
-The **Reporting Flow 10** tab lists the generated Flux 10 XML reports, one row per report.
+The **Reporting Flow 10** tab lists the generated Flow 10 XML reports, one row per report.
 
-Each row shows the **Reporting period** the report covers, the **Role** of the stream (Seller, Buyer, or B2C), the **Kind** (Transactions for invoice data, Payments for payment data), the **SIREN**, the submission **Status**, the report **Sequence** number, the PPF **Ack ref**, the **Submitted at** and **Generated at** timestamps, and the **Period ID**.
+Each row shows the Reporting period the report covers, the SIREN, the Kind (Transactions for invoice data, Payments for payment data), the Role of the stream (Seller, Buyer), the submission Status, the report Sequence number, the PPF Ack ref, the Submitted at timestamp, and the Period ID.
 
 | Status | Meaning |
 |---|---|
@@ -171,11 +170,11 @@ Each row shows the **Reporting period** the report covers, the **Role** of the s
 
 Click options on this tab:
 
-* **Clicking the Reporting period link** goes back to the [Transactions tab](#reading-submitted-reports) filtered to the documents behind the report: its SIREN, role, and B2B flow type (`10.1` for transaction reports, `10.2` for payment reports). Flip the Flow type chip to `10.3` or `10.4` to see the B2C streams instead.
-* **Clicking Download** fetches the exact XML submitted to the PPF, the same payload the [`/xml` endpoint](#reading-whats-filed) returns.
-* **Clicking the Period ID** copies the reporting period's ID, the same value the [read endpoints](#reading-whats-filed) take as `period_id`.
+<Note>
+Clicking Download fetches the exact XML submitted to the PPF, the same payload the [`/xml` endpoint](#reading-whats-filed) returns.
+</Note>
 
-Filter the table by **SIREN**, **Period ID**, **Generated at**, the **Reporting period** window, **Kind**, or **Role**.
+Filter the table by **SIREN**, **Period ID**, the **Reporting period** window, or **Kind**.
 
 ## Reading what's filed
 

--- a/guides/fr-pa-status.mdx
+++ b/guides/fr-pa-status.mdx
@@ -416,6 +416,8 @@ The France dashboard's **E-Invoicing Flow 6** tab lists every lifecycle status t
 
 Each row shows the referenced Invoice code and Invoice year, the CDAR Code (for example <Badge color="green">205</Badge> Approved), the Silo entry that holds the status document, the Owner SIREN, the invoice's Supplier SIREN, the Role (Sender when you issued the status, Receiver when it arrived from the counterparty's PA), the PPF status of the mandatory forward (same vocabulary as the [invoicing guide](/guides/fr-pa-invoicing#reading-submitted-invoices)), the Issue date, and the Invoice ID this status was recorded against. 
 
+The PPF status only applies to the [mandatory status codes](#status-codes) — <Badge color="gray">200</Badge> Déposée, <Badge color="red">210</Badge> Refusée, and <Badge color="green">212</Badge> Encaissée, the only ones forwarded to the PPF. All other codes are exchanged between PAs over Peppol only, so their PPF status stays at <Badge color="gray">Ready</Badge>.
+
 <Note>
 Clicking the Invoice code looks up the exact invoice on the **E-Invoicing Flow 2** tab, filtered by the Invoice ID.
 </Note>

--- a/guides/fr-pa-status.mdx
+++ b/guides/fr-pa-status.mdx
@@ -414,15 +414,13 @@ One example per code you build, each referencing the same invoice (`INV-2026-004
 
 The France dashboard's **E-Invoicing Flow 6** tab lists every lifecycle status the workspace has sent or received, newest first. In the Console, open the **Apps** view, select the **France** app, and switch to the **E-Invoicing Flow 6** tab.
 
-Each row shows the referenced **Invoice number** and **Invoice year**, the CDAR **Code** as a labelled pill (for example <Badge color="green">205</Badge> Approved), the **Silo entry** that holds the status document, the **Owner SIREN**, the invoice's **Supplier SIREN**, the **Role** (Sender when you issued the status, Receiver when it arrived from the counterparty's PA), the **PPF status** of the mandatory forward (the same vocabulary as the [invoicing guide](/guides/fr-pa-invoicing#reading-submitted-invoices)), the **Issue date**, and the **Invoice ID** of the invoice copy the status was resolved to.
+Each row shows the referenced Invoice code and Invoice year, the CDAR Code (for example <Badge color="green">205</Badge> Approved), the Silo entry that holds the status document, the Owner SIREN, the invoice's Supplier SIREN, the Role (Sender when you issued the status, Receiver when it arrived from the counterparty's PA), the PPF status of the mandatory forward (same vocabulary as the [invoicing guide](/guides/fr-pa-invoicing#reading-submitted-invoices)), the Issue date, and the Invoice ID this status was recorded against. 
 
-Click options on this tab:
+<Note>
+Clicking the Invoice code looks up the exact invoice on the **E-Invoicing Flow 2** tab, filtered by the Invoice ID.
+</Note>
 
-* **Clicking a row** jumps to the **E-Invoicing Flow 2** tab filtered to the referenced invoice number.
-* **Clicking the magnifier** next to the Invoice ID looks up the exact invoice copy by document UUID. Useful when the same invoice number exists under several suppliers.
-* **Clicking the Silo entry or Invoice ID values** copies their full IDs to the clipboard.
-
-Filter the table by **Owner SIREN**, **Invoice ID**, **Invoice number**, or an **Issue date** range.
+Filter the table by **Owner SIREN**, **Invoice ID**, **Invoice code**, or **Status code**.
 
 ## FAQ
 

--- a/guides/fr-pa-status.mdx
+++ b/guides/fr-pa-status.mdx
@@ -410,6 +410,20 @@ One example per code you build, each referencing the same invoice (`INV-2026-004
 
 
 
+## Reading submitted statuses
+
+The France dashboard's **E-Invoicing Flow 6** tab lists every lifecycle status the workspace has sent or received, newest first. In the Console, open the **Apps** view, select the **France** app, and switch to the **E-Invoicing Flow 6** tab.
+
+Each row shows the referenced **Invoice number** and **Invoice year**, the CDAR **Code** as a labelled pill (for example <Badge color="green">205</Badge> Approved), the **Silo entry** that holds the status document, the **Owner SIREN**, the invoice's **Supplier SIREN**, the **Role** (Sender when you issued the status, Receiver when it arrived from the counterparty's PA), the **PPF status** of the mandatory forward (the same vocabulary as the [invoicing guide](/guides/fr-pa-invoicing#reading-submitted-invoices)), the **Issue date**, and the **Invoice ID** of the invoice copy the status was resolved to.
+
+Click options on this tab:
+
+* **Clicking a row** jumps to the **E-Invoicing Flow 2** tab filtered to the referenced invoice number.
+* **Clicking the magnifier** next to the Invoice ID looks up the exact invoice copy by document UUID. Useful when the same invoice number exists under several suppliers.
+* **Clicking the Silo entry or Invoice ID values** copies their full IDs to the clipboard.
+
+Filter the table by **Owner SIREN**, **Invoice ID**, **Invoice number**, or an **Issue date** range.
+
 ## FAQ
 
 <FAQ />


### PR DESCRIPTION
Document the France dashboard in the PA guides: one "Reading …" section per guide describing the matching tab, its columns, status pills, filters, and click options.

Changes:
- Registration: "Reading parties registrations" (Parties tab, Annuaire side panel)
- Invoicing: "Reading submitted invoices" (E-Invoicing Flow 2 tab)
- Status: "Reading submitted statuses" (E-Invoicing Flow 6 tab)
- Reporting: "Reading submitted transactions" (Transactions Flow 8/9 tab) and "Reading generated reports" (Reporting Flow 10 tab)

🤖 Generated with [Claude Code](https://claude.com/claude-code)