### PR TITLE
Document credit note line matching in the Portugal AT FAQ

### DIFF
--- a/guides/pt-at.mdx
+++ b/guides/pt-at.mdx
@@ -11,6 +11,8 @@ import CancelPayment from '/snippets/workflows/pt/at-cancel-payment.mdx';
 import IssueDelivery from '/snippets/workflows/pt/at-issue-delivery.mdx';
 import CancelDelivery from '/snippets/workflows/pt/at-cancel-delivery.mdx';
 import DocumentAccordion from '/snippets/documents/pt/accordion.mdx';
+import ATCreditNoteMin from '/snippets/invoices/pt/at-creditnote.min.mdx';
+import ATCreditNote from '/snippets/invoices/pt/at-creditnote.mdx';
 import PortugalResources from '/snippets/tables/portugal-resources.mdx';
 import FAQ from '/snippets/faqs/pt/composers/guide-at-invoicing.mdx';
 import { WorkflowDiagram } from '/snippets/components/workflow.jsx';
@@ -192,6 +194,38 @@ The following examples show partial [GOBL](https://docs.gobl.org) documents you 
 </Note>
 
 <DocumentAccordion />
+
+### Credit notes
+
+To rectify an invoice that has already been issued, send a credit note: an invoice document with `type` set to `credit-note` whose `preceding` array references the invoice being credited. Credit notes run through the same invoice processing workflow as regular invoices and are issued under a series with the `NC ` prefix.
+
+<CodeGroup>
+  <ATCreditNoteMin />
+  <ATCreditNote />
+</CodeGroup>
+
+#### The preceding reference
+
+- A credit note supports exactly **one** preceding reference, identifying the credited invoice by `series` and `code`.
+- If the referenced invoice was issued through Invopop, it must exist, must not be canceled, and — when the reference includes an `issue_date` — the date must match the recorded one. Each credit note line is then validated against the amounts still available to credit on the invoice, as described below.
+- If the referenced series is not managed through Invopop (for example, the invoice was issued by a previous provider), the reference is accepted as external and no line matching is performed.
+
+#### How credit note lines are matched
+
+Invopop keeps track of the quantity and price still available to credit on every line of every issued invoice. Each credit note line must be matched to one of those lines, following these rules:
+
+1. The credit note line's `item.name` must be **exactly identical** to the invoice line's, and both lines must have the same VAT treatment — the same rate and, where applicable, the same exemption extension.
+2. Among the lines that match by name and VAT, the credit note line must satisfy one of:
+   - **Same unit price** as the invoice line, with a quantity up to the remaining quantity — use this to credit fewer units at the original price.
+   - **Same quantity** as the invoice line, with a unit price up to the remaining price — use this to credit part of the amount for the full quantity.
+
+Some practical consequences of these rules:
+
+- Include **only the lines you are crediting** — the credit note does not need to mirror the full invoice.
+- The order of the lines is irrelevant; each credit note line is matched independently.
+- Availability is cumulative across credit notes: every accepted credit note reduces the remaining quantity or price on the invoice's lines, so the total credited per line can never exceed the original invoice amount.
+
+If a line cannot be matched, the workflow fails with the error `The credit note line #N cannot be applied to any line available to credit`. This means either that no invoice line matches the credit note line's item name and VAT treatment (check for typos or differences in the name, rate, or exemption), or that the matching lines don't have enough quantity or amount left to credit (check previously issued credit notes against the same invoice).
 
 ### Cancel a document
 

--- a/guides/pt-at.mdx
+++ b/guides/pt-at.mdx
@@ -11,8 +11,6 @@ import CancelPayment from '/snippets/workflows/pt/at-cancel-payment.mdx';
 import IssueDelivery from '/snippets/workflows/pt/at-issue-delivery.mdx';
 import CancelDelivery from '/snippets/workflows/pt/at-cancel-delivery.mdx';
 import DocumentAccordion from '/snippets/documents/pt/accordion.mdx';
-import ATCreditNoteMin from '/snippets/invoices/pt/at-creditnote.min.mdx';
-import ATCreditNote from '/snippets/invoices/pt/at-creditnote.mdx';
 import PortugalResources from '/snippets/tables/portugal-resources.mdx';
 import FAQ from '/snippets/faqs/pt/composers/guide-at-invoicing.mdx';
 import { WorkflowDiagram } from '/snippets/components/workflow.jsx';
@@ -194,38 +192,6 @@ The following examples show partial [GOBL](https://docs.gobl.org) documents you 
 </Note>
 
 <DocumentAccordion />
-
-### Credit notes
-
-To rectify an invoice that has already been issued, send a credit note: an invoice document with `type` set to `credit-note` whose `preceding` array references the invoice being credited. Credit notes run through the same invoice processing workflow as regular invoices and are issued under a series with the `NC ` prefix.
-
-<CodeGroup>
-  <ATCreditNoteMin />
-  <ATCreditNote />
-</CodeGroup>
-
-#### The preceding reference
-
-- A credit note supports exactly **one** preceding reference, identifying the credited invoice by `series` and `code`.
-- If the referenced invoice was issued through Invopop, it must exist, must not be canceled, and — when the reference includes an `issue_date` — the date must match the recorded one. Each credit note line is then validated against the amounts still available to credit on the invoice, as described below.
-- If the referenced series is not managed through Invopop (for example, the invoice was issued by a previous provider), the reference is accepted as external and no line matching is performed.
-
-#### How credit note lines are matched
-
-Invopop keeps track of the quantity and price still available to credit on every line of every issued invoice. Each credit note line must be matched to one of those lines, following these rules:
-
-1. The credit note line's `item.name` must be **exactly identical** to the invoice line's, and both lines must have the same VAT treatment — the same rate and, where applicable, the same exemption extension.
-2. Among the lines that match by name and VAT, the credit note line must satisfy one of:
-   - **Same unit price** as the invoice line, with a quantity up to the remaining quantity — use this to credit fewer units at the original price.
-   - **Same quantity** as the invoice line, with a unit price up to the remaining price — use this to credit part of the amount for the full quantity.
-
-Some practical consequences of these rules:
-
-- Include **only the lines you are crediting** — the credit note does not need to mirror the full invoice.
-- The order of the lines is irrelevant; each credit note line is matched independently.
-- Availability is cumulative across credit notes: every accepted credit note reduces the remaining quantity or price on the invoice's lines, so the total credited per line can never exceed the original invoice amount.
-
-If a line cannot be matched, the workflow fails with the error `The credit note line #N cannot be applied to any line available to credit`. This means either that no invoice line matches the credit note line's item name and VAT treatment (check for typos or differences in the name, rate, or exemption), or that the matching lines don't have enough quantity or amount left to credit (check previously issued credit notes against the same invoice).
 
 ### Cancel a document
 

--- a/snippets/faqs/pt/leaves/at/invoicing.mdx
+++ b/snippets/faqs/pt/leaves/at/invoicing.mdx
@@ -27,6 +27,23 @@
     Adjust your GOBL customer block (or equivalent) accordingly and re-run the workflow.
   </Accordion>
 
+  <Accordion title="Why does my credit note fail with 'The credit note line #N cannot be applied to any line available to credit'?">
+    **What it means:** when a credit note references an invoice issued through Invopop, every credit note line must be matched against the quantity and price still available to credit on the original invoice's lines. Line `#N` could not be matched to any of them.
+
+    For a credit note line to be applied to an invoice line:
+
+    1. Its `item.name` must be **exactly identical** to the invoice line's, and both lines must have the same VAT treatment — the same rate and, where applicable, the same exemption.
+    2. Among the lines matching by name and VAT, it must satisfy one of:
+       - **Same unit price** as the invoice line, with a quantity up to the remaining quantity — to credit fewer units at the original price.
+       - **Same quantity** as the invoice line, with a unit price up to the remaining price — to credit part of the amount for the full quantity.
+
+    Include only the lines you are crediting — the credit note does not need to mirror the full invoice — and the order of the lines is irrelevant. Availability is cumulative: every accepted credit note reduces the remaining quantity or price, so the total credited per line can never exceed the original invoice amount.
+
+    **What to do:** check that line `#N`'s item name and VAT rate or exemption exactly match a line on the referenced invoice (watch for typos or renamed items), and that it keeps either the original unit price or the original quantity as described above. If everything matches, review credit notes previously issued against the same invoice — the remaining quantity or amount may already have been credited.
+
+    Note that a credit note supports exactly **one** `preceding` reference, and line matching only applies when the referenced invoice was issued through Invopop — references to external series (for example, invoices issued by a previous provider) are accepted without matching.
+  </Accordion>
+
   <Accordion title="Why does my payment workflow fail with 'payment type RG is not supported for real-time reporting'?">
     This error means your workflow includes the **Send to the AT** step for a payment receipt. Payment receipts are not supported for real-time reporting — the AT does not accept them via the real-time webservice.
 


### PR DESCRIPTION
## What changed

Adds one FAQ accordion to the AT invoicing leaf (`snippets/faqs/pt/leaves/at/invoicing.mdx`): **"Why does my credit note fail with 'The credit note line #N cannot be applied to any line available to credit'?"**, following the leaf's existing error-driven "What it means / What to do" style. Via the existing composers it surfaces on the [issuing guide](https://docs.invopop.com/guides/pt-at)'s FAQ section, the [AT Portugal app page](https://docs.invopop.com/apps/at-portugal), and [/faq/portugal](https://docs.invopop.com/faq/portugal).

It explains:

- Each credit note line is matched against the quantity/price still available to credit on the referenced invoice's lines: exact item name + same VAT treatment, then either same unit price with quantity ≤ remaining, or same quantity with price ≤ remaining.
- Only the credited lines are needed (no need to mirror the invoice), line order is irrelevant, and availability is cumulative across credit notes.
- What to check when the error appears, plus the preceding-reference constraints (one reference only; external series skip matching).

## Why

The matching logic in at-pt (`internal/domain/models/avail_to_credit.go`) was undocumented, and customers hit the error without any way to learn the rules.

## Notes for reviewers

- All rules were verified against the at-pt source (`avail_to_credit.go`, `seals.go`) rather than written from memory.
- No other PT FAQ touches credit notes, so there's no overlap. No composer or `docs.json` changes needed.
- An earlier revision added this as a guide section; it was moved to the FAQ as a better fit (the second commit reverts the guide).

🤖 Generated with [Claude Code](https://claude.com/claude-code)