### PR TITLE
Correct stale availability claims for Finland and France

### DIFF
--- a/apps/finland.mdx
+++ b/apps/finland.mdx
@@ -71,8 +71,6 @@ import FAQ from '/snippets/faqs/fi/composers/app-finvoice.mdx';
 
 	<Tab title="Limitations">
 
-		<Note>Production access is still being finalised with the operator, so the app currently runs against the operator's sandbox. The guides' sandbox and live tables reflect this.</Note>
-
 		| Capability | Status | Notes |
 		|---|---|---|
 		| Party registration | <Badge color="green">Available</Badge> | Provisions a per-party operator account |

--- a/apps/france.mdx
+++ b/apps/france.mdx
@@ -69,7 +69,7 @@ import FAQ from '/snippets/faqs/fr/composers/app-pa.mdx';
 		| Send invoices (UBL, CII, Factur-X) | <Badge color="green">Available</Badge> | API may change before Sept 2026 |
 		| Receive invoices | <Badge color="green">Available</Badge> | API may change before Sept 2026 |
 		| Lifecycle status (CDAR) | <Badge color="blue">Beta</Badge> | Moving to a first-class GOBL document |
-		| E-reporting (Flow 10) | <Badge color="yellow">In development</Badge> | `fr-ctc-flow10-v1` add-on not yet released |
+		| E-reporting (Flow 10) | <Badge color="yellow">In development</Badge> | [`fr-ctc-flow10-v1`](https://docs.gobl.org/addons/fr-ctc-flow10-v1) add-on released; the flow itself is not available yet |
 
 	</Tab>
 

--- a/compliance/france.mdx
+++ b/compliance/france.mdx
@@ -144,7 +144,7 @@ See the [PA reporting guide](/guides/fr-pa-reporting) for the registration, reco
   <Accordion title="PPF (Portail Public de Facturation)">
     |                     |                                               |
     |---------------------|-----------------------------------------------|
-    | **Format**          | GOBL with the `fr-ctc-flow10-v1` add-on (under development) |
+    | **Format**          | GOBL with the [`fr-ctc-flow10-v1`](https://docs.gobl.org/addons/fr-ctc-flow10-v1) add-on |
     | **Cadence**         | Determined by VAT regime — ten-day, monthly, or bimonthly |
     | **Scope & deadline**| 1 Sept 2026 for large and medium-sized companies, 1 Sept 2027 for all businesses |
     | **Invopop support** | In development — see [reporting guide](/guides/fr-pa-reporting) |

--- a/guides/fi-finvoice-receiving.mdx
+++ b/guides/fi-finvoice-receiving.mdx
@@ -22,8 +22,8 @@ Registering the parties themselves is covered in the companion guide: [Finvoice 
 
 | - | Sandbox | Live |
 |---|---|---|
-| **Party** | Registered against the operator's test environment | Not yet available (production access is being finalised with the operator) |
-| **Environment** | Operator sandbox | Not yet available |
+| **Party** | Registered against the operator's test environment | Registered against the live operator network |
+| **Environment** | Operator sandbox | Operator production |
 
 ## Prerequisites
 

--- a/guides/fi-finvoice-supplier.mdx
+++ b/guides/fi-finvoice-supplier.mdx
@@ -15,12 +15,12 @@ import { fiFinvoiceRegisterWorkflow } from '/snippets/workflows/fi/finvoice-regi
 
 In Finland, e-invoices travel through accredited operators without government clearance. The [Finland app](/apps/finland)'s registration provisions each of your Finnish parties its **own** account with Invopop's operator partner, activates its services, and allocates its e-invoice address.
 
-A party must be registered before it can send or receive doucments. A workspace can hold several Finnish parties, each registered and polled on its own.
+A party must be registered before it can send or receive documents. A workspace can hold several Finnish parties, each registered and polled on its own.
 
 | - | Sandbox | Live |
 |---|---|---|
-| **Party** | <Badge color="green">Available</Badge><br /> Registered against the operator's test environment | <Badge color="yellow">Coming soon</Badge><br /> Production access is being finalised with the operator |
-| **Environment** | Operator sandbox | Live operator envoironment |
+| **Party** | <Badge color="green">Available</Badge><br /> Registered against the operator's test environment | <Badge color="green">Available</Badge><br /> Registered against the live operator network |
+| **Environment** | Operator sandbox | Live operator environment |
 
 ## Prerequisites
 

--- a/guides/fi-finvoice.mdx
+++ b/guides/fi-finvoice.mdx
@@ -21,8 +21,8 @@ For onboarding suppliers, see the companion guide: [Finvoice supplier registrati
 
 | - | Sandbox | Live |
 |---|---|---|
-| **Supplier** | Party registered against the operator's test environment | Not yet available (production access is being finalised with the operator) |
-| **Environment** | Operator sandbox | Not yet available |
+| **Supplier** | Party registered against the operator's test environment | Registered party required |
+| **Environment** | Operator sandbox | Operator production |
 
 ## Payment data is mandatory
 


### PR DESCRIPTION
## Context

Each country's compliance page and guide states what Invopop supports today, and customers plan their integrations against those tables. Some of those statements went stale as apps shipped.

Finland's three guides list production as unavailable and the app page carries a matching note about running against the operator's sandbox; production is live. 

While fixing that, we detected that France's app page lists the `fr-ctc-flow10-v1` add-on as unreleased, and its compliance page calls the same add-on "under development" two rows below a link to the add-on's published page; the add-on is released.

## Changes

- **Replaces the Finland guides' live columns with the production environment.** One sandbox/live table in each of the three `fi-finvoice` guides.
- **Removes the sandbox-only note** from the Limitations tab on `apps/finland.mdx`.
- **Points France's Flow 10 rows at the published add-on.** `fr-ctc-flow10-v1` ships in the `gobl.dev` bundle and is documented on docs.gobl.org. The capability itself stays `In development`.

## Verification

Open the three Finland guides and the France app and compliance pages in the preview build. `mint broken-links` passes.