### PR TITLE
Document the SDI unregister action

### DIFF
--- a/apps/sdi-italy.mdx
+++ b/apps/sdi-italy.mdx
@@ -99,6 +99,7 @@ import FAQ from '/snippets/faqs/it/composers/app-sdi.mdx';
 			<Accordion title="SDI Italy unregister customer workflow">
 			This workflow stops a company from receiving invoices through SDI.
 				<SDIUnregisterCustomerWorkflow />
+				[Add to my workspace →](https://console.invopop.com/redirect/workflows/new?template=it-sdi-unregister-customer)
 			</Accordion>
 			<Accordion title="SDI Italy import invoices workflow">
 			This workflow imports and processes invoices received through SDI.

--- a/apps/sdi-italy.mdx
+++ b/apps/sdi-italy.mdx
@@ -7,6 +7,7 @@ mode: wide
 
 import SDISendWorkflow from '/snippets/workflows/it/sdi-send.mdx';
 import SDIRegisterCustomerWorkflow from '/snippets/workflows/it/sdi-register-customer.mdx';
+import SDIUnregisterCustomerWorkflow from '/snippets/workflows/it/sdi-unregister-customer.mdx';
 import SDIImportInvoicesWorkflow from '/snippets/workflows/it/sdi-import-invoices.mdx';
 import InvoiceAccordion from '/snippets/invoices/it/accordion.mdx';
 import Supplier from '/snippets/parties/it/supplier.mdx';
@@ -72,6 +73,10 @@ import FAQ from '/snippets/faqs/it/composers/app-sdi.mdx';
 		 Register a GOBL party (customer) to receive invoices from the Italian SDI.
 		</Card>
 
+		<Card title="Unregister supplier from SDI" icon="https://assets.invopop.com/apps/sdi-italy/icon.svg" horizontal>
+		 Stop a registered party from receiving invoices from the Italian SDI, freeing its tax ID to be registered again.
+		</Card>
+
 		<Card title="Import invoice from SDI" icon="https://assets.invopop.com/apps/sdi-italy/icon.svg" horizontal>
 		 <div class="pop-count"><Icon icon="https://assets.invopop.com/icons/pops.svg" /> 3</div>
 		 Import invoices from the Italian SDI using the FatturaPA format.
@@ -90,6 +95,10 @@ import FAQ from '/snippets/faqs/it/composers/app-sdi.mdx';
 			This workflow registers a company to receive invoices through SDI.
 				<SDIRegisterCustomerWorkflow />
 				[Add to my workspace →](https://console.invopop.com/redirect/workflows/new?template=it-sdi-register-customer)
+			</Accordion>
+			<Accordion title="SDI Italy unregister customer workflow">
+			This workflow stops a company from receiving invoices through SDI.
+				<SDIUnregisterCustomerWorkflow />
 			</Accordion>
 			<Accordion title="SDI Italy import invoices workflow">
 			This workflow imports and processes invoices received through SDI.

--- a/apps/sdi-italy.mdx
+++ b/apps/sdi-italy.mdx
@@ -73,7 +73,7 @@ import FAQ from '/snippets/faqs/it/composers/app-sdi.mdx';
 		 Register a GOBL party (customer) to receive invoices from the Italian SDI.
 		</Card>
 
-		<Card title="Unregister supplier from SDI" icon="https://assets.invopop.com/apps/sdi-italy/icon.svg" horizontal>
+		<Card title="Unregister party from SDI" icon="https://assets.invopop.com/apps/sdi-italy/icon.svg" horizontal>
 		 Stop a registered party from receiving invoices from the Italian SDI, freeing its tax ID to be registered again.
 		</Card>
 

--- a/guides/it-sdi-receiving.mdx
+++ b/guides/it-sdi-receiving.mdx
@@ -132,6 +132,9 @@ Registering a tax ID claims it for a single party record, and only one party per
 
 Use this workflow to stop a company from receiving invoices through SDI:
 
+<Card iconType="duotone" title="SDI unregister party workflow" icon="code-branch" href="https://console.invopop.com/redirect/workflows/new?template=it-sdi-unregister-customer" horizontal>
+  Add to my workspace →
+</Card>
 <Tabs>
   <Tab title="Workflow">
     <WorkflowDiagram workflow={itSdiUnregisterCustomerWorkflow} />

--- a/guides/it-sdi-receiving.mdx
+++ b/guides/it-sdi-receiving.mdx
@@ -5,11 +5,13 @@ description: "Receive and process electronic invoices from Italy's SDI system"
 ---
 
 import CustomerRegistrationWorkflow from '/snippets/workflows/it/sdi-register-customer.mdx';
+import CustomerUnregistrationWorkflow from '/snippets/workflows/it/sdi-unregister-customer.mdx';
 import ImportInvoicesWorkflow from '/snippets/workflows/it/sdi-import-invoices.mdx';
 import ItalyResources from '/snippets/tables/italy-resources.mdx';
 import FAQ from '/snippets/faqs/it/composers/guide-sdi-receiving.mdx';
 import { WorkflowDiagram } from '/snippets/components/workflow.jsx';
 import { itSdiRegisterCustomerWorkflow } from '/snippets/workflows/it/sdi-register-customer-data.mdx';
+import { itSdiUnregisterCustomerWorkflow } from '/snippets/workflows/it/sdi-unregister-customer-data.mdx';
 import { itSdiImportInvoicesWorkflow } from '/snippets/workflows/it/sdi-import-invoices-data.mdx';
 
 
@@ -123,6 +125,34 @@ For each company you want to receive invoices, register the Recipient Code (Codi
 Once registered, any invoices addressed to the registered companies with the Recipient Code will be automatically received and processed through the Import Invoices workflow configured in the app settings. Received invoices will appear in your **Expenses** folder.
 
 If errors occur during the import process, they will trigger the rescue steps in the workflow, allowing users to check what went wrong and take appropriate action.
+
+## Unregistering a company
+
+Registering a tax ID claims it for a single party record, and only one party per environment can hold a given tax ID at a time. Unregister a company when it is no longer your client, or when you need to register the same tax ID again from a different party record.
+
+Use this workflow to stop a company from receiving invoices through SDI:
+
+<Tabs>
+  <Tab title="Workflow">
+    <WorkflowDiagram workflow={itSdiUnregisterCustomerWorkflow} />
+  </Tab>
+  <Tab title="Code">
+    Copy and paste into a new [Empty Party workflow](https://console.invopop.com/redirect/workflows/new?template=empty-party) code view.
+    <CustomerUnregistrationWorkflow />
+  </Tab>
+</Tabs>
+
+The `sdi-it.unregister` action turns off invoice receiving for the company and clears its SDI registration from the party record. Once it completes, the tax ID is free to register again, whether from another party record in the same workspace or from a different workspace. Running it on a party that is not registered skips the step rather than failing, so it is safe to re-run.
+
+<Warning>
+  Unregistering stops receiving only. Sending never required registration, so it is unaffected. Invoices addressed to the company after it is unregistered are no longer imported into your workspace.
+</Warning>
+
+<Note>
+  Unregistering does not affect legal archiving. Invoices already preserved under _conservazione a norma_ stay preserved, as the law requires.
+</Note>
+
+The Recipient Code registration at Agenzia delle Entrate is separate and stays in place. If the company should stop receiving through Invopop altogether, update its reception settings at the [Italian tax authority](https://ivaservizi.agenziaentrate.gov.it/portale/) as well.
 
 ## FAQ
 

--- a/snippets/faqs/it/leaves/sdi/receiving.mdx
+++ b/snippets/faqs/it/leaves/sdi/receiving.mdx
@@ -18,6 +18,13 @@
 
     This two-step registration process (with the tax authority and with Invopop) must be completed for each company you want to register. This is particularly useful for white-labeling scenarios where a user manages multiple entities.
   </Accordion>
+  <Accordion title="Can I register the same tax ID again from a different party?">
+    Yes, but only one party at a time can hold a given tax ID. Run the [unregister workflow](/guides/it-sdi-receiving#unregistering-a-company) on the party that currently holds it, then register the new one.
+
+    Registering a tax ID that another party already holds fails with `supplier already registered in a different workspace or with a different entry`.
+
+    Sandbox and live are counted separately, so the same tax ID can be registered in both at the same time.
+  </Accordion>
   <Accordion title="What is the difference between registering with the tax authority and registering with Invopop?">
     The two-step registration process serves different purposes:
 

--- a/snippets/workflows/it/sdi-unregister-customer-data.mdx
+++ b/snippets/workflows/it/sdi-unregister-customer-data.mdx
@@ -1,0 +1,42 @@
+export const itSdiUnregisterCustomerWorkflow = {
+  "name": "SDI unregister customer",
+  "description": "Unregister a customer from SDI to stop receiving invoices",
+  "schema": "org/party",
+  "steps": [
+    {
+      "id": "b56b1f70-90e1-11f1-9fc8-92000767c8b7",
+      "name": "Set state",
+      "provider": "silo.state",
+      "summary": "Set state to `processing`{.state .processing}",
+      "config": {
+        "state": "processing"
+      }
+    },
+    {
+      "id": "b56e7f7c-90e1-11f1-8a81-92000767c8b7",
+      "name": "Unregister party from SDI",
+      "provider": "sdi-it.unregister",
+      "summary": "Stop receiving invoices for this company"
+    },
+    {
+      "id": "b56e8088-90e1-11f1-b95f-92000767c8b7",
+      "name": "Set state",
+      "provider": "silo.state",
+      "summary": "Set state to `void`{.state .void}",
+      "config": {
+        "state": "void"
+      }
+    }
+  ],
+  "rescue": [
+    {
+      "id": "cf5af04f-90e1-11f1-8a24-92000767c8b7",
+      "name": "Set state",
+      "provider": "silo.state",
+      "summary": "Set state to `error`{.state .error}",
+      "config": {
+        "state": "error"
+      }
+    }
+  ]
+};

--- a/snippets/workflows/it/sdi-unregister-customer.mdx
+++ b/snippets/workflows/it/sdi-unregister-customer.mdx
@@ -1,0 +1,52 @@
+---
+title: "SDI unregister customer"
+description: "Unregister a customer from SDI to stop receiving invoices"
+countryCode: "it"
+appId: "sdi-it"
+schema: "org/party"
+---
+
+```json Example SDI unregister customer workflow
+{
+  "name": "SDI unregister customer",
+  "description": "Unregister a customer from SDI to stop receiving invoices",
+  "schema": "org/party",
+  "steps": [
+    {
+      "id": "b56b1f70-90e1-11f1-9fc8-92000767c8b7",
+      "name": "Set state",
+      "provider": "silo.state",
+      "summary": "Set state to `processing`{.state .processing}",
+      "config": {
+        "state": "processing"
+      }
+    },
+    {
+      "id": "b56e7f7c-90e1-11f1-8a81-92000767c8b7",
+      "name": "Unregister party from SDI",
+      "provider": "sdi-it.unregister",
+      "summary": "Stop receiving invoices for this company"
+    },
+    {
+      "id": "b56e8088-90e1-11f1-b95f-92000767c8b7",
+      "name": "Set state",
+      "provider": "silo.state",
+      "summary": "Set state to `void`{.state .void}",
+      "config": {
+        "state": "void"
+      }
+    }
+  ],
+  "rescue": [
+    {
+      "id": "cf5af04f-90e1-11f1-8a24-92000767c8b7",
+      "name": "Set state",
+      "provider": "silo.state",
+      "summary": "Set state to `error`{.state .error}",
+      "config": {
+        "state": "error"
+      }
+    }
+  ]
+}
+```


### PR DESCRIPTION
## Summary

- **Documents the `sdi-it.unregister` action**, the reverse of `sdi-it.register`. It turns off invoice receiving for a party and clears its SDI registration, which frees the tax ID to be registered again — only one party per environment can hold a given tax ID at a time.
- **Adds the `SDI unregister customer` workflow snippet pair**, shaped like the register workflow: processing → action → terminal state, with a rescue step.
- **Lists the action on the SDI Italy app page**, under both Actions and Workflows, and adds an "Unregistering a company" section to the receiving guide.
- **Adds an FAQ answer on reusing a tax ID** from a different party, including the error you get while another party still holds it.

## Notes for review

- The new snippet sets no `environment` config. The app reads only `response` (send) and `flow` (archive.store) from step config, so the key the neighbouring Italy snippets carry has no effect — I left those as they are rather than widen this PR.
- The guide notes that legal archiving is unaffected: invoices already preserved under _conservazione a norma_ stay preserved.
- The unregister accordion has no "Add to my workspace" link, since no workflow template is registered for it yet.

## Test plan

- [x] Imports in both edited pages resolve to existing files
- [x] The `.mdx` / `-data.mdx` pair parses as identical JSON, and the export name is unique across `snippets/workflows/`
- [x] The FAQ's `#unregistering-a-company` anchor matches the new heading
- [x] Mintlify Deployment and link-rot validation both pass on this PR
