### PR TITLE
Clarify that real-time AT reporting replaces manual SAF-T submission

### DIFF
--- a/guides/pt-at.mdx
+++ b/guides/pt-at.mdx
@@ -267,6 +267,8 @@ The workflow templates provided in this guide enable both reporting mechanisms.
 
 The **Send document to AT** step uses the AT's webservice to submit each document to the tax authority immediately after it is recorded.
 
+Documents submitted by this step are already communicated to the AT, so the supplier does not need to include them in a monthly SAF-T PT submission — real-time reporting replaces the manual monthly upload for those documents. A manual SAF-T PT submission is only needed for documents that are not reported in real time, either because the workflow omits this step or because the AT's webservice does not accept the document type (for example, RG payment receipts).
+
 This step is optional. If you prefer to report documents only via SAF-T PT reports, you can remove it from your workflows.
 
 <Info>
@@ -276,6 +278,8 @@ This step is optional. If you prefer to report documents only via SAF-T PT repor
 #### SAF-T PT reporting
 
 SAF-T PT reports allow you to submit documents to the AT in batch format. The **Record document for SAF-T** step takes care of recording the documents for this purpose.
+
+Suppliers only need to submit monthly SAF-T PT reports for documents that were not reported in real time. If every document a supplier issues goes through the **Send document to AT** step, no manual monthly submission is required.
 
 <Info>
   The **Record document for SAF-T** step is required in all workflows, regardless of whether you also use real-time reporting. The AT may request SAF-T PT reports for audit purposes at any time, so all documents must be properly recorded.

--- a/snippets/faqs/pt/leaves/at/invoicing.mdx
+++ b/snippets/faqs/pt/leaves/at/invoicing.mdx
@@ -5,6 +5,8 @@
     2. **Real-time transmission** – instead of a monthly file, each invoice is sent individually to the AT at the time of issuance, using the authority's API.
 
     Whether one model or the other is used usually depends on the issuer's accountant's preference (who typically uploads the SAF-T monthly report should they choose that model). Invopop's [AT Portugal app](/apps/at-portugal) supports both reporting methods, so each supplier can pick the one that best fits their needs.
+
+    If a supplier uses real-time transmission — the **Send document to AT** step in the workflow — the documents submitted this way are already communicated to the AT, so they don't need to upload a monthly SAF-T file for them. The only documents that still require the monthly SAF-T upload are those not reported in real time, such as RG payment receipts, which the AT's webservice does not accept.
   </Accordion>
 
   <Accordion title="How do I configure my workspace for Portuguese invoicing?">


### PR DESCRIPTION
## What changed

Clarifies a recurring customer question in the Portugal AT docs: **if a supplier uses the "Send document to AT" step, do they still need to upload the monthly SAF-T PT file manually?** The answer is no — documents submitted in real time via the AT webservice are already communicated, so the manual monthly upload is only needed for documents not reported in real time (e.g. RG payment receipts, which the webservice does not accept).

- `guides/pt-at.mdx` — the "Real-time reporting" section now states this explicitly, and the "SAF-T PT reporting" section gets the mirror statement (monthly submission only for documents not sent in real time).
- `snippets/faqs/pt/leaves/at/invoicing.mdx` — extended the existing "Should our customers upload their SAF-T files manually?" accordion to answer the question directly. This FAQ renders on the AT invoicing guide, the AT Portugal app page, and the Portugal FAQ page.

## Notes for reviewers

- The existing guidance is unchanged: the **Record document for SAF-T** step remains mandatory in all workflows for audit purposes, and RG receipts remain SAF-T-only, consistent with the existing FAQ about the "payment type RG is not supported for real-time reporting" error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)