### PR TITLE
Reflect Finland production availability in the guides

### DIFF
--- a/apps/finland.mdx
+++ b/apps/finland.mdx
@@ -71,8 +71,6 @@ import FAQ from '/snippets/faqs/fi/composers/app-finvoice.mdx';
 
 	<Tab title="Limitations">
 
-		<Note>Production access is still being finalised with the operator, so the app currently runs against the operator's sandbox. The guides' sandbox and live tables reflect this.</Note>
-
 		| Capability | Status | Notes |
 		|---|---|---|
 		| Party registration | <Badge color="green">Available</Badge> | Provisions a per-party operator account |

--- a/guides/fi-finvoice-receiving.mdx
+++ b/guides/fi-finvoice-receiving.mdx
@@ -22,8 +22,8 @@ Registering the parties themselves is covered in the companion guide: [Finvoice 
 
 | - | Sandbox | Live |
 |---|---|---|
-| **Party** | Registered against the operator's test environment | Not yet available (production access is being finalised with the operator) |
-| **Environment** | Operator sandbox | Not yet available |
+| **Party** | Registered against the operator's test environment | Registered against the live operator network |
+| **Environment** | Operator sandbox | Operator production |
 
 ## Prerequisites
 

--- a/guides/fi-finvoice-supplier.mdx
+++ b/guides/fi-finvoice-supplier.mdx
@@ -21,8 +21,8 @@ Once a supplier is registered, continue with the companion guide: [Finvoice issu
 
 | - | Sandbox | Live |
 |---|---|---|
-| **Party** | Registered against the operator's test environment | Not yet available (production access is being finalised with the operator) |
-| **Environment** | Operator sandbox | Not yet available |
+| **Party** | Registered against the operator's test environment | Registered against the live operator network |
+| **Environment** | Operator sandbox | Operator production |
 
 ## Prerequisites
 

--- a/guides/fi-finvoice.mdx
+++ b/guides/fi-finvoice.mdx
@@ -21,8 +21,8 @@ For onboarding suppliers, see the companion guide: [Finvoice supplier registrati
 
 | - | Sandbox | Live |
 |---|---|---|
-| **Supplier** | Party registered against the operator's test environment | Not yet available (production access is being finalised with the operator) |
-| **Environment** | Operator sandbox | Not yet available |
+| **Supplier** | Party registered against the operator's test environment | Registered party required |
+| **Environment** | Operator sandbox | Operator production |
 
 ## Payment data is mandatory
 


### PR DESCRIPTION
## Context

Production access for the Finland app is set up, but the pages that merged this morning still said it was being finalised — the announcement to our first production user is going out today, so the published docs shouldn't contradict it.

## Changes

- The three `fi-finvoice` guides' sandbox/live tables now describe the live environment instead of "Not yet available".
- The Limitations tab's sandbox-only note is removed from `apps/finland.mdx`.