### PR TITLE
Use the France flag icon on France app PA action cards

### DIFF
--- a/apps/france.mdx
+++ b/apps/france.mdx
@@ -77,62 +77,62 @@ import FAQ from '/snippets/faqs/fr/composers/app-pa.mdx';
 		The following workflow actions will be available once you install and enable this app.
 
 		Plateforme Agréée — registration
-		<Card title="Register in Annuaire" icon="https://assets.invopop.com/apps/peppol/icon.svg" horizontal>
+		<Card title="Register in Annuaire" icon="https://assets.invopop.com/flags/fr.svg" horizontal>
 			Register a party in the French Annuaire so they can issue and receive regulated e-invoices.
 		</Card>
-		<Card title="Register party on Peppol" icon="https://assets.invopop.com/apps/peppol/icon.svg" horizontal>
+		<Card title="Register party on Peppol" icon="https://assets.invopop.com/flags/fr.svg" horizontal>
 			Register the party on the Peppol network for transport.
 		</Card>
-		<Card title="Register reporter" icon="https://assets.invopop.com/apps/peppol/icon.svg" horizontal>
+		<Card title="Register reporter" icon="https://assets.invopop.com/flags/fr.svg" horizontal>
 			Enable the party for periodic e-reporting to the PPF.
 		</Card>
-		<Card title="Disable in Annuaire" icon="https://assets.invopop.com/apps/peppol/icon.svg" horizontal>
+		<Card title="Disable in Annuaire" icon="https://assets.invopop.com/flags/fr.svg" horizontal>
 			Remove a party's Annuaire registration.
 		</Card>
-		<Card title="Disable reporter" icon="https://assets.invopop.com/apps/peppol/icon.svg" horizontal>
+		<Card title="Disable reporter" icon="https://assets.invopop.com/flags/fr.svg" horizontal>
 			Disable a party's e-reporting registration.
 		</Card>
 
 		Plateforme Agréée — invoicing
-		<Card title="Record invoice" icon="https://assets.invopop.com/apps/peppol/icon.svg" horizontal>
+		<Card title="Record invoice" icon="https://assets.invopop.com/flags/fr.svg" horizontal>
 			<div class="pop-count"><Icon icon="https://assets.invopop.com/icons/pops.svg" /> 1</div>
 			Record the invoice in the directory ahead of transmission and PPF reporting.
 		</Card>
-		<Card title="Generate UBL document" icon="https://assets.invopop.com/apps/peppol/icon.svg" horizontal>
+		<Card title="Generate UBL document" icon="https://assets.invopop.com/flags/fr.svg" horizontal>
 			<div class="pop-count"><Icon icon="https://assets.invopop.com/icons/pops.svg" /> 1</div>
 			Generate a Peppol France CIUS UBL invoice or credit note from a GOBL document.
 		</Card>
-		<Card title="Generate CII document" icon="https://assets.invopop.com/apps/peppol/icon.svg" horizontal>
+		<Card title="Generate CII document" icon="https://assets.invopop.com/flags/fr.svg" horizontal>
 			Generate a UN/CEFACT CII XML document from a GOBL invoice.
 		</Card>
-		<Card title="Send Peppol document" icon="https://assets.invopop.com/apps/peppol/icon.svg" horizontal>
+		<Card title="Send Peppol document" icon="https://assets.invopop.com/flags/fr.svg" horizontal>
 			<div class="pop-count"><Icon icon="https://assets.invopop.com/icons/pops.svg" /> 1</div>
 			Send the generated document over the Peppol network to the buyer's PA.
 		</Card>
-		<Card title="Forward invoice to PPF" icon="https://assets.invopop.com/apps/peppol/icon.svg" horizontal>
+		<Card title="Forward invoice to PPF" icon="https://assets.invopop.com/flags/fr.svg" horizontal>
 			Forward the simplified F1 invoice to the PPF as the fifth corner.
 		</Card>
-		<Card title="Import Peppol document" icon="https://assets.invopop.com/apps/peppol/icon.svg" horizontal>
+		<Card title="Import Peppol document" icon="https://assets.invopop.com/flags/fr.svg" horizontal>
 			Import an inbound Peppol document into the workflow.
 		</Card>
-		<Card title="Import UBL document" icon="https://assets.invopop.com/apps/peppol/icon.svg" horizontal>
+		<Card title="Import UBL document" icon="https://assets.invopop.com/flags/fr.svg" horizontal>
 			Parse an inbound UBL document into a GOBL invoice.
 		</Card>
-		<Card title="Import CII document" icon="https://assets.invopop.com/apps/peppol/icon.svg" horizontal>
+		<Card title="Import CII document" icon="https://assets.invopop.com/flags/fr.svg" horizontal>
 			Parse an inbound UN/CEFACT CII document into a GOBL invoice.
 		</Card>
-		<Card title="Import Factur-X PDF" icon="https://assets.invopop.com/apps/peppol/icon.svg" horizontal>
+		<Card title="Import Factur-X PDF" icon="https://assets.invopop.com/flags/fr.svg" horizontal>
 			Extract the embedded CII XML from a Factur-X PDF/A-3 and parse it into GOBL.
 		</Card>
 
 		Plateforme Agréée — status
-		<Card title="Generate CDAR" icon="https://assets.invopop.com/apps/peppol/icon.svg" horizontal>
+		<Card title="Generate CDAR" icon="https://assets.invopop.com/flags/fr.svg" horizontal>
 			Build a Cross Domain Acknowledgement and Response document for lifecycle status updates.
 		</Card>
-		<Card title="Record status" icon="https://assets.invopop.com/apps/peppol/icon.svg" horizontal>
+		<Card title="Record status" icon="https://assets.invopop.com/flags/fr.svg" horizontal>
 			Persist a lifecycle status update in the directory.
 		</Card>
-		<Card title="Forward status to PPF" icon="https://assets.invopop.com/apps/peppol/icon.svg" horizontal>
+		<Card title="Forward status to PPF" icon="https://assets.invopop.com/flags/fr.svg" horizontal>
 			Forward a lifecycle status to the PPF for regulated flows.
 		</Card>
 	</Tab>


### PR DESCRIPTION
## What changed

All 17 Plateforme Agréée action cards in the Actions tab of `apps/france.mdx` (registration, invoicing, and status sections) were hardcoded to the Peppol app icon (`apps/peppol/icon.svg`). They now use the French flag (`flags/fr.svg`).

## Why

Country app action cards use the country flag by convention (see the Denmark app page), and the PA guide card at the top of the France page already uses the flag. The workflow diagrams were already correct — they resolve icons per provider (`gov-fr.*` → French flag, `peppol.*` → Peppol icon) — so only the static cards needed fixing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)