### PR TITLE
Add France PA pop-cost FAQs

### DIFF
--- a/snippets/faqs/fr/leaves/pa/invoicing.mdx
+++ b/snippets/faqs/fr/leaves/pa/invoicing.mdx
@@ -9,3 +9,7 @@
   <Accordion title="Is a self-billed invoice a different document type in France?">
     No. Most Peppol countries treat self-billing as a document type of its own, but France models it as a **standard invoice** with the `untdid-document-type` extension set to `389`. In GOBL you never set the code yourself: add the `self-billed` tag and the [`fr-ctc-flow2-v1`](https://docs.gobl.org/addons/fr-ctc-flow2-v1#standard-self-billed) add-on applies it automatically. See [Self-billing](/guides/fr-pa-invoicing#self-billing) for the full flow.
   </Accordion>
+
+  <Accordion title="How many pops does a France B2B e-invoice cost?">
+    Each invoice or lifecycle status sent through France PA costs **5 pops**: 1 pop for the conversion to UBL/CII, 2 pops to send it over Peppol, 1 pop to forward it to the PPF, and 1 pop for the silo entry. See [Pops & pricing](/get-started/pricing) for how pops work.
+  </Accordion>

--- a/snippets/faqs/fr/leaves/pa/invoicing.mdx
+++ b/snippets/faqs/fr/leaves/pa/invoicing.mdx
@@ -10,6 +10,6 @@
     No. Most Peppol countries treat self-billing as a document type of its own, but France models it as a **standard invoice** with the `untdid-document-type` extension set to `389`. In GOBL you never set the code yourself: add the `self-billed` tag and the [`fr-ctc-flow2-v1`](https://docs.gobl.org/addons/fr-ctc-flow2-v1#standard-self-billed) add-on applies it automatically. See [Self-billing](/guides/fr-pa-invoicing#self-billing) for the full flow.
   </Accordion>
 
-  <Accordion title="How many pops does a France B2B e-invoice cost?">
+  <Accordion title="How many pops does a B2B e-invoice through France PA cost?">
     Each invoice or lifecycle status sent through France PA costs **5 pops**: 1 pop for the conversion to UBL/CII, 2 pops to send it over Peppol, 1 pop to forward it to the PPF, and 1 pop for the silo entry. See [Pops & pricing](/get-started/pricing) for how pops work.
   </Accordion>

--- a/snippets/faqs/fr/leaves/pa/reporting.mdx
+++ b/snippets/faqs/fr/leaves/pa/reporting.mdx
@@ -6,6 +6,6 @@
     Flow 10 uses a JSON envelope wrapping aggregated transaction data, defined in the PPF technical specification. Lifecycle CDAR payloads are XML messages exchanged over Peppol with structured status codes.
   </Accordion>
 
-  <Accordion title="How many pops does France e-reporting cost?">
-    Recording a transaction for e-reporting (B2C or international B2B) costs **2 pops** per invoice: 1 pop to record it and 1 pop for the silo entry. On top of that, each report submitted costs **10 pops** per reporting cadence. See [Pops & pricing](/get-started/pricing) for how pops work.
+  <Accordion title="How many pops does e-reporting in France cost?">
+    Recording a transaction for e-reporting (B2C or international B2B) costs **2 pops** per invoice: 1 pop to record it and 1 pop for the silo entry. On top of that, each report submission costs **10 pops**. See [Pops & pricing](/get-started/pricing) for how pops work.
   </Accordion>

--- a/snippets/faqs/fr/leaves/pa/reporting.mdx
+++ b/snippets/faqs/fr/leaves/pa/reporting.mdx
@@ -5,3 +5,7 @@
   <Accordion title="What format does France PA expect for periodic reports?">
     Flow 10 uses a JSON envelope wrapping aggregated transaction data, defined in the PPF technical specification. Lifecycle CDAR payloads are XML messages exchanged over Peppol with structured status codes.
   </Accordion>
+
+  <Accordion title="How many pops does France e-reporting cost?">
+    Recording a transaction for e-reporting (B2C or international B2B) costs **2 pops** per invoice: 1 pop to record it and 1 pop for the silo entry. On top of that, each report submitted costs **10 pops** per reporting cadence. See [Pops & pricing](/get-started/pricing) for how pops work.
+  </Accordion>

--- a/snippets/faqs/fr/leaves/pa/supplier.mdx
+++ b/snippets/faqs/fr/leaves/pa/supplier.mdx
@@ -12,5 +12,5 @@
     - **E-invoicing (B2B)** — **150 pops** per merchant: 50 pops for the French directory (Annuaire) registration plus 100 pops for Peppol.
     - **E-reporting only (B2C or international B2B)** — **50 pops** per merchant to register the party for reporting.
 
-    Each registered merchant counts as a Seat: the pops are deducted on registration and again every 30 days for as long as the merchant stays registered — see [Pops & pricing](/get-started/pricing) for how seats are billed.
+    Each registered merchant counts as a seat: the same seat pops are deducted on registration and again every 30 days for as long as the merchant stays registered — see [Pops & pricing](/get-started/pricing) for how seats are billed.
   </Accordion>

--- a/snippets/faqs/fr/leaves/pa/supplier.mdx
+++ b/snippets/faqs/fr/leaves/pa/supplier.mdx
@@ -12,5 +12,5 @@
     - **E-invoicing (B2B)** — **150 pops** per merchant: 50 pops for the French directory (Annuaire) registration plus 100 pops for Peppol.
     - **E-reporting only (B2C or international B2B)** — **50 pops** per merchant to register the party for reporting.
 
-    Each registered merchant counts as a Seat — see [Pops & pricing](/get-started/pricing) for how seats are billed.
+    Each registered merchant counts as a Seat: the pops are deducted on registration and again every 30 days for as long as the merchant stays registered — see [Pops & pricing](/get-started/pricing) for how seats are billed.
   </Accordion>

--- a/snippets/faqs/fr/leaves/pa/supplier.mdx
+++ b/snippets/faqs/fr/leaves/pa/supplier.mdx
@@ -5,3 +5,12 @@
   <Accordion title="What certificates does France PA require to authenticate a supplier?">
     None at the supplier level. The Plateforme Agréée holds an OpenPeppol-issued mTLS certificate (Invopop's), and the PA-to-PPF channel uses additional DGFiP credentials managed by Invopop.
   </Accordion>
+
+  <Accordion title="How many pops does registering a merchant (seat) for France cost?">
+    It depends on the flows the merchant uses:
+
+    - **E-invoicing (B2B)** — **150 pops** per merchant: 50 pops for the French directory (Annuaire) registration plus 100 pops for Peppol.
+    - **E-reporting only (B2C or international B2B)** — **50 pops** per merchant to register the party for reporting.
+
+    Each registered merchant counts as a Seat — see [Pops & pricing](/get-started/pricing) for how seats are billed.
+  </Accordion>


### PR DESCRIPTION
## What changed

Adds three FAQ accordions explaining pop costs for France, appended to the existing France PA leaves under `snippets/faqs/fr/leaves/pa/`:

- **invoicing.mdx** — 5 pops per B2B e-invoice or lifecycle status sent (1 UBL/CII conversion + 2 Peppol send + 1 PPF forward + 1 silo entry).
- **supplier.mdx** — 150 pops per e-invoicing merchant seat (50 Annuaire directory + 100 Peppol); 50 pops for e-reporting-only merchants. Seat pops are deducted on registration and again every 30 days while the merchant stays registered.
- **reporting.mdx** — 2 pops per e-reported invoice (1 record + 1 silo entry) plus 10 pops per report per cadence.

Each answer links to the Pops & pricing page for the general pop model.

## Why

Customers evaluating France PA need to know what the flows consume in pops. This surfaces the costs on the France FAQ page, the France app page, and the PA guides.

## Notes for reviewers

- No composer or navigation changes — these leaves are already imported by `page-faq`, `app-pa`, and the `guide-pa-*` composers, so the new accordions appear everywhere automatically. The FAQ skill's broken-import check passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)