### PR TITLE
Document payment collection for Italian Smart Receipts

### DIFF
--- a/guides/it-ticket.mdx
+++ b/guides/it-ticket.mdx
@@ -141,7 +141,7 @@ You can void an invoice if it was issued in error, such as when a receipt is acc
 2. Run the "Void Italian Smart Receipts" workflow with this uuid
 
 <Warning>
-You can only void invoices that were originally sent through this app during the same business day.
+Voiding produces a new document, dated the day it is emitted rather than the original sale date, and it reduces the daily totals reported to the AdE for that day. Keep this in mind when voiding receipts from previous days, as it may have fiscal implications for the supplier.
 </Warning>
 
 ## FAQ

--- a/guides/it-ticket.mdx
+++ b/guides/it-ticket.mdx
@@ -25,7 +25,7 @@ Important distinctions for the _Documento Commerciale_:
 - It is not an invoice (_fattura_) - invoices require detailed buyer information and follow different tax rules.
 - It does not replace transport documents (_documento di trasporto_).
 - It is not a simple internal receipt - it serves an official fiscal function requiring AdE transmission.
-- It must include VAT at the time of sale - deferred VAT payment is not permitted.
+- VAT is always calculated when the document is issued - unlike FatturaPA, there is no deferred VAT option. Amounts not collected at the time of sale are reported as _corrispettivo non riscosso_ (see [Payment collection](#payment-collection)).
 
 The AdE portal provides functionality to create tickets, void them entirely, and process refunds at the item level. Invopop's Smart Receipts implementation supports all these operations, allowing you to manage your electronic tickets programmatically through our API or manually via the Console.
 
@@ -128,6 +128,10 @@ Every receipt reports to the AdE how much of the total was collected at the time
 <Warning>
 Any part of the total not covered by `payment.advances` is reported to the AdE as not collected (_corrispettivo non riscosso_). An invoice with no `payment` block is reported as fully uncollected. If the customer paid at the point of sale, always include `payment.advances` covering the amount paid.
 </Warning>
+
+Receipts cannot be changed once the AdE has accepted them, so an amount reported as _corrispettivo non riscosso_ is not corrected by editing the original. If you need to report an amount collected later, issue a new receipt for that amount with `payment.advances` covering it in full. The AdE does not require the new receipt to reference the original; if you want the two to be traceable, include the original's number and date in the line description.
+
+Whether a later collection needs reporting depends on the operation: for goods, VAT is already chargeable at delivery regardless of collection; for services, it becomes chargeable when the payment is received. Which applies to your sales is a determination for you and your tax advisors.
 
 ### Refund an invoice
 

--- a/guides/it-ticket.mdx
+++ b/guides/it-ticket.mdx
@@ -118,6 +118,17 @@ The AdE will automatically generate a document number for the invoice. Once the 
   <img src="/assets/guides/it-ticket-invoice-stamp.png" alt="Invoice Stamp" />
 </Frame>
 
+### Payment collection
+
+Every receipt reports to the AdE how much of the total was collected at the time of sale, and how. Use `payment.advances` in your GOBL invoice to record what the customer paid:
+
+- Advances with the `cash` key are reported as cash payments (_pagamento contante_).
+- Advances with any other key, such as `card`, are reported as electronic payments (_pagamento elettronico_).
+
+<Warning>
+Any part of the total not covered by `payment.advances` is reported to the AdE as not collected (_corrispettivo non riscosso_). An invoice with no `payment` block is reported as fully uncollected. If the customer paid at the point of sale, always include `payment.advances` covering the amount paid.
+</Warning>
+
 ### Refund an invoice
 
 Refund processing is handled through corrective invoices, which you can issue using the same workflow as regular invoices. See the "Corrective Invoice" accordion above for details and examples.

--- a/snippets/invoices/it/ticket-accordion.mdx
+++ b/snippets/invoices/it/ticket-accordion.mdx
@@ -16,6 +16,7 @@ import TicketB2CInvoiceCorrective from '/snippets/invoices/it/ticket-b2c-correct
 			- Items have an extension identifying them as goods or services
 			- VAT exemptions require an Italian exemption code
 		- The `prices_include` field indicates that item prices include VAT
+		- The `payment.advances` entry records the total as paid by card. Without it, the receipt is reported to the AdE as fully uncollected (_corrispettivo non riscosso_)
 		- When running `gobl build`, the system automatically calculates totals, line item sums, IVA breakdowns, and normalizes the document according to Smart Receipts requirements
 		- The built version in the second tab shows the normalized document with all calculated fields including line indices, sums, and total amounts
 

--- a/snippets/invoices/it/ticket-b2c.mdx
+++ b/snippets/invoices/it/ticket-b2c.mdx
@@ -65,6 +65,16 @@
 			"total": "412.50"
 		}
 	],
+	"payment": {
+		"advances": [
+			{
+				"key": "card",
+				"description": "Card payment",
+				"percent": "100%",
+				"amount": "537.50"
+			}
+		]
+	},
 	"totals": {
 		"sum": "537.50",
 		"tax_included": "74.39",
@@ -96,7 +106,9 @@
 		},
 		"tax": "74.39",
 		"total_with_tax": "537.50",
-		"payable": "537.50"
+		"payable": "537.50",
+		"advance": "537.50",
+		"due": "0.00"
 	}
 }
 ```

--- a/snippets/invoices/it/ticket-b2c.min.mdx
+++ b/snippets/invoices/it/ticket-b2c.min.mdx
@@ -51,6 +51,15 @@
         }
       ]
     }
-  ]
+  ],
+  "payment": {
+    "advances": [
+      {
+        "key": "card",
+        "description": "Card payment",
+        "percent": "100%"
+      }
+    ]
+  }
 }
 ```


### PR DESCRIPTION
## Context

The Italian Smart Receipts guide never mentions how a receipt's collection status is reported to the AdE. Integrators who copy the example invoices — which carry no `payment` block — unknowingly report every receipt as fully uncollected (*corrispettivo non riscosso*), when in most point-of-sale scenarios the amount was paid in full. This has bitten a customer in production.

While working the same case, the customer quoted the guide's warning that receipts can only be voided during the same business day:

<img width="766" height="352" alt="image" src="https://github.com/user-attachments/assets/f615ed09-7380-4a85-9112-f2cfef8f6075" />

That claim was introduced with the original void section (#167) without a recorded source, and it doesn't hold up:
* A-Cube's docs impose no void deadline (their only same-day rule is the 11:58 PM transmission cutoff for sends and we verified by voiding a months-old receipt end-to-end in sandbox). 
* The AdE rules define void/return documents as the standard reversal for finalized receipts, referencing originals from any previous day by number and date (AdE clarifications for RT manufacturers, 9 May 2017).

## Changes

- **Add a "Payment collection" section to the Smart Receipts guide** explaining that `payment.advances` drives what's reported: `cash` → *pagamento contante*, any other key (e.g. `card`) → *pagamento elettronico*, and anything not covered by advances → *non riscosso*, with a warning that a missing `payment` block means fully uncollected.
- **Add `payment.advances` to the B2C example invoice** (min + built) so the template integrators copy reports the receipt as paid. The built version was updated by hand rather than via `gobl-build.sh` — the current `gobl` CLI pairs with a different GOBL version and regenerates unrelated churn across all examples; the spliced `payment`, `advance` and `due` values were verified by running GOBL's calculation (v0.216.0, the version silo pins) on the updated minimal input.
- **Note the new payment line in the example accordion** so readers see it called out alongside the other field explanations.
- **Correct the void timing warning.** The same-business-day claim is replaced with the real caveat: a void document is dated at emission and reduces that day's reported totals — the original day is never rewritten.
- **Explain deferred collection instead of forbidding it.** The guide claimed a receipt "must include VAT at the time of sale - deferred VAT payment is not permitted". Uncollected sales are permitted, they're just reported differently. The bullet now says there's no deferred VAT option as in FatturaPA and points to Payment collection, which describes how to report an amount collected later (a new receipt covering that amount, no reference to the original required). When that applies is left to the integrator: goods are chargeable at delivery, services on payment, and the determination is theirs.