### PR TITLE
Document Norwegian specifics and fix broken GOBL addon links

### DIFF
--- a/snippets/faqs/be/leaves/general/invoicing.mdx
+++ b/snippets/faqs/be/leaves/general/invoicing.mdx
@@ -6,7 +6,7 @@
   </Accordion>
 
   <Accordion title="Where do I find Belgium-specific GOBL documentation?">
-    See the [Belgium tax regime in GOBL](https://docs.gobl.org/regimes/be) for tax IDs and category codes. The Peppol BIS Billing 3.0 mapping is shared across EU members and lives in [`peppol-bis-v3`](https://docs.gobl.org/addons/peppol-bis-v3).
+    See the [Belgium tax regime in GOBL](https://docs.gobl.org/regimes/be) for tax IDs and category codes. The Peppol BIS Billing 3.0 mapping is shared across EU members and comes from the [`eu-en16931-v2017`](https://docs.gobl.org/addons/eu-en16931-v2017) addon.
   </Accordion>
     <Accordion title="What is the difference between scheme 0208 and 9925 in Belgium?">
     Belgium uses two Peppol scheme identifiers:

--- a/snippets/faqs/no/leaves/general/invoicing.mdx
+++ b/snippets/faqs/no/leaves/general/invoicing.mdx
@@ -41,3 +41,28 @@
 
     <Tip>Use the **Lookup Participant ID** workflow step to verify a recipient's Peppol registration before sending. If a lookup with `0192` fails, try again with `9908`.</Tip>
   </Accordion>
+
+  <Accordion title="How do I include Foretaksregisteret on my invoices?">
+    Limited liability companies (AS), public limited companies (ASA) and branches of foreign companies must show the word "Foretaksregisteret" on their sales documents — see the [invoice content requirements](/compliance/norway). Add it as a tax-scoped identity on the supplier:
+
+    ```json
+    "supplier": {
+      "name": "Fjordlys AS",
+      "tax_id": {
+        "country": "NO",
+        "code": "123456785MVA"
+      },
+      "identities": [
+        {
+          "type": "TAX",
+          "code": "Foretaksregisteret",
+          "scope": "tax"
+        }
+      ]
+    }
+    ```
+
+    The identity becomes a second `PartyTaxScheme` on the supplier, under scheme `TAX`, which is where the Peppol rule NO-R-002 looks for it. Sole traders (enkeltpersonforetak) aren't covered by the requirement and should leave the identity out.
+
+    <Tip>NO-R-002 is a warning rather than a fatal rule, so an invoice without it still reaches the recipient and no workflow step will report the omission.</Tip>
+  </Accordion>

--- a/snippets/faqs/no/leaves/general/invoicing.mdx
+++ b/snippets/faqs/no/leaves/general/invoicing.mdx
@@ -6,7 +6,7 @@
   </Accordion>
 
   <Accordion title="Where do I find Norway-specific GOBL documentation?">
-    See the [Norway tax regime in GOBL](https://docs.gobl.org/regimes/no) for tax IDs and category codes. The Peppol BIS Billing 3.0 mapping is shared across the network and lives in [`peppol-bis-v3`](https://docs.gobl.org/addons/peppol-bis-v3).
+    See the [Norway tax regime in GOBL](https://docs.gobl.org/regimes/no) for tax IDs and category codes. The Peppol BIS Billing 3.0 mapping is shared across the network and comes from the [`eu-en16931-v2017`](https://docs.gobl.org/addons/eu-en16931-v2017) addon.
   </Accordion>
     <Accordion title="What is the difference between scheme 0192 and 9908 in Norway?">
     Both schemes identify a company by its Norwegian organization number:
@@ -65,4 +65,39 @@
     The identity becomes a second `PartyTaxScheme` on the supplier, under scheme `TAX`, which is where the Peppol rule NO-R-002 looks for it. Sole traders (enkeltpersonforetak) aren't covered by the requirement and should leave the identity out.
 
     <Tip>NO-R-002 is a warning rather than a fatal rule, so an invoice without it still reaches the recipient and no workflow step will report the omission.</Tip>
+  </Accordion>
+
+  <Accordion title="Which VAT rates and tax categories apply in Norway?">
+    Norway has four positive VAT rates. All of them are category `S` in Peppol — the percentage carries the distinction, not the category code.
+
+    | Rate | Percentage | Applies to |
+    |------|-----------|------------|
+    | Standard | 25% | Most goods and services |
+    | Reduced (food) | 15% | Foodstuffs, water and wastewater services |
+    | Reduced (services) | 12% | Passenger transport, accommodation, cinema, museums, sporting events, public broadcasting |
+    | Special (marine) | 11.11% | Wild marine resources sold through a fiskesalgslag |
+
+    Set the percentage on the line tax and tag it with the [`untdid-tax-category`](https://docs.gobl.org/addons/eu-en16931-v2017) extension:
+
+    ```json
+    "taxes": [
+      {
+        "cat": "VAT",
+        "percent": "25.0%",
+        "ext": { "untdid-tax-category": "S" }
+      }
+    ]
+    ```
+
+    Supplies that carry no VAT use a different category and omit the percentage:
+
+    | Category | Meaning |
+    |----------|---------|
+    | `Z` | Zero rated goods — exports, international transport, newspapers, books |
+    | `E` | Exempt from tax |
+    | `K` | VAT exempt for EEA intra-community supply of goods and services |
+    | `AE` | VAT reverse charge |
+    | `G` | Free export item, tax not charged |
+
+    See the [Norway compliance page](/compliance/norway) for what each rate covers and the registration threshold.
   </Accordion>

--- a/snippets/faqs/peppol/leaves/invoicing.mdx
+++ b/snippets/faqs/peppol/leaves/invoicing.mdx
@@ -25,5 +25,5 @@
   </Accordion>
 
   <Accordion title="Where do I find Peppol GOBL documentation?">
-    See the [`oasis-ubl-v2`](https://docs.gobl.org/addons/oasis-ubl-v2) addon and the [Peppol app reference](/apps/peppol) for required fields, supported document types, and Participant ID schemes.
+    See the [`eu-en16931-v2017`](https://docs.gobl.org/addons/eu-en16931-v2017) addon for the field and validation rules Peppol BIS Billing 3.0 builds on, and the [Peppol app reference](/apps/peppol) for supported document types and Participant ID schemes.
   </Accordion>


### PR DESCRIPTION
## Context

Norwegian limited companies (AS), public limited companies (ASA) and branches of foreign companies must show the word "Foretaksregisteret" on their sales documents. Our [compliance page](https://docs.invopop.com/compliance/norway) lists that among the mandatory invoice contents, but nothing tells a customer how to express it in GOBL. The omission is silent too: NO-R-002, the Peppol rule that checks the word, is a warning, so the invoice still reaches the recipient and no workflow step reports anything.

Review turned up two more gaps: the Norwegian VAT rates and Peppol categories were missing from the guide, and the FAQ pointed at two GOBL addons that don't exist.

## Changes

**Foretaksregisteret.** An accordion giving the supplier identity that produces the field:

```json
"identities": [
  { "type": "TAX", "code": "Foretaksregisteret", "scope": "tax" }
]
```

It links the compliance page for the obligation, and says sole traders (enkeltpersonforetak) should leave the identity out since the requirement doesn't cover them.

**VAT rates and categories.** An accordion with the four positive rates (25%, 15%, 12%, 11.11%), all of them category `S`, plus the categories for supplies that carry no VAT (`Z`, `E`, `K`, `AE`, `G`) and a line-tax example.

**Broken addon links.** GOBL has no `oasis-ubl-v2` and no `peppol-bis-v3`; both now point at [`eu-en16931-v2017`](https://docs.gobl.org/addons/eu-en16931-v2017), the addon our Peppol workflows apply. `oasis-ubl-v2` was in the shared Peppol leaf, so that fix also lands on the BE, DE, FI and FR pages. `peppol-bis-v3` was in the Norway and Belgium leaves.

Both accordions go in the Norway invoicing leaf, so they render on the [Norway FAQ](https://docs.invopop.com/faq/norway) and the [Norway Peppol guide](https://docs.invopop.com/guides/no-peppol) with no composer changes.

I ran every snippet here through `gobl.ubl`. The identity emits a second `cac:PartyTaxScheme` with `cbc:CompanyID` of `Foretaksregisteret` under scheme `TAX`, which satisfies the [NO-R-002 assertion](https://github.com/OpenPEPPOL/peppol-bis-invoice-3/blob/master/rules/sch/PEPPOL-EN16931-UBL.sch), and all four rates plus the five zero-VAT categories convert to the expected `cac:TaxCategory`.

## Next

- Three dead GOBL links remain outside Norway: `ar-arca-v1`, `pl-ksef-v1` and `regimes/gr`.
- `snippets/faqs/fr/leaves/pa/invoicing.mdx` still names `peppol-bis-v3` in prose.
- Norway has no `snippets/parties/no/` or `snippets/invoices/no/`, unlike the other Peppol countries.
- The Peppol guide's setup step lists only the Peppol app, but `ubl.generate` in the send workflow needs OASIS UBL connected too. With only Peppol enrolled, the documented workflow fails with `enrollment not found`.
