### PR TITLE
Document explicit migration-key registration for Peppol

### DIFF
--- a/compliance/glossary.mdx
+++ b/compliance/glossary.mdx
@@ -49,12 +49,6 @@ This section clarifies terms as they are defined or used in relevant laws and of
 | **Validation Error** | Issue identified during document structure or content verification |
 | **White-label** | Service offered under another company's brand |
 
-## Belgium
-
-|  |  |
-|------|------------|
-| **BOSA** | Belgian Peppol Authority, the organization managing Peppol registration in Belgium |
-
 ## Brazil
 
 |  |  |

--- a/guides/peppol.mdx
+++ b/guides/peppol.mdx
@@ -256,6 +256,37 @@ If you need to unregister an entity (because the supplier is no longer your clie
   </Tab>
 </Tabs>
 
+#### Migrating a participant from another provider
+
+If a party is already registered with another Peppol Access Point — a national authority like BOSA in Belgium, or a different commercial provider — you don't need to unregister it there first. Peppol supports migrating an existing participant to a new provider using a **migration key** issued by their current one.
+
+To migrate a participant into Invopop:
+
+1. Request a migration key for the participant from their current Peppol provider. This step happens outside Invopop — each provider has its own process for issuing migration keys.
+2. Pass the key as a `peppol-migration-key` argument when running the **Register party on Peppol** step, using the [Create a Job](/api-ref/transform/jobs/create-a-job-post) endpoint:
+
+```json
+{
+  "workflow_id": "your-workflow-uuid",
+  "silo_entry_id": "your-silo-entry-uuid",
+  "args": {
+    "peppol-migration-key": "the-migration-key-from-the-current-provider"
+  }
+}
+```
+
+The party still needs to go through Invopop's own proof-of-ownership approval before this step, same as a fresh registration — the migration key only determines how the final **Register party on Peppol** step brings the participant onto our Access Point.
+
+When `peppol-migration-key` is provided:
+
+- Invopop uses it to accept the inbound migration on our SMP — there are no eligibility checks of our own, so the key must genuinely have been issued for this participant.
+- If the key is invalid or has expired, the job fails with a `migration key is not valid` error and no registration takes place.
+- If the key is valid, registration proceeds as usual.
+
+<Note>
+Invopop doesn't currently support the reverse direction — generating a migration key so a participant can move away to another provider.
+</Note>
+
 ### Sending invoices
 
 To send an invoice:

--- a/guides/peppol.mdx
+++ b/guides/peppol.mdx
@@ -258,12 +258,14 @@ If you need to unregister an entity (because the supplier is no longer your clie
 
 #### Migrating a participant from another provider
 
-If a party is already registered with another Peppol Access Point — a national authority like BOSA in Belgium, or a different commercial provider — you don't need to unregister it there first. Peppol supports migrating an existing participant to a new provider using a **migration key** issued by their current one.
+If a party is already registered with another Peppol Access Point, you don't need to unregister it there first. Peppol supports migrating an existing participant to a new provider using a **migration key** issued by their current one.
 
 To migrate a participant into Invopop:
 
 1. Request a migration key for the participant from their current Peppol provider. This step happens outside Invopop — each provider has its own process for issuing migration keys.
-2. Pass the key as a `peppol-migration-key` argument when running the **Register party on Peppol** step, using the [Create a Job](/api-ref/transform/jobs/create-a-job-post) endpoint:
+2. Pass the key as a `peppol-migration-key` argument when running the **Register party on Peppol** step:
+   - **From the Console**: run the registration workflow directly from the workflow editor or list (see [Running from the Console](/guides/workflows#running-from-the-console)) and add `peppol-migration-key` in the **Arguments** field of the run panel.
+   - **Via the API**: include it in the `args` map when calling the [Create a Job](/api-ref/transform/jobs/create-a-job-post) endpoint:
 
 ```json
 {

--- a/snippets/faqs/be/leaves/general/compliance.mdx
+++ b/snippets/faqs/be/leaves/general/compliance.mdx
@@ -3,7 +3,7 @@
   </Accordion>
 
   <Accordion title="Who can issue invoices in Belgium?">
-    Any entity with a Belgian KBO/BCE enterprise number (and a VAT number where applicable). Most Belgian companies are pre-registered in Peppol via BOSA — you can bring that registration over with a migration key instead of registering fresh, see [Migrating a participant from another provider](/guides/peppol#migrating-a-participant-from-another-provider).
+    Any entity with a Belgian KBO/BCE enterprise number (and a VAT number where applicable).
   </Accordion>
 
   <Accordion title="What are the legal obligations for receiving invoices in Belgium?">

--- a/snippets/faqs/be/leaves/general/compliance.mdx
+++ b/snippets/faqs/be/leaves/general/compliance.mdx
@@ -3,7 +3,7 @@
   </Accordion>
 
   <Accordion title="Who can issue invoices in Belgium?">
-    Any entity with a Belgian KBO/BCE enterprise number (and a VAT number where applicable). Most Belgian companies are pre-registered in Peppol via BOSA, so onboarding is a migration rather than a fresh registration.
+    Any entity with a Belgian KBO/BCE enterprise number (and a VAT number where applicable). Most Belgian companies are pre-registered in Peppol via BOSA — you can bring that registration over with a migration key instead of registering fresh, see [Migrating a participant from another provider](/guides/peppol#migrating-a-participant-from-another-provider).
   </Accordion>
 
   <Accordion title="What are the legal obligations for receiving invoices in Belgium?">

--- a/snippets/faqs/be/leaves/general/invoicing.mdx
+++ b/snippets/faqs/be/leaves/general/invoicing.mdx
@@ -1,5 +1,5 @@
   <Accordion title="How do I configure my workspace for Belgian invoicing?">
-    Install the Peppol app, register your supplier with BOSA-migrated participant ID, and use a workflow that generates a Peppol BIS Billing 3.0 document and sends it via the Lookup → Send actions.
+    Install the Peppol app, register your supplier with its KBO/BCE-based participant ID (scheme `0208`), and use a workflow that generates a Peppol BIS Billing 3.0 document and sends it via the Lookup → Send actions.
   </Accordion>
     <Accordion title="Do invoices need to be sent to the tax authority?">
     In Belgium specifically there is no need to send a copy to the tax authority until the e-reporting mandate comes into effect in Jan 2028.

--- a/snippets/faqs/be/leaves/general/supplier.mdx
+++ b/snippets/faqs/be/leaves/general/supplier.mdx
@@ -1,6 +1,3 @@
   <Accordion title="How do I onboard a new supplier in Belgium?">
-    Run the Register Participant workflow with the supplier's KBO/BCE number (scheme `0208`). Most Belgian companies are already registered with BOSA — to bring that existing registration over instead of registering fresh, request a migration key from BOSA and pass it as the `peppol-migration-key` job argument on the final registration step. See [Migrating a participant from another provider](/guides/peppol#migrating-a-participant-from-another-provider).
-  </Accordion>
-  <Accordion title="How do I ensure my Peppol participant ID corresponds to BOSA?">
-    In Belgium, all Peppol participants are already registered with BOSA, the Belgian Peppol Authority, so every Belgian company is already technically part of the Peppol network. Onboarding a company into Invopop doesn't migrate that BOSA registration automatically — request a migration key from BOSA and provide it via the `peppol-migration-key` job argument if you want to bring the existing registration over rather than registering fresh.
+    Run the Register Participant workflow with the supplier's KBO/BCE number (scheme `0208`), the same as onboarding a supplier in any other country. If the supplier is already registered with another Peppol provider and you'd rather bring that registration over than register fresh, see [Migrating a participant from another provider](/guides/peppol#migrating-a-participant-from-another-provider).
   </Accordion>

--- a/snippets/faqs/be/leaves/general/supplier.mdx
+++ b/snippets/faqs/be/leaves/general/supplier.mdx
@@ -1,6 +1,6 @@
   <Accordion title="How do I onboard a new supplier in Belgium?">
-    Run the Register Participant workflow with the supplier's KBO/BCE number (scheme `0208`). Invopop migrates the BOSA registration into our Peppol Access Point so we become the supplier's SMP for sending and receiving.
+    Run the Register Participant workflow with the supplier's KBO/BCE number (scheme `0208`). Most Belgian companies are already registered with BOSA — to bring that existing registration over instead of registering fresh, request a migration key from BOSA and pass it as the `peppol-migration-key` job argument on the final registration step. See [Migrating a participant from another provider](/guides/peppol#migrating-a-participant-from-another-provider).
   </Accordion>
   <Accordion title="How do I ensure my Peppol participant ID corresponds to BOSA?">
-    In Belgium, all Peppol participants are already registered with BOSA, the Belgian Peppol Authority. This means that every Belgian company is automatically part of the Peppol network. To onboard these companies in Invopop, we first migrate their registration from BOSA to our system.
+    In Belgium, all Peppol participants are already registered with BOSA, the Belgian Peppol Authority, so every Belgian company is already technically part of the Peppol network. Onboarding a company into Invopop doesn't migrate that BOSA registration automatically — request a migration key from BOSA and provide it via the `peppol-migration-key` job argument if you want to bring the existing registration over rather than registering fresh.
   </Accordion>


### PR DESCRIPTION
## Summary
- Adds a "Migrating a participant from another provider" section to the [Peppol guide](/guides/peppol), explaining the `peppol-migration-key` job argument: how to obtain a migration key from the participant's current provider, how to pass it on the **Register party on Peppol** step via the Create a Job API, and what happens on success/failure (`migration key is not valid`).
- Fixes three Belgium FAQ entries that described the old automatic BOSA→Invopop migration (`snippets/faqs/be/leaves/general/{supplier,compliance,invoicing}.mdx`) — migration is no longer automatic for Belgian companies; it now requires explicitly requesting a migration key from BOSA and passing it as `peppol-migration-key`.

Related: invopop/peppol#87 (drops the automatic Belgian/BOSA migration and adds the explicit `peppol-migration-key` job argument).

## Test plan
- [x] `mint broken-links` — no broken links found