### PR TITLE
Document automatic Déposée transmission in the France invoicing guide

### DIFF
--- a/guides/fr-pa-invoicing.mdx
+++ b/guides/fr-pa-invoicing.mdx
@@ -31,7 +31,7 @@ These workflows are shared between invoice and [status documents](/guides/fr-pa-
 
 ### Sending
 
-The send workflow records the invoice for compliance, generates the chosen format, transmits it to the receiver’s PA over Peppol, and forwards the F1 copy to the PPF as the fifth corner.
+The send workflow records the invoice for compliance, generates the chosen format, transmits it to the receiver’s PA over Peppol, and forwards the F1 copy to the PPF. The mandatory `200` Déposée status is transmitted automatically alongside the F1: by default it reports the standard *déposée*, or *déposée – non transmise* when the forward step's **Deposited and not transmitted** toggle is enabled for recipients without an active receiving address.
 
 The **PPF record document** step validates SIRENs and checks both parties against the Annuaire. Documents where either side is missing are rejected and should branch into the [reporting flow](/guides/fr-pa-reporting)  for non-regulated transactions.
 


### PR DESCRIPTION
The sending section now mentions that the mandatory 200 Déposée status is transmitted automatically with the F1, and that the forward step's "Deposited and not transmitted" toggle switches it to déposée – non transmise for recipients without an active receiving address.

Notes:
- Documents the toggle added in invopop/gov-fr#115.

🤖 Generated with [Claude Code](https://claude.com/claude-code)