### PR TITLE
Document receive-only France registration (annuaire only)

### DIFF
--- a/guides/fr-pa-registration.mdx
+++ b/guides/fr-pa-registration.mdx
@@ -14,7 +14,7 @@ import FAQ from '/snippets/faqs/fr/composers/guide-pa-supplier.mdx';
 import Supplier from '/snippets/parties/fr/supplier.mdx';
 
   
-Registration on the French Directory is required for any SIREN that will issue, report or receive invoices through Invopop as its Plateforme Agréée. Each party (a SIREN) is registered once. The workflow collects a signed agreement, registers the party in the French Annuaire, publishes it on the Peppol network and registers for Reporting. After registration is completed, the party can both send and receive invoices as well as report transactions. The Annuaire requires every entry to be receive-capable, so there is no send-only option as in other Peppol countries.
+Registration on the French Directory is required for any SIREN that will issue, report or receive invoices through Invopop as its Plateforme Agréée. Each party (a SIREN) is registered once. The workflow collects a signed agreement, registers the party in the French Annuaire, publishes it on the Peppol network and registers for Reporting. After registration is completed, the party can both send and receive invoices as well as report transactions. The Annuaire requires every entry to be receive-capable, so there is no send-only option as in other Peppol countries. For parties that only need to receive invoices for now — most SMEs and micro-businesses until September 2027 — see [Registering without e-reporting](#registering-without-e-reporting).
 
 | - | Sandbox | Live |
 |---|---|---|
@@ -137,6 +137,30 @@ If a SIREN's Annuaire line is already held by another Plateforme Agréée (PA), 
 <Warning>
   Due to recent changes in how PA migrations work, taking over a line is no longer performed automatically. Registration fails and asks the party to contact support, who will complete the switch manually. This is temporary, until further notice.
 </Warning>
+
+## Registering without e-reporting
+
+Obligations under the French mandate kick in separately: from 1 September 2026 every business must be registered in the Annuaire to *receive* e-invoices, but SMEs and micro-businesses are not required to issue e-invoices or e-report until 1 September 2027 (see the [timeline](/guides/fr-pa#timeline)). If you onboard many smaller suppliers, most of them initially need only an Annuaire line and a Peppol inbox — not a reporting registration.
+
+The default template registers the party for everything, including reporting. To register parties for receiving only, create a modified copy of the template:
+
+<Steps>
+  <Step title="Add the template">
+    Add the [PPF register supplier](#ppf-register-supplier-workflow) template to your workspace and rename the copy, e.g. "PPF register supplier — Annuaire only".
+  </Step>
+  <Step title="Remove the reporting step">
+    Delete the **Register party for reporting** (`gov-fr.reporting.register`) step. Keep the Directory and Peppol steps — every Annuaire entry is receive-capable, so nothing else needs to change.
+  </Step>
+  <Step title="Run it for receive-only parties">
+    Use this workflow for parties that don't yet have issuing or reporting obligations, and keep the unmodified template for those that do. Receive-only parties appear in the [Parties tab](#reading-parties-registrations) with a dash in the Reporting column.
+  </Step>
+</Steps>
+
+When a party's e-reporting obligations begin — for example when the September 2027 mandate reaches SMEs and micro-businesses — complete its registration by running the **Register party for reporting** step against the party's silo entry: create a workflow containing just that step and run it on the already-registered party. The [VAT regime](/guides/fr-pa-reporting#picking-a-vat-regime-at-supplier-registration) is picked the same way as in the full registration.
+
+<Note>
+  A party registered without the reporting step is not on any reporting cadence: Invopop only generates and files Flux 10 reports for parties registered for reporting. The signed agreement is the same in both cases, so no new mandate is needed when reporting is added later.
+</Note>
 
 ## PPF unregister supplier workflow
 

--- a/guides/fr-pa.mdx
+++ b/guides/fr-pa.mdx
@@ -64,6 +64,8 @@ Reception is universal from 1 September 2026 for all companies regardless of siz
 | SME (PME) | under 250 staff and turnover < €50M or balance sheet < €43M | 1 Sep 2026 | 1 Sep 2027 |
 | Micro (TPE) | subset of the SME band, at the smallest end | 1 Sep 2026 | 1 Sep 2027 |
 
+Because the obligations kick in separately, most SMEs and micro-businesses only need an Annuaire line and an inbox until September 2027 — see [Registering without e-reporting](/guides/fr-pa-registration#registering-without-e-reporting).
+
 View our [compliance timeline for France](/timelines/france).
 
 ## Key concepts

--- a/snippets/faqs/fr/leaves/pa/compliance.mdx
+++ b/snippets/faqs/fr/leaves/pa/compliance.mdx
@@ -7,6 +7,10 @@
   </Accordion>
 
 
+  <Accordion title="Do SMEs have to register in the Annuaire before their e-invoicing mandate applies?">
+    Yes. From 1 September 2026 every French business, regardless of size, must be able to receive e-invoices, which requires an Annuaire registration through a PA. SMEs and micro-businesses are not required to issue e-invoices or e-report until 1 September 2027 — those obligations follow the company's size band, so registering to receive does not bring them forward. Until then they can be [registered for receiving only](/guides/fr-pa-registration#registering-without-e-reporting).
+  </Accordion>
+
   <Accordion title="What's the difference between e-invoicing and e-reporting?">
     **E-invoicing** transmits the invoice itself between trading parties via Peppol, with the PPF receiving the regulated dataset as a fifth corner. **E-reporting** is a periodic submission to the PPF covering transactions out of scope for e-invoicing — B2C, cross-border B2B, and any flow where the counterparty is not in the Annuaire.
   </Accordion>

--- a/snippets/faqs/fr/leaves/pa/supplier.mdx
+++ b/snippets/faqs/fr/leaves/pa/supplier.mdx
@@ -2,6 +2,10 @@
     Run the France PA Register Party workflow with the supplier's SIREN. Invopop publishes them to the Annuaire and the Peppol SMP — they are then routable for both invoicing and e-reporting through Invopop.
   </Accordion>
 
+  <Accordion title="Can I register a supplier to receive invoices without enabling e-reporting?">
+    Yes. Copy the PPF register supplier template and remove the **Register party for reporting** step. The party gets its Annuaire line and Peppol inbox and can receive invoices, but no reporting cadence starts. When its obligations begin, run the removed step against the party to complete the registration. See [Registering without e-reporting](/guides/fr-pa-registration#registering-without-e-reporting).
+  </Accordion>
+
   <Accordion title="What certificates does France PA require to authenticate a supplier?">
     None at the supplier level. The Plateforme Agréée holds an OpenPeppol-issued mTLS certificate (Invopop's), and the PA-to-PPF channel uses additional DGFiP credentials managed by Invopop.
   </Accordion>


### PR DESCRIPTION
Fixes APP-710

French mandate obligations kick in separately: all businesses must be registered in the Annuaire to receive e-invoices from 1 Sep 2026, but SMEs and micro-businesses don't have to issue e-invoices or e-report until 1 Sep 2027. Many platform tenants therefore only need an Annuaire line and a Peppol inbox at first — the default register template signs them up for reporting too.

Prompted by [Pylon #5624](https://app.usepylon.com/issues?issueNumber=5624), where support promised docs instructions for selective registration.

## Changes

- **guides/fr-pa-registration.mdx** — new "Registering without e-reporting" section: copy the PPF register supplier template, delete the `gov-fr.reporting.register` step, and run the reporting step later against the party when its obligations begin. Plus a pointer from the intro paragraph.
- **guides/fr-pa.mdx** — cross-link from the timeline table to the new section.
- **snippets/faqs/fr/leaves/pa/compliance.mdx** — FAQ: SMEs must register to receive by Sep 2026, but registering doesn't bring issuing/e-reporting obligations forward.
- **snippets/faqs/fr/leaves/pa/supplier.mdx** — FAQ: how to register a supplier without enabling e-reporting.

## Notes for review

- The claim that the signed agreement/mandate is identical for receive-only and full registrations (so no re-signing when adding reporting later) follows from the workflow structure but please double-check.
- A branching register workflow to handle this natively (per the Pylon thread) is a separate product discussion — not covered here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)