### PR TITLE
Document silo entry versions

### DIFF
--- a/api-ref/silo/entries/fetch-entry-version.mdx
+++ b/api-ref/silo/entries/fetch-entry-version.mdx
@@ -1,0 +1,8 @@
+---
+title: "Fetch an entry version"
+sidebarTitle: "Fetch entry version"
+description: "Retrieve the GOBL envelope data stored for a specific version of a Silo entry."
+openapi: "GET /silo/v1/entries/{id}/versions/{version}"
+---
+
+Use the `version` value returned in an entry's `version` or `versions` fields to retrieve that exact historical envelope. The response contains only the requested version identifier and its GOBL envelope data; other entry metadata remains available from the standard [fetch entry](/api-ref/silo/entries/fetch-an-entry) endpoint.

--- a/docs.json
+++ b/docs.json
@@ -589,6 +589,7 @@
 									"api-ref/silo/entries/fetch-all-entries",
 									"api-ref/silo/entries/search-entries",
 									"api-ref/silo/entries/fetch-an-entry",
+									"api-ref/silo/entries/fetch-entry-version",
 									"api-ref/silo/entries/fetch-an-entry-by-key",
 									"api-ref/silo/entries/create-an-entry-put",
 									"api-ref/silo/entries/create-an-entry-post",

--- a/openapi/silo_v1.yaml
+++ b/openapi/silo_v1.yaml
@@ -587,6 +587,35 @@ paths:
               schema:
                 $ref: '#/components/schemas/SiloEntryCollection'
           description: OK
+  /silo/v1/entries/{id}/versions/{version}:
+    get:
+      description: Fetch a specific version of a silo entry's envelope data.
+      parameters:
+      - description: UUID of the silo entry to fetch.
+        in: path
+        name: id
+        required: true
+        schema:
+          description: UUID of the silo entry to fetch.
+          example: 347c5b04-cde2-11ed-afa1-0242ac120002
+          title: ID
+          type: string
+      - description: Version of the envelope data to fetch.
+        in: path
+        name: version
+        required: true
+        schema:
+          description: Version of the envelope data to fetch.
+          example: 76f845c125
+          title: Version
+          type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SiloEntryData'
+          description: OK
   /silo/v1/entries/key/{key}:
     get:
       description: Fetch an existing silo entry by its key.
@@ -922,6 +951,36 @@ components:
       required:
       - key
       type: object
+    SiloDataVersion:
+      properties:
+        at:
+          description: Timestamp when this version was created.
+          example: "2018-01-01T00:00:00.000Z"
+          title: At
+          type: string
+        invalid:
+          description: When true, this version's envelope is invalid.
+          title: Invalid
+          type: boolean
+        signed:
+          description: When true, this version's envelope is signed.
+          title: Signed
+          type: boolean
+        src:
+          description: Service or source that created this version.
+          example: api
+          title: Source
+          type: string
+        src_id:
+          description: Identifier of the source object that created this version.
+          title: Source ID
+          type: string
+        version:
+          description: Content-derived identifier for this envelope version.
+          example: 76f845c125
+          title: Version
+          type: string
+      type: object
     SiloEntry:
       properties:
         attachments:
@@ -1023,6 +1082,17 @@ components:
           example: "2018-01-01T00:00:00.000Z"
           title: Updated At
           type: string
+        version:
+          description: Version of the latest envelope data.
+          example: 76f845c125
+          title: Version
+          type: string
+        versions:
+          description: Available envelope data versions, newest first.
+          items:
+            $ref: '#/components/schemas/SiloDataVersion'
+          title: Versions
+          type: array
       type: object
     SiloEntryCollection:
       properties:
@@ -1058,6 +1128,19 @@ components:
         next_cursor:
           description: Cursor used to identify the next page of results.
           title: Next Cursor
+          type: string
+      type: object
+    SiloEntryData:
+      properties:
+        data:
+          description: JSON envelope contents for the requested version.
+          nullable: true
+          title: Data
+          type: object
+        version:
+          description: Version of the returned envelope data.
+          example: 76f845c125
+          title: Version
           type: string
       type: object
     SiloEntrySearchCollection:


### PR DESCRIPTION
## Summary

- document the endpoint for fetching a specific Silo entry data version
- expose current and available version metadata in the Silo entry OpenAPI schema
- add the new operation page to the API reference navigation

Related API change: invopop/api#120.
Related Go client change: invopop/client.go#68.

## Validation

- parsed `openapi/silo_v1.yaml` and confirmed the new operation and schemas
- parsed `docs.json` and confirmed the navigation entry
- `git diff --check`

Mintlify validation could not run locally because the installed CLI does not support Node 25 and requires an LTS Node version.