### PR TITLE
Note that France PA line takeovers are temporarily manual

### DIFF
--- a/guides/fr-pa-registration.mdx
+++ b/guides/fr-pa-registration.mdx
@@ -132,11 +132,11 @@ For platforms that want to drive the signing process programmatically, use the e
 
 ### Taking over a line from another Plateforme Agréée
 
-If a SIREN's Annuaire line is already held by another Plateforme Agréée (PA), registration takes that line over instead of creating a duplicate. To do so, the party must specify the former PA line under `fr-former-matricule` meta key. This will add an additional section in the signed agreement that asks for consent to take over the line. 
+If a SIREN's Annuaire line is already held by another Plateforme Agréée (PA), the party must specify the former PA line under the `fr-former-matricule` meta key. This adds an additional section to the signed agreement asking for consent to take over the line.
 
-<Note>
-  If a takeover is required and the matricule is missing, registration fails and asks for it.
-</Note>
+<Warning>
+  Due to recent changes in how PA migrations work, taking over a line is no longer performed automatically. Registration fails and asks the party to contact support, who will complete the switch manually. This is temporary, until further notice.
+</Warning>
 
 ## PPF unregister supplier workflow
 


### PR DESCRIPTION
## Summary
- Updates the "Taking over a line from another Plateforme Agréée" section in `guides/fr-pa-registration.mdx` to reflect that the annuaire line takeover is no longer performed automatically.
- Matches a recent gov-fr change ([invopop/gov-fr#92](https://github.com/invopop/gov-fr/pull/92)): registration now fails and asks the party to contact support instead of calling PPF to end the former platform's line, until DGFiP's official portability process ships.

## Test plan
- [x] `mint broken-links` — no broken links