### PR TITLE
Add the Denmark (NemHandel) documentation family

### DIFF
--- a/apps/denmark.mdx
+++ b/apps/denmark.mdx
@@ -1,0 +1,188 @@
+---
+title: "Denmark"
+description: "Send and receive OIOUBL invoices over Denmark's NemHandel network."
+keywords: ['denmark', 'nemhandel', 'oioubl', 'cvr', 'ean', 'gln', 'ecourier', 'dk']
+mode: wide
+---
+
+import SendInvoiceWorkflow from '/snippets/workflows/dk/nemhandel-send-invoice.mdx';
+import RegisterWorkflow from '/snippets/workflows/dk/nemhandel-register.mdx';
+import UnregisterWorkflow from '/snippets/workflows/dk/nemhandel-unregister.mdx';
+import ImportWorkflow from '/snippets/workflows/dk/nemhandel-import.mdx';
+import Supplier from '/snippets/parties/dk/supplier.mdx';
+import Customer from '/snippets/parties/dk/customer.mdx';
+import InvoiceAccordion from '/snippets/invoices/dk/accordion.mdx';
+import DenmarkResources from '/snippets/tables/denmark-resources.mdx';
+import FAQ from '/snippets/faqs/dk/composers/app-nemhandel.mdx';
+
+<Tabs>
+	<Tab title="Description">
+		<Columns cols="2">
+			<div class="flex flex-col grow items-center justify-center">
+				<Card title="Register suppliers" icon="https://assets.invopop.com/flags/dk.svg"
+				  href="/guides/dk-nemhandel-supplier" horizontal>
+				  Supplier registration guide ›
+				</Card>
+				<Card title="Issue invoices" icon="https://assets.invopop.com/flags/dk.svg"
+				  href="/guides/dk-nemhandel" horizontal>
+				  Issuing guide ›
+				</Card>
+				<Card title="Receive invoices" icon="https://assets.invopop.com/flags/dk.svg"
+				  href="/guides/dk-nemhandel-receiving" horizontal>
+				  Receiving guide ›
+				</Card>
+			</div>
+
+				|           |                                        |
+				|-----------|----------------------------------------|
+				| Developer | [Invopop](https://invopop.com)         |
+				| Category  | Government                             |
+				| Scope     | B2B, B2G                               |
+				| System    | NemHandel (Erhvervsstyrelsen)          |
+				| Country   | [Denmark](/compliance/denmark)         |
+		</Columns>
+
+		**NemHandel** is Denmark's national e-invoicing network, run by the Danish Business Authority (*Erhvervsstyrelsen*). Denmark was the first country in Europe to mandate B2G e-invoicing, back in 2005: public authorities only accept electronic invoices, delivered over NemHandel or Peppol, and the Digital Bookkeeping Act now requires nearly every Danish business to be able to send and receive e-invoices as well.
+
+		Documents travel on NemHandel as **OIOUBL 2.1**, Denmark's national UBL dialect. This app owns the full journey in both directions: it converts GOBL invoices and credit notes to OIOUBL, validates them against the official schematron before anything is sent, delivers them over the network, and imports the documents your parties receive back into GOBL.
+
+		Invopop has partnered with [eCourier](https://ecourier.dk), a Danish NemHandel access point, to transmit documents and onboard suppliers onto the network. Registering a supplier includes a signing step: the supplier's representative signs an authorisation agreement through a hosted wizard (or your own UI over the API), and the app completes the network registration once it's signed.
+
+		#### Key features
+
+		* **Workflow automation:** Register parties, issue invoices, and import received ones as steps in your workflows.
+		* **OIOUBL 2.1 both ways:** GOBL → OIOUBL conversion for sending and OIOUBL → GOBL for received documents, including embedded attachments.
+		* **Schematron validation up front:** Every generated document is validated against the official OIOUBL schematron (v1.17) before it leaves the platform.
+		* **Delivery confirmation:** The send step waits until the network confirms delivery — submission alone doesn't complete the job, and duplicates are never resubmitted.
+		* **Hosted supplier onboarding:** The authorisation agreement is signed through a hosted wizard, with API endpoints for integrators building their own onboarding UI.
+		* **Push reception:** Inbound documents are delivered by webhook the moment they arrive and handed to your import workflow.
+
+		Check out the guides below to get started:
+		- [Supplier registration](/guides/dk-nemhandel-supplier) · [Issuing invoices](/guides/dk-nemhandel) · [Receiving invoices](/guides/dk-nemhandel-receiving)
+
+	## FAQ
+
+	<FAQ />
+
+	More answers in our [Denmark FAQ](/faq/denmark) section
+
+	</Tab>
+
+	<Tab title="Limitations">
+
+		| Capability | Status | Notes |
+		|---|---|---|
+		| Party registration | <Badge color="green">Available</Badge> | Includes the hosted agreement-signing wizard |
+		| Invoice delivery | <Badge color="green">Available</Badge> | OIOUBL 2.1 invoices and credit notes, delivery-confirmed |
+		| Invoice reception | <Badge color="green">Available</Badge> | Webhook push into your import workflow |
+		| Party deregistration | <Badge color="green">Available</Badge> | Releases the participant and its inbound routing |
+		| Reminders | <Badge color="yellow">In development</Badge> | OIOUBL Reminder documents are planned for a follow-up release |
+		| Invoice responses | <Badge color="yellow">In development</Badge> | The OIOUBL ApplicationResponse leg is planned for a follow-up release |
+
+	</Tab>
+
+	<Tab title="Actions">
+		The following workflow actions will be available once you install and enable this app:
+
+		Invoicing
+
+		<Card title="Generate OIOUBL" icon="https://assets.invopop.com/flags/dk.svg" horizontal>
+		 Convert a GOBL invoice or credit note to OIOUBL 2.1, validate it against the official schematron, and attach the XML to the entry under the `oioubl` file key.
+		</Card>
+
+		<Card title="Send to NemHandel" icon="https://assets.invopop.com/flags/dk.svg" horizontal>
+		 Submit the attached OIOUBL document to the network and queue until delivery is confirmed. Requires a preceding Generate OIOUBL step.
+		</Card>
+
+		Registration
+
+		<Card title="Sign NemHandel Agreement" icon="https://assets.invopop.com/flags/dk.svg" horizontal>
+		 Publish the authorisation agreement for the supplier's representative to sign, adding a public signing link to the party's entry.
+		</Card>
+
+		<Card title="Wait for NemHandel Agreement" icon="https://assets.invopop.com/flags/dk.svg" horizontal>
+		 Pause the workflow until the agreement is signed, then upload it to the network partner.
+		</Card>
+
+		<Card title="Register on NemHandel" icon="https://assets.invopop.com/flags/dk.svg" horizontal>
+		 Create the party's NemHandel participant and record the routing that delivers its inbound documents to your workspace.
+		</Card>
+
+		<Card title="Unregister from NemHandel" icon="https://assets.invopop.com/flags/dk.svg" horizontal>
+		 Release the registration, removing the participant and its inbound routing.
+		</Card>
+
+		Reception
+
+		<Card title="Load from NemHandel" icon="https://assets.invopop.com/flags/dk.svg" horizontal>
+		 Fetch one received document, parse the OIOUBL, and create a GOBL silo entry with the original XML and its embedded attachments.
+		</Card>
+	</Tab>
+
+	<Tab title="Workflows">
+
+		Invoice workflows
+		<AccordionGroup>
+			<Accordion title="Send NemHandel invoice">
+				[Add to my workspace →](https://console.invopop.com/redirect/workflows/new?template=dk-send)
+
+				<SendInvoiceWorkflow />
+			</Accordion>
+		</AccordionGroup>
+
+		Party workflows
+		<AccordionGroup>
+			<Accordion title="Register on NemHandel">
+				[Add to my workspace →](https://console.invopop.com/redirect/workflows/new?template=dk-register)
+
+				<RegisterWorkflow />
+			</Accordion>
+			<Accordion title="Unregister from NemHandel">
+				[Add to my workspace →](https://console.invopop.com/redirect/workflows/new?template=dk-unregister)
+
+				<UnregisterWorkflow />
+			</Accordion>
+		</AccordionGroup>
+
+		Reception workflows
+		<AccordionGroup>
+			<Accordion title="Import NemHandel invoice">
+				[Add to my workspace →](https://console.invopop.com/redirect/workflows/new?template=dk-import)
+
+				<ImportWorkflow />
+			</Accordion>
+		</AccordionGroup>
+
+	</Tab>
+
+	<Tab title="Documents">
+		<AccordionGroup>
+			<Accordion title="Denmark supplier">
+				A Danish company with its CVR number as the tax ID and a contact person with a name and role — the prefilled signer for the registration agreement. The `DK:CVR` endpoint is derived from the tax ID automatically.
+				<Supplier />
+			</Accordion>
+			<Accordion title="Denmark customer">
+				A Danish public institution identified by its EAN/GLN number as an endpoint (`GLN:…`), the identifier public entities carry in the NemHandelsregisteret. Business customers can carry just their CVR tax ID instead.
+				<Customer />
+			</Accordion>
+		</AccordionGroup>
+
+		<InvoiceAccordion />
+
+		Copy and paste these documents into the [GOBL builder](https://build.gobl.org) in order to preview and verify them.
+	</Tab>
+
+</Tabs>
+
+---
+
+<DenmarkResources />
+
+<Card title="Participate in our community"
+  icon="forumbee"
+  href="https://community.invopop.com"
+  arrow="true"
+  horizontal
+>
+  Ask and answer questions about the Denmark app →
+</Card>

--- a/apps/index.mdx
+++ b/apps/index.mdx
@@ -31,6 +31,9 @@ Invopop apps extend the platform's core functionality by connecting to governmen
 	<Card title="DIAN Colombia" icon="https://assets.invopop.com/apps/dian-colombia/icon.svg" href="/apps/dian-colombia" horizontal>
 		Submit invoices to the Colombian DIAN system.
 	</Card>
+	<Card title="Denmark" icon="https://assets.invopop.com/flags/dk.svg" href="/apps/denmark" horizontal>
+		Send and receive OIOUBL invoices over Denmark's NemHandel network.
+	</Card>
 	<Card title="Finland" icon="https://assets.invopop.com/flags/fi.svg" href="/apps/finland" horizontal>
 		Send and receive Finnish e-invoices across the domestic operator network and Peppol.
 	</Card>

--- a/compliance/denmark.mdx
+++ b/compliance/denmark.mdx
@@ -5,6 +5,7 @@ description: "Denmark's mandatory e-invoicing requirements, NemHandel, OIOUBL, P
 ---
 
 import DenmarkResources from '/snippets/tables/denmark-resources.mdx';
+import FAQ from '/snippets/faqs/dk/composers/page-compliance.mdx';
 
 
 <Card title="Denmark's e-invoicing regulation timeline" size="20" icon="timeline" href="/timelines/denmark" horizontal>
@@ -47,8 +48,11 @@ Denmark's e-invoicing framework is built on NemHandel and Peppol, paired with a 
     | **Model**           | Decentralized (access point network)                                                              |
     | **Effective date**  | Mandatory since **February 2005**                                                                 |
     | **Agency**          | [Erhvervsstyrelsen (ERST)](https://erhvervsstyrelsen.dk) / [Digitaliseringsstyrelsen](https://digst.dk) |
-    | **Invopop support** | [Peppol App](/apps/peppol)                                                                        |
+    | **Invopop support** | [Denmark App](/apps/denmark), [Peppol App](/apps/peppol)                                          |
 
+    <Card title="Denmark" size="20" icon="https://assets.invopop.com/flags/dk.svg" href="/apps/denmark" horizontal>
+      Connect the app to send OIOUBL invoices over NemHandel →
+    </Card>
     <Card title="Peppol" size="20" icon="https://assets.invopop.com/apps/peppol/icon.svg" href="/apps/peppol" horizontal>
       Connect the app to send invoices to Danish public authorities →
     </Card>
@@ -69,8 +73,11 @@ Denmark's e-invoicing framework is built on NemHandel and Peppol, paired with a 
     | **Model**           | Post-audit with SAF-T on demand                                                             |
     | **Effective date**  | Phased rollout, completing **January 1, 2026** for most businesses                         |
     | **Agency**          | [Erhvervsstyrelsen (ERST)](https://erhvervsstyrelsen.dk)                                    |
-    | **Invopop support** | [Peppol App](/apps/peppol), upcoming SAF-T support.                                                                 |
+    | **Invopop support** | [Denmark App](/apps/denmark), [Peppol App](/apps/peppol), upcoming SAF-T support.                                   |
 
+    <Card title="Denmark" size="20" icon="https://assets.invopop.com/flags/dk.svg" href="/apps/denmark" horizontal>
+      Connect the app to send and receive e-invoices over NemHandel →
+    </Card>
     <Card title="Peppol" size="20" icon="https://assets.invopop.com/apps/peppol/icon.svg" href="/apps/peppol" horizontal>
       Connect the app to get you covered →
     </Card>
@@ -174,6 +181,12 @@ There is no real-time reporting to tax authorities — SAF-T exports are provide
   </Accordion>
 
 </AccordionGroup>
+
+### Compliance questions
+
+<FAQ />
+
+More available in our [Denmark FAQ](/faq/denmark) section
 
 ---
 

--- a/docs.json
+++ b/docs.json
@@ -310,6 +310,15 @@
 								]
 							},
 							{
+								"group": "Denmark",
+								"icon": "https://assets.invopop.com/flags/dk.svg",
+								"pages": [
+									"/guides/dk-nemhandel-supplier",
+									"/guides/dk-nemhandel",
+									"/guides/dk-nemhandel-receiving"
+								]
+							},
+							{
 								"group": "Finland",
 								"icon": "https://assets.invopop.com/flags/fi.svg",
 								"pages": [
@@ -512,6 +521,7 @@
 							"/apps/argentina",
 							"/apps/at-portugal",
 							"/apps/choruspro-france",
+							"/apps/denmark",
 							"/apps/dian-colombia",
 							"/apps/finland",
 							"/apps/france",

--- a/faq/denmark.mdx
+++ b/faq/denmark.mdx
@@ -4,13 +4,9 @@ description: "Frequently asked questions about invoicing compliance in Denmark"
 sidebarTitle: "FAQ"
 ---
 
-<AccordionGroup>
-  <Accordion title="Am I required to issue B2B or B2C e-invoices in Denmark?">
-    No. As of 2026, Denmark has **no B2B or B2C e-invoicing transmission mandate**. The [Digital Bookkeeping Act](/compliance/denmark#digital-bookkeeping-act-b2b) requires businesses to use certified systems that are *capable* of sending and receiving structured e-invoices (Peppol BIS 3.0 and OIOUBL), but it does not require that every invoice is actually sent electronically. You must be ready to e-invoice, but you are not yet obligated to do so for B2B or B2C transactions.
+import FAQ from '/snippets/faqs/dk/composers/page-faq.mdx';
 
-    E-invoicing is only mandatory for **B2G** — all invoices to Danish public authorities must be submitted electronically via NemHandel or the Peppol network. A domestic e-reporting obligation covering B2B is expected by approximately 2028.
-  </Accordion>
-</AccordionGroup>
+<FAQ />
 
 ---
 

--- a/guides/dk-nemhandel-receiving.mdx
+++ b/guides/dk-nemhandel-receiving.mdx
@@ -1,0 +1,88 @@
+---
+title: "NemHandel receiving invoices guide"
+sidebarTitle: "Receiving invoices"
+description: Import the OIOUBL documents Danish trading partners send to your registered parties.
+---
+
+import ImportWorkflow from '/snippets/workflows/dk/nemhandel-import.mdx';
+import DenmarkResources from '/snippets/tables/denmark-resources.mdx';
+import FAQ from '/snippets/faqs/dk/composers/guide-nemhandel-receiving.mdx';
+import { WorkflowDiagram } from '/snippets/components/workflow.jsx';
+import { dkNemhandelImportWorkflow } from '/snippets/workflows/dk/nemhandel-import-data.mdx';
+
+## Introduction
+
+Documents sent to a registered party's NemHandel participant are pushed to Invopop the moment they arrive: eCourier notifies the [Denmark app](/apps/denmark) by webhook, and the app starts your import workflow for each document. There is no polling schedule to wait for — received invoices show up as soon as the network delivers them.
+
+Each received document becomes exactly one silo entry carrying the GOBL invoice, the original OIOUBL XML, and any binary attachments embedded in it, so received invoices show up like any other workflow-processed document.
+
+Registering the parties themselves is covered in the companion guide: [NemHandel supplier registration](/guides/dk-nemhandel-supplier).
+
+| - | Sandbox | Live |
+|---|---|---|
+| **Party** | Registered against eCourier's test environment | Registered on the live NemHandel network |
+| **Environment** | eCourier sandbox | eCourier production |
+
+## Prerequisites
+
+- **The Denmark app connected**: navigate to **Configuration** → **Apps**, find **Denmark**, and click **Connect**.
+- **A party ready to register**: inbound routing is created when a party is registered, so set up the import workflow below before registering it.
+
+## Setup
+
+<Steps>
+<Step title="Create the import workflow">
+The import step fetches one received document, parses the OIOUBL, and files it as a GOBL silo entry with the original XML and its embedded attachments; everything after it is yours to shape: routing to a folder, setting a state, or any other processing your operation needs.
+<Card iconType="duotone" title="Import NemHandel invoice workflow" icon="code-branch" href="https://console.invopop.com/redirect/workflows/new?template=dk-import" horizontal>
+  Add to my workspace →
+</Card>
+<Tabs>
+  <Tab title="Workflow">
+    <WorkflowDiagram workflow={dkNemhandelImportWorkflow} />
+  </Tab>
+  <Tab title="Code">
+    Copy and paste into a new [Empty Invoice workflow](https://console.invopop.com/redirect/workflows/new?template=empty-invoice) code view.
+
+    <ImportWorkflow />
+  </Tab>
+</Tabs>
+</Step>
+
+<Step title="Configure the app with the import workflow">
+Navigate to **Configuration** → **Apps**, find the **Denmark** app, tap **Configure**, and select the import workflow you just created. Every inbound document is handed to this workflow, so save the configuration before registering any party.
+</Step>
+
+<Step title="Register the party">
+Run the registration workflow on the party as described in the [supplier registration guide](/guides/dk-nemhandel-supplier#register-a-supplier). Registration records the participant → workspace routing that inbound delivery depends on.
+</Step>
+</Steps>
+
+## Receiving invoices
+
+From then on, reception is automatic: each document sent to a registered party becomes one silo entry processed by your import workflow.
+
+A few behaviours worth knowing:
+
+- **Delivery is push, not polling.** The network's webhook triggers the import within moments of a document arriving.
+- **Documents are acknowledged only after import succeeds.** A failure partway through leaves the document ready on the network to retry, so nothing is lost to a transient error; the network redelivers on its own schedule.
+- **Unsupported document types are surfaced, not looped.** The current release imports invoices and credit notes. An OIOUBL ApplicationResponse or Reminder is acknowledged once and the import job fails with a message naming the document type and the participant it was addressed to, so it's visible instead of being retried forever.
+- **Embedded attachments are preserved.** Binary attachments carried inside the OIOUBL document are extracted and stored on the silo entry alongside the XML.
+
+## FAQ
+
+<FAQ />
+
+More available in our [Denmark FAQ](/faq/denmark) section
+
+---
+
+<DenmarkResources />
+
+<Card title="Participate in our community"
+  icon="forumbee"
+  href="https://community.invopop.com"
+  arrow="true"
+  horizontal
+>
+  Ask and answer questions about invoicing in Denmark →
+</Card>

--- a/guides/dk-nemhandel-supplier.mdx
+++ b/guides/dk-nemhandel-supplier.mdx
@@ -1,0 +1,154 @@
+---
+title: "NemHandel supplier registration guide"
+sidebarTitle: "Supplier registration"
+description: Register Danish parties on the NemHandel network so they can send and receive invoices.
+---
+
+import RegisterWorkflow from '/snippets/workflows/dk/nemhandel-register.mdx';
+import UnregisterWorkflow from '/snippets/workflows/dk/nemhandel-unregister.mdx';
+import Supplier from '/snippets/parties/dk/supplier.mdx';
+import DenmarkResources from '/snippets/tables/denmark-resources.mdx';
+import FAQ from '/snippets/faqs/dk/composers/guide-nemhandel-supplier.mdx';
+import { WorkflowDiagram } from '/snippets/components/workflow.jsx';
+import { dkNemhandelRegisterWorkflow } from '/snippets/workflows/dk/nemhandel-register-data.mdx';
+import { dkNemhandelUnregisterWorkflow } from '/snippets/workflows/dk/nemhandel-unregister-data.mdx';
+
+## Introduction
+
+**NemHandel** is Denmark's national e-invoicing network, run by the Danish Business Authority (Erhvervsstyrelsen). The [Denmark app](/apps/denmark) registers each of your Danish parties as a NemHandel participant through Invopop's partner [eCourier](https://ecourier.dk), so the party can send and receive OIOUBL invoices over the network.
+
+Registration includes one step no other party in the flow can do for you: the supplier's representative must **sign an authorisation agreement** before the network participant can be created. The registration workflow publishes a signing link you share with them, and continues automatically once they've signed.
+
+Once a supplier is registered, continue with the companion guide: [NemHandel issuing invoices](/guides/dk-nemhandel).
+
+| - | Sandbox | Live |
+|---|---|---|
+| **Party** | Registered against eCourier's test environment | Registered on the live NemHandel network |
+| **Environment** | eCourier sandbox | eCourier production |
+
+## Prerequisites
+
+- **The party's details**: legal name, **CVR number** (8-digit business registration number, uploaded as the GOBL `tax_id.code`), and a Danish address.
+- **A contact person on the party**: the first entry in the party's `people` list, with a name and a role in the company. The signing wizard prefills this person as the agreement's signer, and the API signing flow requires it.
+- **The representative's availability**: someone authorized to sign on the supplier's behalf has to complete the signing step before registration can finish.
+
+<Info>
+  A registered party starts receiving inbound documents right away, so configure reception first: follow the [receiving guide's setup](/guides/dk-nemhandel-receiving#setup) to create the import workflow and select it in the app's configuration, then come back here.
+</Info>
+
+## Setup
+
+All of the following steps must be carried out from the [Invopop Console](https://console.invopop.com).
+
+<Steps>
+<Step title="Connect the Denmark app">
+1. Navigate to **Configuration** → **Apps**
+2. Find **Denmark** in the app discovery list
+3. Click **Connect** to activate
+</Step>
+
+<Step title="Create the registration workflow">
+<Card iconType="duotone" title="Register on NemHandel workflow" icon="code-branch" href="https://console.invopop.com/redirect/workflows/new?template=dk-register" horizontal>
+  Add to my workspace →
+</Card>
+<Tabs>
+  <Tab title="Workflow">
+    <WorkflowDiagram workflow={dkNemhandelRegisterWorkflow} />
+  </Tab>
+  <Tab title="Code">
+    Copy and paste into a new [Empty Party workflow](https://console.invopop.com/redirect/workflows/new?template=empty-party) code view.
+
+    <RegisterWorkflow />
+  </Tab>
+</Tabs>
+</Step>
+
+</Steps>
+
+## Register a supplier
+
+<Steps>
+<Step title="Upload the party">
+Create a silo entry with the party's details. The example below shows the fields a Danish party carries; the name, the CVR number, and the contact person are what registration uses:
+
+<Supplier />
+</Step>
+
+<Step title="Run the registration workflow">
+Run the registration workflow on the party's silo entry, from the Console or [via the API](/api-ref/transform/jobs/create-a-job-post). The workflow publishes the authorisation agreement and pauses at the **wait for approval** step until it is signed.
+</Step>
+
+<Step title="Share the signing link">
+The workflow adds a public **agreement signing link** to the party's silo entry. Open the party in the Console to copy it, and send it to the supplier's representative.
+</Step>
+
+<Step title="Have the representative sign">
+The link opens a short hosted wizard: the representative confirms their name and role (prefilled from the party's contact person), reviews the agreement document, and signs it — drawing a signature that is stamped onto the agreement.
+</Step>
+
+<Step title="Wait for registration to complete">
+As soon as the agreement is signed, the workflow resumes on its own: it uploads the signed agreement, creates the party's NemHandel participant, and records the routing that delivers the party's inbound documents to your workspace. The party's entry ends in the `registered` state.
+</Step>
+</Steps>
+
+<Note>
+  The party is registered under its NemHandel participant identifier: the first `endpoints` entry on the party if it has one (a `GLN:` number, for example), otherwise the `DK:CVR` identifier derived from its Danish tax ID.
+</Note>
+
+<Warning>
+  A participant can only be held by one Invopop workspace. If another workspace has already registered the same identifier, registration fails with `this party is registered on NemHandel by a different workspace`.
+</Warning>
+
+## Sign the agreement via the API
+
+Integrators building their own onboarding UI can drive the signing step without the hosted wizard. The Denmark app exposes two endpoints on its service, authenticated per enrollment; both take `?sandbox=true` (or `"sandbox": true` in the body) to address the sandbox environment:
+
+| Endpoint | Purpose |
+|---|---|
+| `GET /v1/entry/:silo_entry_id/agreement` | The agreement PDF to render on screen: the signed one once it exists, the unsigned document before that. |
+| `POST /v1/entry/:silo_entry_id/sign` | Sign it. Send `document` with a PDF you signed yourself, or `signature` with a drawn PNG/JPEG to have it stamped onto ours; send neither and the signer's typed name is used. |
+
+Both endpoints read the signer from the party entry, so the first person in the party's `people` list must carry a name and a role before either is called.
+
+## Unregister a supplier
+
+To offboard a party, create the unregister workflow and run it on the party's silo entry: it releases the registration, removing the NemHandel participant along with the routing that delivered its inbound documents to your workspace.
+
+<Card iconType="duotone" title="Unregister from NemHandel workflow" icon="code-branch" href="https://console.invopop.com/redirect/workflows/new?template=dk-unregister" horizontal>
+  Add to my workspace →
+</Card>
+<Tabs>
+  <Tab title="Workflow">
+    <WorkflowDiagram workflow={dkNemhandelUnregisterWorkflow} />
+  </Tab>
+  <Tab title="Code">
+    Copy and paste into a new [Empty Party workflow](https://console.invopop.com/redirect/workflows/new?template=empty-party) code view.
+
+    <UnregisterWorkflow />
+  </Tab>
+</Tabs>
+
+<Warning>
+  An unregistered party can no longer send or receive over NemHandel, and documents addressed to it after unregistration will not reach your workspace. To operate on its behalf again, run the registration workflow again.
+</Warning>
+
+At this point, you're ready to start sending invoices on behalf of the supplier. Head over to the [NemHandel issuing invoices guide](/guides/dk-nemhandel) to continue.
+
+## FAQ
+
+<FAQ />
+
+More available in our [Denmark FAQ](/faq/denmark) section
+
+---
+
+<DenmarkResources />
+
+<Card title="Participate in our community"
+  icon="forumbee"
+  href="https://community.invopop.com"
+  arrow="true"
+  horizontal
+>
+  Ask and answer questions about invoicing in Denmark →
+</Card>

--- a/guides/dk-nemhandel.mdx
+++ b/guides/dk-nemhandel.mdx
@@ -1,0 +1,100 @@
+---
+title: "NemHandel issuing invoices guide"
+sidebarTitle: "Issuing invoices"
+description: Issue OIOUBL invoices and credit notes in Denmark over the NemHandel network.
+---
+
+import SendInvoiceWorkflow from '/snippets/workflows/dk/nemhandel-send-invoice.mdx';
+import ExampleAccordion from '/snippets/invoices/dk/accordion.mdx';
+import DenmarkResources from '/snippets/tables/denmark-resources.mdx';
+import FAQ from '/snippets/faqs/dk/composers/guide-nemhandel-invoicing.mdx';
+import { WorkflowDiagram } from '/snippets/components/workflow.jsx';
+import { dkNemhandelSendInvoiceWorkflow } from '/snippets/workflows/dk/nemhandel-send-invoice-data.mdx';
+
+## Introduction
+
+**NemHandel** is the Danish e-invoicing network all public authorities — and a large share of businesses — receive their invoices through. Documents travel as **OIOUBL 2.1**, Denmark's national UBL dialect. The [Denmark app](/apps/denmark) converts GOBL invoices and credit notes to OIOUBL, validates them against the official schematron, and delivers them over the network through Invopop's partner [eCourier](https://ecourier.dk).
+
+For onboarding suppliers, see the companion guide: [NemHandel supplier registration](/guides/dk-nemhandel-supplier). For importing the invoices your parties receive, see [NemHandel receiving invoices](/guides/dk-nemhandel-receiving).
+
+| - | Sandbox | Live |
+|---|---|---|
+| **Supplier** | Party registered against eCourier's test environment | Registered party required |
+| **Environment** | eCourier sandbox | eCourier production |
+
+## Prerequisites
+
+- **A registered supplier**: follow the [NemHandel supplier registration guide](/guides/dk-nemhandel-supplier) to connect the Denmark app, have the supplier sign the authorisation agreement, and register their NemHandel participant before issuing.
+- **The [`dk-oioubl-v2` addon](https://docs.gobl.org/addons/dk-oioubl-v2)** declared in `$addons` on every invoice, so the OIOUBL rules are validated before signing.
+- **A routable customer**: the customer must resolve to a NemHandel endpoint. Public entities carry their **EAN/GLN number** as an endpoint (`GLN:5798000000000`-style); a Danish business with only a tax ID gets its `DK:CVR` endpoint derived automatically.
+- **OIOUBL-compatible payment data**, if you include payment instructions: OIOUBL supports IBAN transfers plus the Danish channels (Giro, FIK, domestic bank transfer with its four-digit registration number, and NemKonto).
+
+<Note>
+  OIOUBL has no VAT-exempt category: invoices are standard-rated, zero-rated, or reverse-charge. An exempt VAT key is rejected up front — state the supply as zero-rated instead.
+</Note>
+
+## Setup
+
+All of the following steps must be carried out from the [Invopop Console](https://console.invopop.com).
+
+<Steps>
+<Step title="Create the send workflow">
+<Card iconType="duotone" title="Send NemHandel invoice workflow" icon="code-branch" href="https://console.invopop.com/redirect/workflows/new?template=dk-send" horizontal>
+  Add to my workspace →
+</Card>
+<Tabs>
+  <Tab title="Workflow">
+    <WorkflowDiagram workflow={dkNemhandelSendInvoiceWorkflow} />
+  </Tab>
+  <Tab title="Code">
+    Copy and paste into a new [Empty Invoice workflow](https://console.invopop.com/redirect/workflows/new?template=empty-invoice) code view.
+
+    <SendInvoiceWorkflow />
+  </Tab>
+</Tabs>
+</Step>
+</Steps>
+
+## Send an invoice
+
+Upload the invoice as a silo entry and run the send workflow on it.
+
+<Info>The recommended approach for running jobs is to perform two steps: first upload the document to the [silo](/api-ref/silo/entries/create-an-entry-put), then [create a job](/api-ref/transform/jobs/create-a-job-post).</Info>
+
+The workflow's two app steps split the work:
+
+- **Generate OIOUBL** converts the signed GOBL envelope into an OIOUBL 2.1 document, validates it against the official schematron (v1.17), and stores the XML as an attachment on the entry under the `oioubl` file key. An invoice that would be rejected by the network fails here, before anything leaves the platform.
+- **Send to NemHandel** submits that attachment and then waits: the job stays queued until eCourier confirms the document is delivered, re-checking whenever the network reports a status change. Delivery — not submission — is what completes the job.
+
+The bytes stored on the entry are exactly the bytes that reached the network, so you can always download the OIOUBL file that was actually delivered.
+
+### Duplicates are skipped
+
+Running the send workflow again on an invoice that was already delivered skips with a `Duplicated Invoice` result instead of resubmitting, so a retried or repeated run never delivers the document twice.
+
+### Generating without sending
+
+The convert step also works on its own: a workflow that ends after **Generate OIOUBL** produces the validated XML attachment without submitting anything, which is useful for previewing the exact document a customer will receive.
+
+## Example invoices
+
+<ExampleAccordion />
+
+## FAQ
+
+<FAQ />
+
+More available in our [Denmark FAQ](/faq/denmark) section
+
+---
+
+<DenmarkResources />
+
+<Card title="Participate in our community"
+  icon="forumbee"
+  href="https://community.invopop.com"
+  arrow="true"
+  horizontal
+>
+  Ask and answer questions about invoicing in Denmark →
+</Card>

--- a/skills/manage-faqs/SKILL.md
+++ b/skills/manage-faqs/SKILL.md
@@ -71,7 +71,7 @@ The country scope only populates a task if the corresponding country-level flow 
 | Brazil | br | `nfe`, `nfse` |
 | Colombia | co | `dian` |
 | Croatia | hr | (country scope only; own eRačun regime) |
-| Denmark | dk | (uses `peppol` only; no country leaves yet — composers import Peppol leaves directly) |
+| Denmark | dk | `nemhandel` (also uses `peppol`) |
 | Germany | de | (uses `peppol` only) |
 | Finland | fi | `finvoice` (also uses `peppol`) |
 | Hungary | hu | (country scope only; NAV real-time reporting) |
@@ -97,6 +97,7 @@ Folder slugs are lowercase; subheadings in composers use the canonical brand spe
 | `arca` | ARCA |
 | `dian` | DIAN |
 | `finvoice` | Finvoice |
+| `nemhandel` | NemHandel |
 | `peppol` | Peppol |
 | `nfe` | NF-e |
 | `nfse` | NFS-e |
@@ -324,6 +325,12 @@ For single-regime countries, country-level operations or tech content goes into 
 | `apps/dian-colombia.mdx` | `co/composers/app-dian.mdx` |
 | `guides/co-dian.mdx` | `co/composers/guide-dian-invoicing.mdx` |
 | `guides/co-dian-supplier.mdx` | `co/composers/guide-dian-supplier.mdx` |
+| `faq/denmark.mdx` | `dk/composers/page-faq.mdx` |
+| `compliance/denmark.mdx` | `dk/composers/page-compliance.mdx` |
+| `apps/denmark.mdx` | `dk/composers/app-nemhandel.mdx` |
+| `guides/dk-nemhandel.mdx` | `dk/composers/guide-nemhandel-invoicing.mdx` |
+| `guides/dk-nemhandel-supplier.mdx` | `dk/composers/guide-nemhandel-supplier.mdx` |
+| `guides/dk-nemhandel-receiving.mdx` | `dk/composers/guide-nemhandel-receiving.mdx` |
 | `guides/cb-denmark.mdx` | `dk/composers/guide-peppol-invoicing.mdx` |
 | `faq/germany.mdx` | `de/composers/page-faq.mdx` |
 | `compliance/germany.mdx` | `de/composers/page-compliance.mdx` |

--- a/snippets/components/workflow.jsx
+++ b/snippets/components/workflow.jsx
@@ -38,6 +38,7 @@ export const WorkflowDiagram = ({ workflow }) => {
     peppol: "https://assets.invopop.com/apps/peppol/icon.svg",
     ubl: "https://assets.invopop.com/apps/ubl/logo.svg",
     cii: "https://assets.invopop.com/apps/cii/logo.svg",
+    "gov-dk": "https://assets.invopop.com/flags/dk.svg",
     "gov-fi": "https://assets.invopop.com/flags/fi.svg",
     "gov-fr": "https://assets.invopop.com/flags/fr.svg",
     "chorus-pro": "https://assets.invopop.com/apps/chroruspro/icon.svg",

--- a/snippets/faqs/dk/composers/app-nemhandel.mdx
+++ b/snippets/faqs/dk/composers/app-nemhandel.mdx
@@ -1,0 +1,18 @@
+import NhInv from '/snippets/faqs/dk/leaves/nemhandel/invoicing.mdx';
+import NhSup from '/snippets/faqs/dk/leaves/nemhandel/supplier.mdx';
+import NhRec from '/snippets/faqs/dk/leaves/nemhandel/receiving.mdx';
+
+Invoicing questions
+<AccordionGroup>
+  <NhInv />
+</AccordionGroup>
+
+Registering supplier questions
+<AccordionGroup>
+  <NhSup />
+</AccordionGroup>
+
+Receiving questions
+<AccordionGroup>
+  <NhRec />
+</AccordionGroup>

--- a/snippets/faqs/dk/composers/guide-nemhandel-invoicing.mdx
+++ b/snippets/faqs/dk/composers/guide-nemhandel-invoicing.mdx
@@ -1,0 +1,5 @@
+import NhInv from '/snippets/faqs/dk/leaves/nemhandel/invoicing.mdx';
+
+<AccordionGroup>
+  <NhInv />
+</AccordionGroup>

--- a/snippets/faqs/dk/composers/guide-nemhandel-receiving.mdx
+++ b/snippets/faqs/dk/composers/guide-nemhandel-receiving.mdx
@@ -1,0 +1,5 @@
+import NhRec from '/snippets/faqs/dk/leaves/nemhandel/receiving.mdx';
+
+<AccordionGroup>
+  <NhRec />
+</AccordionGroup>

--- a/snippets/faqs/dk/composers/guide-nemhandel-supplier.mdx
+++ b/snippets/faqs/dk/composers/guide-nemhandel-supplier.mdx
@@ -1,0 +1,5 @@
+import NhSup from '/snippets/faqs/dk/leaves/nemhandel/supplier.mdx';
+
+<AccordionGroup>
+  <NhSup />
+</AccordionGroup>

--- a/snippets/faqs/dk/composers/page-compliance.mdx
+++ b/snippets/faqs/dk/composers/page-compliance.mdx
@@ -1,0 +1,18 @@
+import DkCompliance from '/snippets/faqs/dk/leaves/country/compliance.mdx';
+import NhCompliance from '/snippets/faqs/dk/leaves/nemhandel/compliance.mdx';
+import PepCompliance from '/snippets/faqs/peppol/leaves/compliance.mdx';
+
+Denmark
+<AccordionGroup>
+  <DkCompliance />
+</AccordionGroup>
+
+NemHandel
+<AccordionGroup>
+  <NhCompliance />
+</AccordionGroup>
+
+Peppol
+<AccordionGroup>
+  <PepCompliance />
+</AccordionGroup>

--- a/snippets/faqs/dk/composers/page-faq.mdx
+++ b/snippets/faqs/dk/composers/page-faq.mdx
@@ -1,0 +1,62 @@
+import DkCompliance from '/snippets/faqs/dk/leaves/country/compliance.mdx';
+import NhCompliance from '/snippets/faqs/dk/leaves/nemhandel/compliance.mdx';
+import PepCompliance from '/snippets/faqs/peppol/leaves/compliance.mdx';
+import NhInv from '/snippets/faqs/dk/leaves/nemhandel/invoicing.mdx';
+import PepInv from '/snippets/faqs/peppol/leaves/invoicing.mdx';
+import NhSup from '/snippets/faqs/dk/leaves/nemhandel/supplier.mdx';
+import PepSup from '/snippets/faqs/peppol/leaves/supplier.mdx';
+import NhRec from '/snippets/faqs/dk/leaves/nemhandel/receiving.mdx';
+import PepRec from '/snippets/faqs/peppol/leaves/receiving.mdx';
+
+### Compliance questions
+
+**Denmark**
+<AccordionGroup>
+  <DkCompliance />
+</AccordionGroup>
+
+**NemHandel**
+<AccordionGroup>
+  <NhCompliance />
+</AccordionGroup>
+
+**Peppol**
+<AccordionGroup>
+  <PepCompliance />
+</AccordionGroup>
+
+### Invoicing questions
+
+**NemHandel**
+<AccordionGroup>
+  <NhInv />
+</AccordionGroup>
+
+**Peppol**
+<AccordionGroup>
+  <PepInv />
+</AccordionGroup>
+
+### Registering supplier questions
+
+**NemHandel**
+<AccordionGroup>
+  <NhSup />
+</AccordionGroup>
+
+**Peppol**
+<AccordionGroup>
+  <PepSup />
+</AccordionGroup>
+
+### Receiving questions
+
+**NemHandel**
+<AccordionGroup>
+  <NhRec />
+</AccordionGroup>
+
+**Peppol**
+<AccordionGroup>
+  <PepRec />
+</AccordionGroup>

--- a/snippets/faqs/dk/leaves/country/compliance.mdx
+++ b/snippets/faqs/dk/leaves/country/compliance.mdx
@@ -1,0 +1,5 @@
+<Accordion title="Am I required to issue B2B or B2C e-invoices in Denmark?">
+  No. As of 2026, Denmark has **no B2B or B2C e-invoicing transmission mandate**. The [Digital Bookkeeping Act](/compliance/denmark#digital-bookkeeping-act-b2b) requires businesses to use certified systems that are *capable* of sending and receiving structured e-invoices (Peppol BIS 3.0 and OIOUBL), but it does not require that every invoice is actually sent electronically. You must be ready to e-invoice, but you are not yet obligated to do so for B2B or B2C transactions.
+
+  E-invoicing is only mandatory for **B2G** — all invoices to Danish public authorities must be submitted electronically via NemHandel or the Peppol network. A domestic e-reporting obligation covering B2B is expected by approximately 2028.
+</Accordion>

--- a/snippets/faqs/dk/leaves/nemhandel/compliance.mdx
+++ b/snippets/faqs/dk/leaves/nemhandel/compliance.mdx
@@ -1,0 +1,6 @@
+<Accordion title="Is OIOUBL still the right format now that OIOUBL 3.0 has been cancelled?">
+  Yes. **OIOUBL 2.1** remains Denmark's national e-invoicing standard and is accepted alongside Peppol BIS Billing 3.0 for invoicing public authorities. What Erhvervsstyrelsen cancelled in January 2026 was **OIOUBL 3.0**, the planned successor that never left its release-candidate stage. Denmark is converging on a single Peppol-aligned standard in the longer term, but until that is specified and rolled out, OIOUBL 2.1 stays in mandatory use — with updated schematron validation rules (v1.17) applying from May 15, 2026, which the Denmark app already validates against.
+</Accordion>
+<Accordion title="Do I have to use NemHandel to invoice Danish public authorities?">
+  Danish public authorities only accept electronic invoices, delivered over **NemHandel** or the **Peppol network** — paper and PDF invoices are rejected. Public entities are identified by their **EAN/GLN number** in the NemHandelsregisteret (NHR). The [Denmark app](/apps/denmark) delivers OIOUBL 2.1 invoices over NemHandel; for Peppol BIS delivery, the [Peppol app](/apps/peppol) covers the same receivers through the Peppol network.
+</Accordion>

--- a/snippets/faqs/dk/leaves/nemhandel/invoicing.mdx
+++ b/snippets/faqs/dk/leaves/nemhandel/invoicing.mdx
@@ -1,0 +1,15 @@
+<Accordion title="What documents can I send over NemHandel with the Denmark app?">
+  Invoices and credit notes, as **OIOUBL 2.1** documents. Declare the [`dk-oioubl-v2` addon](https://docs.gobl.org/addons/dk-oioubl-v2) in `$addons` on the GOBL invoice: it layers the OIOUBL rules on top of the European EN 16931 baseline and rejects documents that would fail on the network before anything is sent. Reminders and invoice responses (OIOUBL ApplicationResponse) are not supported yet — they are planned for a follow-up release.
+</Accordion>
+<Accordion title="How do I know an invoice was actually delivered?">
+  The send step doesn't report success on submission — it submits the OIOUBL document and then **waits until the network confirms delivery**. The job stays queued, re-checking the document's status when eCourier reports a change (and every few minutes on its own), and only completes when the document is delivered. If delivery fails, the job fails and your workflow's rescue steps run.
+</Accordion>
+<Accordion title="Can I issue a VAT-exempt invoice?">
+  Not as "exempt". OIOUBL's tax category codelist supports standard-rated, zero-rated, and reverse-charge VAT, but has **no exempt category** on the wire. The `dk-oioubl-v2` addon rejects an exempt VAT key up front rather than silently relabelling it — state the supply as **zero-rated** instead.
+</Accordion>
+<Accordion title="What happens if I run the send workflow twice on the same invoice?">
+  Nothing bad. A later run that finds the entry already delivered skips with a `Duplicated Invoice` result instead of resubmitting, so the receiver never gets the document twice.
+</Accordion>
+<Accordion title="Can I generate the OIOUBL file without sending it?">
+  Yes. The convert step works on its own: it converts the GOBL invoice to OIOUBL 2.1, validates it against the official schematron, and stores the XML as an attachment on the silo entry under the `oioubl` file key. A workflow that only converts lets you inspect or download the file without submitting anything to the network.
+</Accordion>

--- a/snippets/faqs/dk/leaves/nemhandel/receiving.mdx
+++ b/snippets/faqs/dk/leaves/nemhandel/receiving.mdx
@@ -1,0 +1,12 @@
+<Accordion title="How do received invoices arrive?">
+  By push, not polling. When a document addressed to one of your registered parties lands on the network, eCourier notifies Invopop by webhook, and the Denmark app starts your configured import workflow for it. The import step fetches the document, parses the OIOUBL, converts it to a GOBL invoice, and creates a silo entry carrying the GOBL document, the original XML, and any binary attachments embedded in it.
+</Accordion>
+<Accordion title="Which workflow processes inbound documents?">
+  The one you select in the Denmark app's configuration (**Configuration** → **Apps** → **Denmark** → **Configure**). Every inbound document is handed to that workflow, so create it before registering any party — its first step must be the app's import action, and everything after it is yours to shape: setting a state, filing into a folder, or any other processing.
+</Accordion>
+<Accordion title="What happens to document types Invopop cannot process?">
+  The current release imports invoices and credit notes. If something else arrives — an OIOUBL ApplicationResponse or a Reminder — the app acknowledges it on the network once and fails the import job with a message naming the document type that arrived and the participant it was addressed to, so it's visible rather than silently retried forever. Support for these document types is planned for a follow-up release.
+</Accordion>
+<Accordion title="Can a document be delivered twice?">
+  The network redelivers its webhook until it is acknowledged, but the import step only acknowledges a document after it has been fully processed — and a document that was already imported isn't imported again. A failure partway through leaves the document ready to retry rather than lost.
+</Accordion>

--- a/snippets/faqs/dk/leaves/nemhandel/supplier.mdx
+++ b/snippets/faqs/dk/leaves/nemhandel/supplier.mdx
@@ -1,0 +1,15 @@
+<Accordion title="Why does registration involve signing an agreement?">
+  NemHandel registration runs through Invopop's partner **eCourier**, which requires a signed authorisation agreement from the supplier before it can create the supplier's NemHandel participant. That's why the registration workflow has three steps: publish the agreement for signing, wait until the supplier's representative signs it, and only then register the participant.
+</Accordion>
+<Accordion title="Who signs the agreement, and how?">
+  A representative of the supplier — typically a director or other authorized signatory. The registration workflow publishes a **public signing link** on the party's silo entry; share it with the representative and they complete a short hosted wizard: confirm their details, review the agreement, and sign. If the party's `people` list carries a person with a name and role, the wizard prefills them as the signer. Integrators building their own onboarding UI can drive the same flow [over the API](/guides/dk-nemhandel-supplier#sign-the-agreement-via-the-api).
+</Accordion>
+<Accordion title="What identifier is the party registered under?">
+  Its NemHandel participant identifier: the party's first GOBL `endpoints` entry if it has one (for example a `GLN:` number), otherwise the **`DK:CVR`** identifier derived from the party's Danish tax ID. NemHandel uses symbolic schemes (`DK:CVR`, `DK:SE`, `GLN`) rather than Peppol's numeric ISO 6523 codes.
+</Accordion>
+<Accordion title="Why was my registration refused with “registered on NemHandel by a different workspace”?">
+  Each NemHandel participant can only be held by one Invopop workspace. If another workspace has already registered the same identifier, registration is refused — which workspace holds it is not disclosed. Re-running registration for a party your own workspace already registered is fine: it's treated as a retry, not an error.
+</Accordion>
+<Accordion title="Can I unregister a party?">
+  Yes. Run the unregister workflow on the party's silo entry: it releases the NemHandel registration, removing the participant and the routing that delivered inbound documents to your workspace. To send or receive on behalf of that party again, you'll need to register it again.
+</Accordion>

--- a/snippets/invoices/dk/accordion.mdx
+++ b/snippets/invoices/dk/accordion.mdx
@@ -1,0 +1,132 @@
+import B2GInvoiceMin from '/snippets/invoices/dk/b2g-invoice.min.mdx';
+import B2GInvoice from '/snippets/invoices/dk/b2g-invoice.mdx';
+import B2BInvoiceMin from '/snippets/invoices/dk/b2b-invoice.min.mdx';
+import B2BInvoice from '/snippets/invoices/dk/b2b-invoice.mdx';
+import CreditNoteMin from '/snippets/invoices/dk/credit-note.min.mdx';
+import CreditNote from '/snippets/invoices/dk/credit-note.mdx';
+import ZeroRateMin from '/snippets/invoices/dk/zero-rate.min.mdx';
+import ZeroRate from '/snippets/invoices/dk/zero-rate.mdx';
+import ReverseChargeMin from '/snippets/invoices/dk/reverse-charge.min.mdx';
+import ReverseCharge from '/snippets/invoices/dk/reverse-charge.mdx';
+import IntraCommunityMin from '/snippets/invoices/dk/intra-community.min.mdx';
+import IntraCommunity from '/snippets/invoices/dk/intra-community.mdx';
+import ExportMin from '/snippets/invoices/dk/export.min.mdx';
+import Export from '/snippets/invoices/dk/export.mdx';
+
+<AccordionGroup>
+	<Accordion title="Example B2G invoice">
+
+		In this example, we're invoicing a Danish public institution, the segment where e-invoicing is mandatory.
+
+		Notice:
+
+		- the `$addons` field is set to `dk-oioubl-v2`, which layers the OIOUBL 2.1 rules on top of the European EN 16931 baseline,
+		- the customer carries its **EAN/GLN number** as an endpoint (`GLN:5798009883735`) — this is how public entities are identified in the NemHandelsregisteret,
+		- the supplier declares no endpoint: the addon derives its `DK:CVR` endpoint automatically from the Danish tax ID,
+		- the `ordering.purchases` block carries the order reference the receiving institution asked for,
+		- the payment instructions use a SEPA credit transfer with an IBAN, and,
+		- there are no calculations in some fields; these will be made automatically when uploading.
+
+		<CodeGroup>
+			<B2GInvoiceMin />
+			<B2GInvoice />
+		</CodeGroup>
+	</Accordion>
+
+	<Accordion title="Example B2B invoice">
+
+		In this example, we're issuing a B2B invoice from a Danish supplier to another Danish business.
+
+		Notice:
+
+		- both parties are identified by their **CVR number** as the GOBL `tax_id.code`; the addon derives each party's `DK:CVR` endpoint from it,
+		- the payment instructions describe a Danish domestic bank transfer (UNTDID payment means `42`): the account number plus the four-digit bank registration (clearing) code the OIOUBL rules require, and,
+		- there are no calculations in some fields; these will be made automatically when uploading.
+
+		<CodeGroup>
+			<B2BInvoiceMin />
+			<B2BInvoice />
+		</CodeGroup>
+	</Accordion>
+
+	<Accordion title="Example zero-rated invoice">
+
+		In this example, we're issuing a domestic invoice for a zero-rated supply — newspapers, one of the few zero-rated categories under Momslovens §34.
+
+		Notice:
+
+		- the line's tax uses the `zero` VAT key: the supply is taxable at 0% with input VAT recovery, unlike an exempt supply,
+		- OIOUBL has **no exempt category** on the wire, so genuinely exempt supplies (healthcare, education, financial services) cannot be invoiced through NemHandel as "exempt" — the addon rejects the `exempt` key and zero-rated is the closest the format supports, and,
+		- everything else works exactly like the standard B2B invoice.
+
+		<CodeGroup>
+			<ZeroRateMin />
+			<ZeroRate />
+		</CodeGroup>
+	</Accordion>
+
+	<Accordion title="Example reverse charge invoice">
+
+		In this example, we're issuing a domestic reverse charge invoice for copper scrap — one of the supplies (along with certain metals and electronics) where Denmark shifts the VAT liability to the buyer.
+
+		Notice:
+
+		- the line's tax uses the `reverse-charge` VAT key, so no VAT is charged and the customer accounts for it instead,
+		- the `cef-vatex` extension carries the exemption reason code `VATEX-EU-AE` (reverse charge), which OIOUBL maps to its reverse-charge tax category, and,
+		- both parties are Danish businesses identified by their CVR numbers.
+
+		<CodeGroup>
+			<ReverseChargeMin />
+			<ReverseCharge />
+		</CodeGroup>
+	</Accordion>
+
+	<Accordion title="Example intra-community invoice">
+
+		In this example, we're invoicing a VAT-registered business in another EU member state — an intra-Community supply of goods, zero-rated under Momslovens §34.
+
+		Notice:
+
+		- the line's tax uses the `intra-community` VAT key with the `VATEX-EU-IC` exemption reason code,
+		- the customer carries its own country's tax ID (a German VAT number here) and a **GLN endpoint** so NemHandel can route the document, and,
+		- no Danish VAT is charged; the customer self-accounts for the acquisition in their own country.
+
+		<CodeGroup>
+			<IntraCommunityMin />
+			<IntraCommunity />
+		</CodeGroup>
+	</Accordion>
+
+	<Accordion title="Example export invoice">
+
+		In this example, we're invoicing a customer outside the EU — an export of goods, zero-rated under Momslovens §34.
+
+		Notice:
+
+		- the line's tax uses the `export` VAT key with the `VATEX-EU-G` exemption reason code,
+		- the customer is a Norwegian business with its organisation number as tax ID and a GLN endpoint for routing, and,
+		- no Danish VAT is charged on exports outside the EU.
+
+		<CodeGroup>
+			<ExportMin />
+			<Export />
+		</CodeGroup>
+	</Accordion>
+
+	<Accordion title="Example credit note">
+
+		In this example, we're issuing a credit note that corrects a previously issued invoice.
+
+		Notice:
+
+		- the `type` is set to `credit-note`, which OIOUBL maps to its own CreditNote document (type code `381`),
+		- the `preceding` array references the original invoice by its `series`, `code`, and `issue_date`, along with a `reason`, and,
+		- there are no calculations in some fields; these will be made automatically when uploading.
+
+		<CodeGroup>
+			<CreditNoteMin />
+			<CreditNote />
+		</CodeGroup>
+	</Accordion>
+
+</AccordionGroup>

--- a/snippets/invoices/dk/b2b-invoice.mdx
+++ b/snippets/invoices/dk/b2b-invoice.mdx
@@ -1,0 +1,148 @@
+```json Built version
+{
+	"$schema": "https://gobl.org/draft-0/bill/invoice",
+	"$regime": "DK",
+	"$addons": [
+		"eu-en16931-v2017",
+		"dk-oioubl-v2"
+	],
+	"type": "standard",
+	"series": "SAMPLE",
+	"code": "0043",
+	"issue_date": "2026-08-01",
+	"currency": "DKK",
+	"tax": {
+		"rounding": "currency",
+		"ext": {
+			"untdid-document-type": "380"
+		}
+	},
+	"supplier": {
+		"name": "Nordlys Software ApS",
+		"tax_id": {
+			"country": "DK",
+			"code": "16356700"
+		},
+		"identities": [
+			{
+				"scope": "legal",
+				"code": "16356700"
+			}
+		],
+		"endpoints": [
+			{
+				"uri": "DK:CVR:16356700"
+			}
+		],
+		"addresses": [
+			{
+				"num": "24",
+				"street": "Vesterbrogade",
+				"locality": "København V",
+				"code": "1620",
+				"country": "DK"
+			}
+		],
+		"emails": [
+			{
+				"addr": "faktura@nordlys.dk"
+			}
+		]
+	},
+	"customer": {
+		"name": "Havnens Byggemarked A/S",
+		"tax_id": {
+			"country": "DK",
+			"code": "12345674"
+		},
+		"identities": [
+			{
+				"scope": "legal",
+				"code": "12345674"
+			}
+		],
+		"endpoints": [
+			{
+				"uri": "DK:CVR:12345674"
+			}
+		],
+		"addresses": [
+			{
+				"num": "3",
+				"street": "Havnegade",
+				"locality": "Aarhus C",
+				"code": "8000",
+				"country": "DK"
+			}
+		]
+	},
+	"lines": [
+		{
+			"i": 1,
+			"quantity": "10",
+			"item": {
+				"name": "Consulting services",
+				"price": "800.00",
+				"unit": "h"
+			},
+			"sum": "8000.00",
+			"taxes": [
+				{
+					"cat": "VAT",
+					"key": "standard",
+					"rate": "general",
+					"percent": "25.0%"
+				}
+			],
+			"total": "8000.00"
+		}
+	],
+	"payment": {
+		"terms": {
+			"due_dates": [
+				{
+					"date": "2026-08-31",
+					"amount": "10000.00",
+					"percent": "100%"
+				}
+			]
+		},
+		"instructions": {
+			"key": "other",
+			"credit_transfer": [
+				{
+					"number": "1234567890",
+					"clearing": "1234"
+				}
+			],
+			"ext": {
+				"untdid-payment-means": "42"
+			}
+		}
+	},
+	"totals": {
+		"sum": "8000.00",
+		"total": "8000.00",
+		"taxes": {
+			"categories": [
+				{
+					"code": "VAT",
+					"rates": [
+						{
+							"key": "standard",
+							"base": "8000.00",
+							"percent": "25.0%",
+							"amount": "2000.00"
+						}
+					],
+					"amount": "2000.00"
+				}
+			],
+			"sum": "2000.00"
+		},
+		"tax": "2000.00",
+		"total_with_tax": "10000.00",
+		"payable": "10000.00"
+	}
+}
+```

--- a/snippets/invoices/dk/b2b-invoice.min.mdx
+++ b/snippets/invoices/dk/b2b-invoice.min.mdx
@@ -1,0 +1,86 @@
+```json Denmark B2B invoice
+{
+  "$schema": "https://gobl.org/draft-0/bill/invoice",
+  "$addons": ["dk-oioubl-v2"],
+  "type": "standard",
+  "series": "SAMPLE",
+  "code": "0043",
+  "issue_date": "2026-08-01",
+  "currency": "DKK",
+  "supplier": {
+    "name": "Nordlys Software ApS",
+    "tax_id": {
+      "country": "DK",
+      "code": "16356700"
+    },
+    "addresses": [
+      {
+        "num": "24",
+        "street": "Vesterbrogade",
+        "locality": "København V",
+        "code": "1620",
+        "country": "DK"
+      }
+    ],
+    "emails": [
+      {
+        "addr": "faktura@nordlys.dk"
+      }
+    ]
+  },
+  "customer": {
+    "name": "Havnens Byggemarked A/S",
+    "tax_id": {
+      "country": "DK",
+      "code": "12345674"
+    },
+    "addresses": [
+      {
+        "num": "3",
+        "street": "Havnegade",
+        "locality": "Aarhus C",
+        "code": "8000",
+        "country": "DK"
+      }
+    ]
+  },
+  "lines": [
+    {
+      "quantity": 10,
+      "item": {
+        "name": "Consulting services",
+        "price": "800.00",
+        "unit": "h"
+      },
+      "taxes": [
+        {
+          "cat": "VAT",
+          "rate": "standard"
+        }
+      ]
+    }
+  ],
+  "payment": {
+    "terms": {
+      "due_dates": [
+        {
+          "date": "2026-08-31",
+          "percent": "100%"
+        }
+      ]
+    },
+    "instructions": {
+      "key": "other",
+      "ext": {
+        "untdid-payment-means": "42"
+      },
+      "credit_transfer": [
+        {
+          "number": "1234567890",
+          "clearing": "1234"
+        }
+      ]
+    }
+  }
+}
+```

--- a/snippets/invoices/dk/b2g-invoice.mdx
+++ b/snippets/invoices/dk/b2g-invoice.mdx
@@ -1,0 +1,153 @@
+```json Built version
+{
+	"$schema": "https://gobl.org/draft-0/bill/invoice",
+	"$regime": "DK",
+	"$addons": [
+		"eu-en16931-v2017",
+		"dk-oioubl-v2"
+	],
+	"type": "standard",
+	"series": "SAMPLE",
+	"code": "0042",
+	"issue_date": "2026-08-01",
+	"currency": "DKK",
+	"tax": {
+		"rounding": "currency",
+		"ext": {
+			"untdid-document-type": "380"
+		}
+	},
+	"supplier": {
+		"name": "Nordlys Software ApS",
+		"tax_id": {
+			"country": "DK",
+			"code": "16356700"
+		},
+		"identities": [
+			{
+				"scope": "legal",
+				"code": "16356700"
+			}
+		],
+		"people": [
+			{
+				"name": {
+					"given": "Mette",
+					"surname": "Kristensen"
+				},
+				"role": "Director"
+			}
+		],
+		"endpoints": [
+			{
+				"uri": "DK:CVR:16356700"
+			}
+		],
+		"addresses": [
+			{
+				"num": "24",
+				"street": "Vesterbrogade",
+				"locality": "København V",
+				"code": "1620",
+				"country": "DK"
+			}
+		],
+		"emails": [
+			{
+				"addr": "faktura@nordlys.dk"
+			}
+		]
+	},
+	"customer": {
+		"name": "Den Lille Skole",
+		"endpoints": [
+			{
+				"uri": "GLN:5798009883735"
+			}
+		],
+		"addresses": [
+			{
+				"num": "10",
+				"street": "Fredericiavej",
+				"locality": "Helsingør",
+				"code": "3000",
+				"country": "DK"
+			}
+		]
+	},
+	"lines": [
+		{
+			"i": 1,
+			"quantity": "20",
+			"item": {
+				"name": "Software licence",
+				"price": "150.00",
+				"unit": "item"
+			},
+			"sum": "3000.00",
+			"taxes": [
+				{
+					"cat": "VAT",
+					"key": "standard",
+					"rate": "general",
+					"percent": "25.0%"
+				}
+			],
+			"total": "3000.00"
+		}
+	],
+	"ordering": {
+		"purchases": [
+			{
+				"code": "5002701"
+			}
+		]
+	},
+	"payment": {
+		"terms": {
+			"due_dates": [
+				{
+					"date": "2026-08-31",
+					"amount": "3750.00",
+					"percent": "100%"
+				}
+			]
+		},
+		"instructions": {
+			"key": "credit-transfer+sepa",
+			"credit_transfer": [
+				{
+					"iban": "DK5000400440116243"
+				}
+			],
+			"ext": {
+				"untdid-payment-means": "58"
+			}
+		}
+	},
+	"totals": {
+		"sum": "3000.00",
+		"total": "3000.00",
+		"taxes": {
+			"categories": [
+				{
+					"code": "VAT",
+					"rates": [
+						{
+							"key": "standard",
+							"base": "3000.00",
+							"percent": "25.0%",
+							"amount": "750.00"
+						}
+					],
+					"amount": "750.00"
+				}
+			],
+			"sum": "750.00"
+		},
+		"tax": "750.00",
+		"total_with_tax": "3750.00",
+		"payable": "3750.00"
+	}
+}
+```

--- a/snippets/invoices/dk/b2g-invoice.min.mdx
+++ b/snippets/invoices/dk/b2g-invoice.min.mdx
@@ -1,0 +1,103 @@
+```json Denmark B2G invoice
+{
+  "$schema": "https://gobl.org/draft-0/bill/invoice",
+  "$addons": [
+    "dk-oioubl-v2"
+  ],
+  "type": "standard",
+  "series": "SAMPLE",
+  "code": "0042",
+  "issue_date": "2026-08-01",
+  "currency": "DKK",
+  "supplier": {
+    "name": "Nordlys Software ApS",
+    "tax_id": {
+      "country": "DK",
+      "code": "16356700"
+    },
+    "people": [
+      {
+        "name": {
+          "given": "Mette",
+          "surname": "Kristensen"
+        },
+        "role": "Director"
+      }
+    ],
+    "addresses": [
+      {
+        "num": "24",
+        "street": "Vesterbrogade",
+        "locality": "København V",
+        "code": "1620",
+        "country": "DK"
+      }
+    ],
+    "emails": [
+      {
+        "addr": "faktura@nordlys.dk"
+      }
+    ]
+  },
+  "customer": {
+    "name": "Den Lille Skole",
+    "endpoints": [
+      {
+        "uri": "GLN:5798009883735"
+      }
+    ],
+    "addresses": [
+      {
+        "num": "10",
+        "street": "Fredericiavej",
+        "locality": "Helsingør",
+        "code": "3000",
+        "country": "DK"
+      }
+    ]
+  },
+  "ordering": {
+    "purchases": [
+      {
+        "code": "5002701"
+      }
+    ]
+  },
+  "lines": [
+    {
+      "quantity": 20,
+      "item": {
+        "name": "Software licence",
+        "price": "150.00",
+        "unit": "item"
+      },
+      "taxes": [
+        {
+          "cat": "VAT",
+          "rate": "standard"
+        }
+      ]
+    }
+  ],
+  "payment": {
+    "terms": {
+      "due_dates": [
+        {
+          "date": "2026-08-31",
+          "percent": "100%"
+        }
+      ]
+    },
+    "instructions": {
+      "key": "credit-transfer+sepa",
+      "credit_transfer": [
+        {
+          "iban": "DK5000400440116243"
+        }
+      ],
+      "ext": {
+        "untdid-payment-means": "58"
+      }
+    }
+  }
+}```

--- a/snippets/invoices/dk/credit-note.mdx
+++ b/snippets/invoices/dk/credit-note.mdx
@@ -1,0 +1,133 @@
+```json Built version
+{
+	"$schema": "https://gobl.org/draft-0/bill/invoice",
+	"$regime": "DK",
+	"$addons": [
+		"eu-en16931-v2017",
+		"dk-oioubl-v2"
+	],
+	"type": "credit-note",
+	"series": "SAMPLE",
+	"code": "0044",
+	"issue_date": "2026-08-10",
+	"currency": "DKK",
+	"preceding": [
+		{
+			"issue_date": "2026-08-01",
+			"series": "SAMPLE",
+			"code": "0043",
+			"reason": "Ordered quantity reduced"
+		}
+	],
+	"tax": {
+		"rounding": "currency",
+		"ext": {
+			"untdid-document-type": "381"
+		}
+	},
+	"supplier": {
+		"name": "Nordlys Software ApS",
+		"tax_id": {
+			"country": "DK",
+			"code": "16356700"
+		},
+		"identities": [
+			{
+				"scope": "legal",
+				"code": "16356700"
+			}
+		],
+		"endpoints": [
+			{
+				"uri": "DK:CVR:16356700"
+			}
+		],
+		"addresses": [
+			{
+				"num": "24",
+				"street": "Vesterbrogade",
+				"locality": "København V",
+				"code": "1620",
+				"country": "DK"
+			}
+		],
+		"emails": [
+			{
+				"addr": "faktura@nordlys.dk"
+			}
+		]
+	},
+	"customer": {
+		"name": "Havnens Byggemarked A/S",
+		"tax_id": {
+			"country": "DK",
+			"code": "12345674"
+		},
+		"identities": [
+			{
+				"scope": "legal",
+				"code": "12345674"
+			}
+		],
+		"endpoints": [
+			{
+				"uri": "DK:CVR:12345674"
+			}
+		],
+		"addresses": [
+			{
+				"num": "3",
+				"street": "Havnegade",
+				"locality": "Aarhus C",
+				"code": "8000",
+				"country": "DK"
+			}
+		]
+	},
+	"lines": [
+		{
+			"i": 1,
+			"quantity": "2",
+			"item": {
+				"name": "Consulting services",
+				"price": "800.00",
+				"unit": "h"
+			},
+			"sum": "1600.00",
+			"taxes": [
+				{
+					"cat": "VAT",
+					"key": "standard",
+					"rate": "general",
+					"percent": "25.0%"
+				}
+			],
+			"total": "1600.00"
+		}
+	],
+	"totals": {
+		"sum": "1600.00",
+		"total": "1600.00",
+		"taxes": {
+			"categories": [
+				{
+					"code": "VAT",
+					"rates": [
+						{
+							"key": "standard",
+							"base": "1600.00",
+							"percent": "25.0%",
+							"amount": "400.00"
+						}
+					],
+					"amount": "400.00"
+				}
+			],
+			"sum": "400.00"
+		},
+		"tax": "400.00",
+		"total_with_tax": "2000.00",
+		"payable": "2000.00"
+	}
+}
+```

--- a/snippets/invoices/dk/credit-note.min.mdx
+++ b/snippets/invoices/dk/credit-note.min.mdx
@@ -1,0 +1,72 @@
+```json Denmark credit note
+{
+  "$schema": "https://gobl.org/draft-0/bill/invoice",
+  "$addons": ["dk-oioubl-v2"],
+  "type": "credit-note",
+  "series": "SAMPLE",
+  "code": "0044",
+  "issue_date": "2026-08-10",
+  "currency": "DKK",
+  "preceding": [
+    {
+      "series": "SAMPLE",
+      "code": "0043",
+      "issue_date": "2026-08-01",
+      "reason": "Ordered quantity reduced"
+    }
+  ],
+  "supplier": {
+    "name": "Nordlys Software ApS",
+    "tax_id": {
+      "country": "DK",
+      "code": "16356700"
+    },
+    "addresses": [
+      {
+        "num": "24",
+        "street": "Vesterbrogade",
+        "locality": "København V",
+        "code": "1620",
+        "country": "DK"
+      }
+    ],
+    "emails": [
+      {
+        "addr": "faktura@nordlys.dk"
+      }
+    ]
+  },
+  "customer": {
+    "name": "Havnens Byggemarked A/S",
+    "tax_id": {
+      "country": "DK",
+      "code": "12345674"
+    },
+    "addresses": [
+      {
+        "num": "3",
+        "street": "Havnegade",
+        "locality": "Aarhus C",
+        "code": "8000",
+        "country": "DK"
+      }
+    ]
+  },
+  "lines": [
+    {
+      "quantity": 2,
+      "item": {
+        "name": "Consulting services",
+        "price": "800.00",
+        "unit": "h"
+      },
+      "taxes": [
+        {
+          "cat": "VAT",
+          "rate": "standard"
+        }
+      ]
+    }
+  ]
+}
+```

--- a/snippets/invoices/dk/export.mdx
+++ b/snippets/invoices/dk/export.mdx
@@ -1,0 +1,144 @@
+```json Built version
+{
+	"$schema": "https://gobl.org/draft-0/bill/invoice",
+	"$regime": "DK",
+	"$addons": [
+		"eu-en16931-v2017",
+		"dk-oioubl-v2"
+	],
+	"type": "standard",
+	"series": "SAMPLE",
+	"code": "0048",
+	"issue_date": "2026-08-01",
+	"currency": "DKK",
+	"tax": {
+		"rounding": "currency",
+		"ext": {
+			"untdid-document-type": "380"
+		}
+	},
+	"supplier": {
+		"name": "Nordlys Software ApS",
+		"tax_id": {
+			"country": "DK",
+			"code": "16356700"
+		},
+		"identities": [
+			{
+				"scope": "legal",
+				"code": "16356700"
+			}
+		],
+		"endpoints": [
+			{
+				"uri": "DK:CVR:16356700"
+			}
+		],
+		"addresses": [
+			{
+				"num": "24",
+				"street": "Vesterbrogade",
+				"locality": "København V",
+				"code": "1620",
+				"country": "DK"
+			}
+		],
+		"emails": [
+			{
+				"addr": "faktura@nordlys.dk"
+			}
+		]
+	},
+	"customer": {
+		"name": "Fjellvann Utstyr AS",
+		"tax_id": {
+			"country": "NO",
+			"code": "987654325MVA"
+		},
+		"endpoints": [
+			{
+				"uri": "GLN:7080000000000"
+			}
+		],
+		"addresses": [
+			{
+				"num": "7",
+				"street": "Storgata",
+				"locality": "Oslo",
+				"code": "0155",
+				"country": "NO"
+			}
+		]
+	},
+	"lines": [
+		{
+			"i": 1,
+			"quantity": "40",
+			"item": {
+				"name": "Industrial valves",
+				"price": "320.00",
+				"unit": "item"
+			},
+			"sum": "12800.00",
+			"taxes": [
+				{
+					"cat": "VAT",
+					"key": "export",
+					"ext": {
+						"cef-vatex": "VATEX-EU-G"
+					}
+				}
+			],
+			"total": "12800.00"
+		}
+	],
+	"payment": {
+		"terms": {
+			"due_dates": [
+				{
+					"date": "2026-08-31",
+					"amount": "12800.00",
+					"percent": "100%"
+				}
+			]
+		},
+		"instructions": {
+			"key": "credit-transfer+sepa",
+			"credit_transfer": [
+				{
+					"iban": "DK5000400440116243"
+				}
+			],
+			"ext": {
+				"untdid-payment-means": "58"
+			}
+		}
+	},
+	"totals": {
+		"sum": "12800.00",
+		"total": "12800.00",
+		"taxes": {
+			"categories": [
+				{
+					"code": "VAT",
+					"rates": [
+						{
+							"key": "export",
+							"ext": {
+								"cef-vatex": "VATEX-EU-G"
+							},
+							"base": "12800.00",
+							"amount": "0.00"
+						}
+					],
+					"amount": "0.00"
+				}
+			],
+			"sum": "0.00"
+		},
+		"tax": "0.00",
+		"total_with_tax": "12800.00",
+		"payable": "12800.00"
+	}
+}
+```

--- a/snippets/invoices/dk/export.min.mdx
+++ b/snippets/invoices/dk/export.min.mdx
@@ -1,0 +1,91 @@
+```json Denmark export invoice
+{
+  "$schema": "https://gobl.org/draft-0/bill/invoice",
+  "$addons": [
+    "dk-oioubl-v2"
+  ],
+  "type": "standard",
+  "series": "SAMPLE",
+  "code": "0048",
+  "issue_date": "2026-08-01",
+  "currency": "DKK",
+  "supplier": {
+    "name": "Nordlys Software ApS",
+    "tax_id": {
+      "country": "DK",
+      "code": "16356700"
+    },
+    "addresses": [
+      {
+        "num": "24",
+        "street": "Vesterbrogade",
+        "locality": "København V",
+        "code": "1620",
+        "country": "DK"
+      }
+    ],
+    "emails": [
+      {
+        "addr": "faktura@nordlys.dk"
+      }
+    ]
+  },
+  "customer": {
+    "name": "Fjellvann Utstyr AS",
+    "tax_id": {
+      "country": "NO",
+      "code": "987654325"
+    },
+    "endpoints": [
+      {
+        "uri": "GLN:7080000000000"
+      }
+    ],
+    "addresses": [
+      {
+        "num": "7",
+        "street": "Storgata",
+        "locality": "Oslo",
+        "code": "0155",
+        "country": "NO"
+      }
+    ]
+  },
+  "lines": [
+    {
+      "quantity": 40,
+      "item": {
+        "name": "Industrial valves",
+        "price": "320.00",
+        "unit": "item"
+      },
+      "taxes": [
+        {
+          "cat": "VAT",
+          "key": "export",
+          "ext": {
+            "cef-vatex": "VATEX-EU-G"
+          }
+        }
+      ]
+    }
+  ],
+  "payment": {
+    "terms": {
+      "due_dates": [
+        {
+          "date": "2026-08-31",
+          "percent": "100%"
+        }
+      ]
+    },
+    "instructions": {
+      "key": "credit-transfer+sepa",
+      "credit_transfer": [
+        {
+          "iban": "DK5000400440116243"
+        }
+      ]
+    }
+  }
+}```

--- a/snippets/invoices/dk/intra-community.mdx
+++ b/snippets/invoices/dk/intra-community.mdx
@@ -1,0 +1,144 @@
+```json Built version
+{
+	"$schema": "https://gobl.org/draft-0/bill/invoice",
+	"$regime": "DK",
+	"$addons": [
+		"eu-en16931-v2017",
+		"dk-oioubl-v2"
+	],
+	"type": "standard",
+	"series": "SAMPLE",
+	"code": "0047",
+	"issue_date": "2026-08-01",
+	"currency": "DKK",
+	"tax": {
+		"rounding": "currency",
+		"ext": {
+			"untdid-document-type": "380"
+		}
+	},
+	"supplier": {
+		"name": "Nordlys Software ApS",
+		"tax_id": {
+			"country": "DK",
+			"code": "16356700"
+		},
+		"identities": [
+			{
+				"scope": "legal",
+				"code": "16356700"
+			}
+		],
+		"endpoints": [
+			{
+				"uri": "DK:CVR:16356700"
+			}
+		],
+		"addresses": [
+			{
+				"num": "24",
+				"street": "Vesterbrogade",
+				"locality": "København V",
+				"code": "1620",
+				"country": "DK"
+			}
+		],
+		"emails": [
+			{
+				"addr": "faktura@nordlys.dk"
+			}
+		]
+	},
+	"customer": {
+		"name": "Rheinwerk Handel GmbH",
+		"tax_id": {
+			"country": "DE",
+			"code": "111111125"
+		},
+		"endpoints": [
+			{
+				"uri": "GLN:4304984000008"
+			}
+		],
+		"addresses": [
+			{
+				"num": "18",
+				"street": "Speditionstraße",
+				"locality": "Düsseldorf",
+				"code": "40221",
+				"country": "DE"
+			}
+		]
+	},
+	"lines": [
+		{
+			"i": 1,
+			"quantity": "40",
+			"item": {
+				"name": "Industrial valves",
+				"price": "320.00",
+				"unit": "item"
+			},
+			"sum": "12800.00",
+			"taxes": [
+				{
+					"cat": "VAT",
+					"key": "intra-community",
+					"ext": {
+						"cef-vatex": "VATEX-EU-IC"
+					}
+				}
+			],
+			"total": "12800.00"
+		}
+	],
+	"payment": {
+		"terms": {
+			"due_dates": [
+				{
+					"date": "2026-08-31",
+					"amount": "12800.00",
+					"percent": "100%"
+				}
+			]
+		},
+		"instructions": {
+			"key": "credit-transfer+sepa",
+			"credit_transfer": [
+				{
+					"iban": "DK5000400440116243"
+				}
+			],
+			"ext": {
+				"untdid-payment-means": "58"
+			}
+		}
+	},
+	"totals": {
+		"sum": "12800.00",
+		"total": "12800.00",
+		"taxes": {
+			"categories": [
+				{
+					"code": "VAT",
+					"rates": [
+						{
+							"key": "intra-community",
+							"ext": {
+								"cef-vatex": "VATEX-EU-IC"
+							},
+							"base": "12800.00",
+							"amount": "0.00"
+						}
+					],
+					"amount": "0.00"
+				}
+			],
+			"sum": "0.00"
+		},
+		"tax": "0.00",
+		"total_with_tax": "12800.00",
+		"payable": "12800.00"
+	}
+}
+```

--- a/snippets/invoices/dk/intra-community.min.mdx
+++ b/snippets/invoices/dk/intra-community.min.mdx
@@ -1,0 +1,91 @@
+```json Denmark intra-community invoice
+{
+  "$schema": "https://gobl.org/draft-0/bill/invoice",
+  "$addons": [
+    "dk-oioubl-v2"
+  ],
+  "type": "standard",
+  "series": "SAMPLE",
+  "code": "0047",
+  "issue_date": "2026-08-01",
+  "currency": "DKK",
+  "supplier": {
+    "name": "Nordlys Software ApS",
+    "tax_id": {
+      "country": "DK",
+      "code": "16356700"
+    },
+    "addresses": [
+      {
+        "num": "24",
+        "street": "Vesterbrogade",
+        "locality": "København V",
+        "code": "1620",
+        "country": "DK"
+      }
+    ],
+    "emails": [
+      {
+        "addr": "faktura@nordlys.dk"
+      }
+    ]
+  },
+  "customer": {
+    "name": "Rheinwerk Handel GmbH",
+    "tax_id": {
+      "country": "DE",
+      "code": "111111125"
+    },
+    "endpoints": [
+      {
+        "uri": "GLN:4304984000008"
+      }
+    ],
+    "addresses": [
+      {
+        "num": "18",
+        "street": "Speditionstraße",
+        "locality": "Düsseldorf",
+        "code": "40221",
+        "country": "DE"
+      }
+    ]
+  },
+  "lines": [
+    {
+      "quantity": 40,
+      "item": {
+        "name": "Industrial valves",
+        "price": "320.00",
+        "unit": "item"
+      },
+      "taxes": [
+        {
+          "cat": "VAT",
+          "key": "intra-community",
+          "ext": {
+            "cef-vatex": "VATEX-EU-IC"
+          }
+        }
+      ]
+    }
+  ],
+  "payment": {
+    "terms": {
+      "due_dates": [
+        {
+          "date": "2026-08-31",
+          "percent": "100%"
+        }
+      ]
+    },
+    "instructions": {
+      "key": "credit-transfer+sepa",
+      "credit_transfer": [
+        {
+          "iban": "DK5000400440116243"
+        }
+      ]
+    }
+  }
+}```

--- a/snippets/invoices/dk/reverse-charge.mdx
+++ b/snippets/invoices/dk/reverse-charge.mdx
@@ -1,0 +1,150 @@
+```json Built version
+{
+	"$schema": "https://gobl.org/draft-0/bill/invoice",
+	"$regime": "DK",
+	"$addons": [
+		"eu-en16931-v2017",
+		"dk-oioubl-v2"
+	],
+	"type": "standard",
+	"series": "SAMPLE",
+	"code": "0046",
+	"issue_date": "2026-08-01",
+	"currency": "DKK",
+	"tax": {
+		"rounding": "currency",
+		"ext": {
+			"untdid-document-type": "380"
+		}
+	},
+	"supplier": {
+		"name": "Nordlys Software ApS",
+		"tax_id": {
+			"country": "DK",
+			"code": "16356700"
+		},
+		"identities": [
+			{
+				"scope": "legal",
+				"code": "16356700"
+			}
+		],
+		"endpoints": [
+			{
+				"uri": "DK:CVR:16356700"
+			}
+		],
+		"addresses": [
+			{
+				"num": "24",
+				"street": "Vesterbrogade",
+				"locality": "København V",
+				"code": "1620",
+				"country": "DK"
+			}
+		],
+		"emails": [
+			{
+				"addr": "faktura@nordlys.dk"
+			}
+		]
+	},
+	"customer": {
+		"name": "Havnens Byggemarked A/S",
+		"tax_id": {
+			"country": "DK",
+			"code": "12345674"
+		},
+		"identities": [
+			{
+				"scope": "legal",
+				"code": "12345674"
+			}
+		],
+		"endpoints": [
+			{
+				"uri": "DK:CVR:12345674"
+			}
+		],
+		"addresses": [
+			{
+				"num": "3",
+				"street": "Havnegade",
+				"locality": "Aarhus C",
+				"code": "8000",
+				"country": "DK"
+			}
+		]
+	},
+	"lines": [
+		{
+			"i": 1,
+			"quantity": "500",
+			"item": {
+				"name": "Copper scrap",
+				"price": "45.00",
+				"unit": "kg"
+			},
+			"sum": "22500.00",
+			"taxes": [
+				{
+					"cat": "VAT",
+					"key": "reverse-charge",
+					"ext": {
+						"cef-vatex": "VATEX-EU-AE"
+					}
+				}
+			],
+			"total": "22500.00"
+		}
+	],
+	"payment": {
+		"terms": {
+			"due_dates": [
+				{
+					"date": "2026-08-31",
+					"amount": "22500.00",
+					"percent": "100%"
+				}
+			]
+		},
+		"instructions": {
+			"key": "credit-transfer+sepa",
+			"credit_transfer": [
+				{
+					"iban": "DK5000400440116243"
+				}
+			],
+			"ext": {
+				"untdid-payment-means": "58"
+			}
+		}
+	},
+	"totals": {
+		"sum": "22500.00",
+		"total": "22500.00",
+		"taxes": {
+			"categories": [
+				{
+					"code": "VAT",
+					"rates": [
+						{
+							"key": "reverse-charge",
+							"ext": {
+								"cef-vatex": "VATEX-EU-AE"
+							},
+							"base": "22500.00",
+							"amount": "0.00"
+						}
+					],
+					"amount": "0.00"
+				}
+			],
+			"sum": "0.00"
+		},
+		"tax": "0.00",
+		"total_with_tax": "22500.00",
+		"payable": "22500.00"
+	}
+}
+```

--- a/snippets/invoices/dk/reverse-charge.min.mdx
+++ b/snippets/invoices/dk/reverse-charge.min.mdx
@@ -1,0 +1,86 @@
+```json Denmark reverse charge invoice
+{
+  "$schema": "https://gobl.org/draft-0/bill/invoice",
+  "$addons": [
+    "dk-oioubl-v2"
+  ],
+  "type": "standard",
+  "series": "SAMPLE",
+  "code": "0046",
+  "issue_date": "2026-08-01",
+  "currency": "DKK",
+  "supplier": {
+    "name": "Nordlys Software ApS",
+    "tax_id": {
+      "country": "DK",
+      "code": "16356700"
+    },
+    "addresses": [
+      {
+        "num": "24",
+        "street": "Vesterbrogade",
+        "locality": "København V",
+        "code": "1620",
+        "country": "DK"
+      }
+    ],
+    "emails": [
+      {
+        "addr": "faktura@nordlys.dk"
+      }
+    ]
+  },
+  "customer": {
+    "name": "Havnens Byggemarked A/S",
+    "tax_id": {
+      "country": "DK",
+      "code": "12345674"
+    },
+    "addresses": [
+      {
+        "num": "3",
+        "street": "Havnegade",
+        "locality": "Aarhus C",
+        "code": "8000",
+        "country": "DK"
+      }
+    ]
+  },
+  "lines": [
+    {
+      "quantity": 500,
+      "item": {
+        "name": "Copper scrap",
+        "price": "45.00",
+        "unit": "kg"
+      },
+      "taxes": [
+        {
+          "cat": "VAT",
+          "key": "reverse-charge",
+          "ext": {
+            "cef-vatex": "VATEX-EU-AE"
+          }
+        }
+      ]
+    }
+  ],
+  "payment": {
+    "terms": {
+      "due_dates": [
+        {
+          "date": "2026-08-31",
+          "percent": "100%"
+        }
+      ]
+    },
+    "instructions": {
+      "key": "credit-transfer+sepa",
+      "credit_transfer": [
+        {
+          "iban": "DK5000400440116243"
+        }
+      ]
+    }
+  }
+}```

--- a/snippets/invoices/dk/zero-rate.mdx
+++ b/snippets/invoices/dk/zero-rate.mdx
@@ -1,0 +1,146 @@
+```json Built version
+{
+	"$schema": "https://gobl.org/draft-0/bill/invoice",
+	"$regime": "DK",
+	"$addons": [
+		"eu-en16931-v2017",
+		"dk-oioubl-v2"
+	],
+	"type": "standard",
+	"series": "SAMPLE",
+	"code": "0045",
+	"issue_date": "2026-08-01",
+	"currency": "DKK",
+	"tax": {
+		"rounding": "currency",
+		"ext": {
+			"untdid-document-type": "380"
+		}
+	},
+	"supplier": {
+		"name": "Nordlys Software ApS",
+		"tax_id": {
+			"country": "DK",
+			"code": "16356700"
+		},
+		"identities": [
+			{
+				"scope": "legal",
+				"code": "16356700"
+			}
+		],
+		"endpoints": [
+			{
+				"uri": "DK:CVR:16356700"
+			}
+		],
+		"addresses": [
+			{
+				"num": "24",
+				"street": "Vesterbrogade",
+				"locality": "København V",
+				"code": "1620",
+				"country": "DK"
+			}
+		],
+		"emails": [
+			{
+				"addr": "faktura@nordlys.dk"
+			}
+		]
+	},
+	"customer": {
+		"name": "Havnens Byggemarked A/S",
+		"tax_id": {
+			"country": "DK",
+			"code": "12345674"
+		},
+		"identities": [
+			{
+				"scope": "legal",
+				"code": "12345674"
+			}
+		],
+		"endpoints": [
+			{
+				"uri": "DK:CVR:12345674"
+			}
+		],
+		"addresses": [
+			{
+				"num": "3",
+				"street": "Havnegade",
+				"locality": "Aarhus C",
+				"code": "8000",
+				"country": "DK"
+			}
+		]
+	},
+	"lines": [
+		{
+			"i": 1,
+			"quantity": "250",
+			"item": {
+				"name": "Morgenavisen daily newspaper",
+				"price": "12.00",
+				"unit": "item"
+			},
+			"sum": "3000.00",
+			"taxes": [
+				{
+					"cat": "VAT",
+					"key": "zero",
+					"percent": "0%"
+				}
+			],
+			"total": "3000.00"
+		}
+	],
+	"payment": {
+		"terms": {
+			"due_dates": [
+				{
+					"date": "2026-08-31",
+					"amount": "3000.00",
+					"percent": "100%"
+				}
+			]
+		},
+		"instructions": {
+			"key": "credit-transfer+sepa",
+			"credit_transfer": [
+				{
+					"iban": "DK5000400440116243"
+				}
+			],
+			"ext": {
+				"untdid-payment-means": "58"
+			}
+		}
+	},
+	"totals": {
+		"sum": "3000.00",
+		"total": "3000.00",
+		"taxes": {
+			"categories": [
+				{
+					"code": "VAT",
+					"rates": [
+						{
+							"key": "zero",
+							"base": "3000.00",
+							"percent": "0%",
+							"amount": "0.00"
+						}
+					],
+					"amount": "0.00"
+				}
+			],
+			"sum": "0.00"
+		},
+		"tax": "0.00",
+		"total_with_tax": "3000.00",
+		"payable": "3000.00"
+	}
+}
+```

--- a/snippets/invoices/dk/zero-rate.min.mdx
+++ b/snippets/invoices/dk/zero-rate.min.mdx
@@ -1,0 +1,83 @@
+```json Denmark zero rate invoice
+{
+  "$schema": "https://gobl.org/draft-0/bill/invoice",
+  "$addons": [
+    "dk-oioubl-v2"
+  ],
+  "type": "standard",
+  "series": "SAMPLE",
+  "code": "0045",
+  "issue_date": "2026-08-01",
+  "currency": "DKK",
+  "supplier": {
+    "name": "Nordlys Software ApS",
+    "tax_id": {
+      "country": "DK",
+      "code": "16356700"
+    },
+    "addresses": [
+      {
+        "num": "24",
+        "street": "Vesterbrogade",
+        "locality": "København V",
+        "code": "1620",
+        "country": "DK"
+      }
+    ],
+    "emails": [
+      {
+        "addr": "faktura@nordlys.dk"
+      }
+    ]
+  },
+  "customer": {
+    "name": "Havnens Byggemarked A/S",
+    "tax_id": {
+      "country": "DK",
+      "code": "12345674"
+    },
+    "addresses": [
+      {
+        "num": "3",
+        "street": "Havnegade",
+        "locality": "Aarhus C",
+        "code": "8000",
+        "country": "DK"
+      }
+    ]
+  },
+  "lines": [
+    {
+      "quantity": 250,
+      "item": {
+        "name": "Morgenavisen daily newspaper",
+        "price": "12.00",
+        "unit": "item"
+      },
+      "taxes": [
+        {
+          "cat": "VAT",
+          "key": "zero"
+        }
+      ]
+    }
+  ],
+  "payment": {
+    "terms": {
+      "due_dates": [
+        {
+          "date": "2026-08-31",
+          "percent": "100%"
+        }
+      ]
+    },
+    "instructions": {
+      "key": "credit-transfer+sepa",
+      "credit_transfer": [
+        {
+          "iban": "DK5000400440116243"
+        }
+      ]
+    }
+  }
+}```

--- a/snippets/parties/dk/customer.mdx
+++ b/snippets/parties/dk/customer.mdx
@@ -1,0 +1,25 @@
+```json Denmark customer example expandable
+{
+    "$schema": "https://gobl.org/draft-0/org/party",
+    "name": "Den Lille Skole",
+    "endpoints": [
+        {
+            "uri": "GLN:5798009883735"
+        }
+    ],
+    "addresses": [
+        {
+            "num": "10",
+            "street": "Fredericiavej",
+            "locality": "Helsingør",
+            "code": "3000",
+            "country": "DK"
+        }
+    ],
+    "emails": [
+        {
+            "addr": "faktura@dls.dk"
+        }
+    ]
+}
+```

--- a/snippets/parties/dk/supplier.mdx
+++ b/snippets/parties/dk/supplier.mdx
@@ -1,0 +1,33 @@
+```json Denmark supplier example expandable
+{
+    "$schema": "https://gobl.org/draft-0/org/party",
+    "name": "Nordlys Software ApS",
+    "tax_id": {
+        "country": "DK",
+        "code": "16356700"
+    },
+    "people": [
+        {
+            "name": {
+                "given": "Mette",
+                "surname": "Kristensen"
+            },
+            "role": "Director"
+        }
+    ],
+    "addresses": [
+        {
+            "num": "24",
+            "street": "Vesterbrogade",
+            "locality": "København V",
+            "code": "1620",
+            "country": "DK"
+        }
+    ],
+    "emails": [
+        {
+            "addr": "faktura@nordlys.dk"
+        }
+    ]
+}
+```

--- a/snippets/tables/denmark-resources.mdx
+++ b/snippets/tables/denmark-resources.mdx
@@ -3,10 +3,10 @@
 |            |                                                                                                                                                       |
 | ---------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Compliance | <Icon icon="https://assets.invopop.com/flags/dk.svg" /> [Invoicing compliance in Denmark](/compliance/denmark)<br /> <Icon icon="timeline" /> [Compliance timeline](/timelines/denmark) |
-| Apps       | <Icon icon="https://assets.invopop.com/apps/peppol/icon.svg" /> [Peppol](/apps/peppol)                                                               |
-| Guides     | <Icon icon="book" /> [Peppol guide](/guides/peppol)<br /> <Icon icon="book" /> [Chargebee guide](/guides/cb-denmark)                           |
+| Apps       | <Icon icon="https://assets.invopop.com/flags/dk.svg" /> [Denmark](/apps/denmark)<br /> <Icon icon="https://assets.invopop.com/apps/peppol/icon.svg" /> [Peppol](/apps/peppol) |
+| Guides     | <Icon icon="book" /> [Supplier registration guide](/guides/dk-nemhandel-supplier)<br /> <Icon icon="book" /> [Issuing invoices guide](/guides/dk-nemhandel)<br /> <Icon icon="book" /> [Receiving invoices guide](/guides/dk-nemhandel-receiving)<br /> <Icon icon="book" /> [Peppol guide](/guides/peppol)<br /> <Icon icon="book" /> [Chargebee guide](/guides/cb-denmark) |
 | FAQ        | <Icon icon="square-question" /> [Denmark FAQ](/faq/denmark)                                                                                           |
-| GOBL       | <Icon icon="https://assets.invopop.com/icons/gobl.svg" /> [EU EN 16931 Addon](https://docs.gobl.org/addons/eu-en16931-v2017)                          |
-| GitHub     | <Icon icon="github" /> [gobl.ubl](https://github.com/invopop/gobl.ubl)                                                                               |
+| GOBL       | <Icon icon="https://assets.invopop.com/icons/gobl.svg" /> [Danish OIOUBL 2.1 Addon](https://docs.gobl.org/addons/dk-oioubl-v2)<br /> <Icon icon="https://assets.invopop.com/icons/gobl.svg" /> [Denmark Tax Regime](https://docs.gobl.org/regimes/dk)<br /> <Icon icon="https://assets.invopop.com/icons/gobl.svg" /> [EU EN 16931 Addon](https://docs.gobl.org/addons/eu-en16931-v2017) |
+| GitHub     | <Icon icon="github" /> [gobl.dk.oioubl](https://github.com/invopop/gobl.dk.oioubl)<br /> <Icon icon="github" /> [gobl.ubl](https://github.com/invopop/gobl.ubl)                                                                               |
   </Accordion>
 </AccordionGroup>

--- a/snippets/workflows/dk/nemhandel-import-data.mdx
+++ b/snippets/workflows/dk/nemhandel-import-data.mdx
@@ -1,0 +1,33 @@
+export const dkNemhandelImportWorkflow = {
+    "name": "Import NemHandel invoice",
+    "description": "Import a received OIOUBL document delivered via NemHandel",
+    "schema": "bill/invoice",
+    "steps": [
+        {
+            "id": "a1c0f2df-4f6a-11f1-9c2d-0242ac120010",
+            "name": "Load from NemHandel",
+            "provider": "gov-dk.import",
+            "summary": "Fetches, parses OIOUBL, and converts to GOBL in one step"
+        },
+        {
+            "id": "a1c0f2e2-4f6a-11f1-9c2d-0242ac120010",
+            "name": "Set State",
+            "provider": "silo.state",
+            "summary": "Set state to `received`{.state .received}",
+            "config": {
+                "state": "received"
+            }
+        }
+    ],
+    "rescue": [
+        {
+            "id": "a1c0f2e3-4f6a-11f1-9c2d-0242ac120010",
+            "name": "Set State",
+            "provider": "silo.state",
+            "summary": "Set state to `error`{.state .error}",
+            "config": {
+                "state": "error"
+            }
+        }
+    ]
+};

--- a/snippets/workflows/dk/nemhandel-import.mdx
+++ b/snippets/workflows/dk/nemhandel-import.mdx
@@ -1,0 +1,43 @@
+---
+title: "Import NemHandel invoice"
+description: "Import a received OIOUBL document delivered via NemHandel"
+countryCode: "dk"
+appId: "gov-dk"
+schema: "bill/invoice"
+---
+
+```json Example Import NemHandel invoice workflow
+{
+    "name": "Import NemHandel invoice",
+    "description": "Import a received OIOUBL document delivered via NemHandel",
+    "schema": "bill/invoice",
+    "steps": [
+        {
+            "id": "a1c0f2df-4f6a-11f1-9c2d-0242ac120010",
+            "name": "Load from NemHandel",
+            "provider": "gov-dk.import",
+            "summary": "Fetches, parses OIOUBL, and converts to GOBL in one step"
+        },
+        {
+            "id": "a1c0f2e2-4f6a-11f1-9c2d-0242ac120010",
+            "name": "Set State",
+            "provider": "silo.state",
+            "summary": "Set state to `received`{.state .received}",
+            "config": {
+                "state": "received"
+            }
+        }
+    ],
+    "rescue": [
+        {
+            "id": "a1c0f2e3-4f6a-11f1-9c2d-0242ac120010",
+            "name": "Set State",
+            "provider": "silo.state",
+            "summary": "Set state to `error`{.state .error}",
+            "config": {
+                "state": "error"
+            }
+        }
+    ]
+}
+```

--- a/snippets/workflows/dk/nemhandel-register-data.mdx
+++ b/snippets/workflows/dk/nemhandel-register-data.mdx
@@ -1,0 +1,41 @@
+export const dkNemhandelRegisterWorkflow = {
+    "name": "Register on NemHandel",
+    "description": "",
+    "schema": "org/party",
+    "steps": [
+        {
+            "id": "c3e2b400-4f6a-11f1-9c2d-0242ac120012",
+            "name": "Set State",
+            "provider": "silo.state",
+            "summary": "Set state to `processing`{.state .processing}",
+            "config": {
+                "state": "processing"
+            }
+        },
+        {
+            "id": "e3af78f6-88d1-11f1-8000-920007eb4d91",
+            "name": "Sign NemHandel Agreement",
+            "provider": "gov-dk.sign"
+        },
+        {
+            "id": "e3af9d5e-88d1-11f1-8000-920007eb4d91",
+            "name": "Wait for NemHandel Agreement",
+            "provider": "gov-dk.wait.approval"
+        },
+        {
+            "id": "c3e2b401-4f6a-11f1-9c2d-0242ac120012",
+            "name": "Register on NemHandel",
+            "provider": "gov-dk.register"
+        },
+        {
+            "id": "c3e2b402-4f6a-11f1-9c2d-0242ac120012",
+            "name": "Set State",
+            "provider": "silo.state",
+            "summary": "Set state to `registered`{.state .registered}",
+            "config": {
+                "state": "registered"
+            }
+        }
+    ],
+    "rescue": []
+};

--- a/snippets/workflows/dk/nemhandel-register.mdx
+++ b/snippets/workflows/dk/nemhandel-register.mdx
@@ -1,0 +1,51 @@
+---
+title: "Register on NemHandel"
+description: "Register a party to send and receive invoices via NemHandel"
+countryCode: "dk"
+appId: "gov-dk"
+schema: "org/party"
+---
+
+```json Example Register on NemHandel workflow
+{
+    "name": "Register on NemHandel",
+    "description": "",
+    "schema": "org/party",
+    "steps": [
+        {
+            "id": "c3e2b400-4f6a-11f1-9c2d-0242ac120012",
+            "name": "Set State",
+            "provider": "silo.state",
+            "summary": "Set state to `processing`{.state .processing}",
+            "config": {
+                "state": "processing"
+            }
+        },
+        {
+            "id": "e3af78f6-88d1-11f1-8000-920007eb4d91",
+            "name": "Sign NemHandel Agreement",
+            "provider": "gov-dk.sign"
+        },
+        {
+            "id": "e3af9d5e-88d1-11f1-8000-920007eb4d91",
+            "name": "Wait for NemHandel Agreement",
+            "provider": "gov-dk.wait.approval"
+        },
+        {
+            "id": "c3e2b401-4f6a-11f1-9c2d-0242ac120012",
+            "name": "Register on NemHandel",
+            "provider": "gov-dk.register"
+        },
+        {
+            "id": "c3e2b402-4f6a-11f1-9c2d-0242ac120012",
+            "name": "Set State",
+            "provider": "silo.state",
+            "summary": "Set state to `registered`{.state .registered}",
+            "config": {
+                "state": "registered"
+            }
+        }
+    ],
+    "rescue": []
+}
+```

--- a/snippets/workflows/dk/nemhandel-send-invoice-data.mdx
+++ b/snippets/workflows/dk/nemhandel-send-invoice-data.mdx
@@ -1,0 +1,64 @@
+export const dkNemhandelSendInvoiceWorkflow = {
+    "name": "Send NemHandel invoice",
+    "description": "Convert an invoice to OIOUBL and send it over the NemHandel network",
+    "schema": "bill/invoice",
+    "steps": [
+        {
+            "id": "e3ad87b2-88d1-11f1-8000-920007eb4d91",
+            "name": "Set State",
+            "provider": "silo.state",
+            "summary": "Set state to `processing`{.state .processing}",
+            "config": {
+                "state": "processing"
+            }
+        },
+        {
+            "id": "e3add26c-88d1-11f1-8000-920007eb4d91",
+            "name": "Add Sequential Code",
+            "provider": "sequence.enumerate",
+            "summary": "Dynamic · NemHandel · 000001",
+            "config": {
+                "name": "NemHandel",
+                "padding": 6,
+                "start": 1
+            }
+        },
+        {
+            "id": "e3ae403a-88d1-11f1-8000-920007eb4d91",
+            "name": "Sign Envelope",
+            "provider": "silo.close"
+        },
+        {
+            "id": "e3afc3a6-88d1-11f1-8000-920007eb4d91",
+            "name": "Generate OIOUBL",
+            "provider": "gov-dk.convert",
+            "summary": "OIOUBL 2.1 Invoice/CreditNote"
+        },
+        {
+            "id": "e3aea606-88d1-11f1-8000-920007eb4d91",
+            "name": "Send to NemHandel",
+            "provider": "gov-dk.send",
+            "summary": "Submits and queues until eCourier confirms delivery"
+        },
+        {
+            "id": "e3af29be-88d1-11f1-8000-920007eb4d91",
+            "name": "Set State",
+            "provider": "silo.state",
+            "summary": "Set state to `sent`{.state .sent}",
+            "config": {
+                "state": "sent"
+            }
+        }
+    ],
+    "rescue": [
+        {
+            "id": "e3af4e58-88d1-11f1-8000-920007eb4d91",
+            "name": "Set State",
+            "provider": "silo.state",
+            "summary": "Set state to `error`{.state .error}",
+            "config": {
+                "state": "error"
+            }
+        }
+    ]
+};

--- a/snippets/workflows/dk/nemhandel-send-invoice.mdx
+++ b/snippets/workflows/dk/nemhandel-send-invoice.mdx
@@ -1,0 +1,74 @@
+---
+title: "Send NemHandel invoice"
+description: "Convert an invoice to OIOUBL and send it over the NemHandel network"
+countryCode: "dk"
+appId: "gov-dk"
+schema: "bill/invoice"
+---
+
+```json Example Send NemHandel invoice workflow
+{
+    "name": "Send NemHandel invoice",
+    "description": "Convert an invoice to OIOUBL and send it over the NemHandel network",
+    "schema": "bill/invoice",
+    "steps": [
+        {
+            "id": "e3ad87b2-88d1-11f1-8000-920007eb4d91",
+            "name": "Set State",
+            "provider": "silo.state",
+            "summary": "Set state to `processing`{.state .processing}",
+            "config": {
+                "state": "processing"
+            }
+        },
+        {
+            "id": "e3add26c-88d1-11f1-8000-920007eb4d91",
+            "name": "Add Sequential Code",
+            "provider": "sequence.enumerate",
+            "summary": "Dynamic · NemHandel · 000001",
+            "config": {
+                "name": "NemHandel",
+                "padding": 6,
+                "start": 1
+            }
+        },
+        {
+            "id": "e3ae403a-88d1-11f1-8000-920007eb4d91",
+            "name": "Sign Envelope",
+            "provider": "silo.close"
+        },
+        {
+            "id": "e3afc3a6-88d1-11f1-8000-920007eb4d91",
+            "name": "Generate OIOUBL",
+            "provider": "gov-dk.convert",
+            "summary": "OIOUBL 2.1 Invoice/CreditNote"
+        },
+        {
+            "id": "e3aea606-88d1-11f1-8000-920007eb4d91",
+            "name": "Send to NemHandel",
+            "provider": "gov-dk.send",
+            "summary": "Submits and queues until eCourier confirms delivery"
+        },
+        {
+            "id": "e3af29be-88d1-11f1-8000-920007eb4d91",
+            "name": "Set State",
+            "provider": "silo.state",
+            "summary": "Set state to `sent`{.state .sent}",
+            "config": {
+                "state": "sent"
+            }
+        }
+    ],
+    "rescue": [
+        {
+            "id": "e3af4e58-88d1-11f1-8000-920007eb4d91",
+            "name": "Set State",
+            "provider": "silo.state",
+            "summary": "Set state to `error`{.state .error}",
+            "config": {
+                "state": "error"
+            }
+        }
+    ]
+}
+```

--- a/snippets/workflows/dk/nemhandel-unregister-data.mdx
+++ b/snippets/workflows/dk/nemhandel-unregister-data.mdx
@@ -1,0 +1,41 @@
+export const dkNemhandelUnregisterWorkflow = {
+    "name": "Unregister from NemHandel",
+    "description": "Release a party's NemHandel registration so it no longer sends or receives",
+    "schema": "org/party",
+    "steps": [
+        {
+            "id": "b0ebea5e-8907-11f1-8000-920007eb4d91",
+            "name": "Set State",
+            "provider": "silo.state",
+            "summary": "Set state to `processing`{.state .processing}",
+            "config": {
+                "state": "processing"
+            }
+        },
+        {
+            "id": "b0ec50f2-8907-11f1-8000-920007eb4d91",
+            "name": "Unregister from NemHandel",
+            "provider": "gov-dk.unregister"
+        },
+        {
+            "id": "b0ecc1fe-8907-11f1-8000-920007eb4d91",
+            "name": "Set State",
+            "provider": "silo.state",
+            "summary": "Set state to `void`{.state .void}",
+            "config": {
+                "state": "void"
+            }
+        }
+    ],
+    "rescue": [
+        {
+            "id": "b0ed13f2-8907-11f1-8000-920007eb4d91",
+            "name": "Set State",
+            "provider": "silo.state",
+            "summary": "Set state to `error`{.state .error}",
+            "config": {
+                "state": "error"
+            }
+        }
+    ]
+};

--- a/snippets/workflows/dk/nemhandel-unregister.mdx
+++ b/snippets/workflows/dk/nemhandel-unregister.mdx
@@ -1,0 +1,51 @@
+---
+title: "Unregister from NemHandel"
+description: "Release a party's NemHandel registration so it no longer sends or receives"
+countryCode: "dk"
+appId: "gov-dk"
+schema: "org/party"
+---
+
+```json Example Unregister from NemHandel workflow
+{
+    "name": "Unregister from NemHandel",
+    "description": "Release a party's NemHandel registration so it no longer sends or receives",
+    "schema": "org/party",
+    "steps": [
+        {
+            "id": "b0ebea5e-8907-11f1-8000-920007eb4d91",
+            "name": "Set State",
+            "provider": "silo.state",
+            "summary": "Set state to `processing`{.state .processing}",
+            "config": {
+                "state": "processing"
+            }
+        },
+        {
+            "id": "b0ec50f2-8907-11f1-8000-920007eb4d91",
+            "name": "Unregister from NemHandel",
+            "provider": "gov-dk.unregister"
+        },
+        {
+            "id": "b0ecc1fe-8907-11f1-8000-920007eb4d91",
+            "name": "Set State",
+            "provider": "silo.state",
+            "summary": "Set state to `void`{.state .void}",
+            "config": {
+                "state": "void"
+            }
+        }
+    ],
+    "rescue": [
+        {
+            "id": "b0ed13f2-8907-11f1-8000-920007eb4d91",
+            "name": "Set State",
+            "provider": "silo.state",
+            "summary": "Set state to `error`{.state .error}",
+            "config": {
+                "state": "error"
+            }
+        }
+    ]
+}
+```


### PR DESCRIPTION
Prepares the docs for the Denmark release: the `gov-dk` app registers parties on the **NemHandel** network through Invopop's partner eCourier, converts GOBL ↔ **OIOUBL 2.1** in both directions, and delivers and imports documents over the network.

## What's included

**Guides** (new Denmark group in the Guides tab, supplier → issuing → receiving):
- `guides/dk-nemhandel-supplier.mdx` — registration built around the authorisation-agreement signing flow (hosted wizard + API endpoints for integrators), plus unregistration.
- `guides/dk-nemhandel.mdx` — issuing: convert (schematron-validated) → send (completes on confirmed delivery, duplicates skipped).
- `guides/dk-nemhandel-receiving.mdx` — webhook-push reception into the app-configured import workflow.

**App page**: `apps/denmark.mdx` (country-umbrella archetype), carded in `apps/index.mdx`, registered in the Government group.

**Snippets**:
- `snippets/workflows/dk/` — four workflow pairs mirroring the **actual workspace workflows**, kept in sync with the templates in invopop/console#289; "Add to my workspace" cards use the `dk-send` / `dk-register` / `dk-unregister` / `dk-import` slugs those files produce.
- `snippets/invoices/dk/` — seven scenarios matching the European grid (standard B2G/B2B, zero rate, reverse charge, intra-community, export, credit note), each min + built pair calculated and validated against the real `dk-oioubl-v2` addon. Exempt/outside-scope are deliberately absent — OIOUBL has no such wire categories, and the zero-rate accordion explains that.
- `snippets/parties/dk/` — supplier (with the contact person the signing flow prefills) and a GLN-identified public-institution customer.

**FAQs**: new `nemhandel` regime leaves + composers per `skills/manage-faqs`; `faq/denmark.mdx` and `compliance/denmark.mdx` refactored onto composers; skill manifest/registry updated.

**Other wiring**: `docs.json`, `snippets/tables/denmark-resources.mdx`, compliance-page Invopop-support rows, `gov-dk` provider icon in `snippets/components/workflow.jsx`.

## For reviewers

- Content is grounded in the gov-dk README/domain code, including invopop/gov-dk#11 (unsupported inbound types acked + surfaced) — that PR and invopop/console#289 should land before/with this one.
- The API-signing section describes the two enrollment-authenticated endpoints without asserting a public hostname — worth a check that this matches how the service will be exposed.
- Validated with `mint broken-links` and cold-start `mint dev` (all new pages render, workflow diagrams and FAQ composers included).

🤖 Generated with [Claude Code](https://claude.com/claude-code)