### PR TITLE
Show the PDF invoice examples as tiles

### DIFF
--- a/guides/pdf-invoice.mdx
+++ b/guides/pdf-invoice.mdx
@@ -273,43 +273,31 @@ Use the following example [GOBL Invoices](https://docs.gobl.org/draft-0/bill/inv
 
 ## Example PDF invoices
 
-<AccordionGroup>
-  <Accordion title="Complete invoice (en)">
-    <Frame caption="[View PDF](/assets/guides/pdf-full-invoice.pdf)">
-      <img src="/assets/guides/pdf-full-invoice.png" width="400" alt="Example PDF invoice Full invoice" />
-    </Frame>
-  </Accordion>
-  <Accordion title="Belgian invoice (fr)">
-    <Frame caption="[View PDF](/assets/guides/pdf-belgium-fr.pdf)">
-      <img src="/assets/guides/pdf-belgium-fr.png" width="400" alt="Example PDF invoice - Belgian invoice in French" />
-    </Frame>
-  </Accordion>
-    <Accordion title="Colombian invoice (es)">
-    <Frame caption="[View PDF](/assets/guides/pdf-colombia-es.pdf)">
-      <img src="/assets/guides/pdf-colombia-es.png" width="400" alt="Example PDF invoice - Colombian invoice in Spanish" />
-    </Frame>
-  </Accordion>
-      <Accordion title="Greek invoice (el)">
-    <Frame caption="[View PDF](/assets/guides/pdf-greece-gr.pdf)">
-      <img src="/assets/guides/pdf-greece-gr.png" width="400" alt="Example PDF invoice - Greek invoice in Greek" />
-    </Frame>
-  </Accordion>
-      <Accordion title="Mexican invoice (es)">
-    <Frame caption="[View PDF](/assets/guides/pdf-mexico-es.pdf)">
-      <img src="/assets/guides/pdf-mexico-es.png" width="400" alt="Example PDF invoice - Mexican invoice in Spanish" />
-    </Frame>
-  </Accordion>
-  <Accordion title="Spanish VERI*FACTU invoice (es)">
-    <Frame caption="[View PDF](/assets/guides/pdf-verifactu-es.pdf)">
-      <img src="/assets/guides/pdf-verifactu-es.png" width="400" alt="Example PDF invoice" />
-    </Frame>
-  </Accordion>
-    <Accordion title="Basque Country TicketBAI invoice (eu)">
-    <Frame caption="[View PDF](/assets/guides/pdf-tbai-eu.pdf)">
-      <img src="/assets/guides/pdf-tbai-eu.png" width="400" alt="Example PDF invoice" />
-    </Frame>
-  </Accordion>
-</AccordionGroup>
+Select an example to open the full PDF.
+
+<Columns cols={3}>
+  <Tile href="/assets/guides/pdf-full-invoice.pdf" title="Complete invoice (en)" description="Full invoice with every section, in English">
+    <img src="/assets/guides/pdf-full-invoice.png" alt="Example PDF invoice - complete invoice in English" />
+  </Tile>
+  <Tile href="/assets/guides/pdf-belgium-fr.pdf" title="Belgian invoice (fr)" description="Localised for Belgium in French">
+    <img src="/assets/guides/pdf-belgium-fr.png" alt="Example PDF invoice - Belgian invoice in French" />
+  </Tile>
+  <Tile href="/assets/guides/pdf-colombia-es.pdf" title="Colombian invoice (es)" description="Localised for Colombia in Spanish">
+    <img src="/assets/guides/pdf-colombia-es.png" alt="Example PDF invoice - Colombian invoice in Spanish" />
+  </Tile>
+  <Tile href="/assets/guides/pdf-greece-gr.pdf" title="Greek invoice (el)" description="Localised for Greece in Greek">
+    <img src="/assets/guides/pdf-greece-gr.png" alt="Example PDF invoice - Greek invoice in Greek" />
+  </Tile>
+  <Tile href="/assets/guides/pdf-mexico-es.pdf" title="Mexican invoice (es)" description="Localised for Mexico in Spanish">
+    <img src="/assets/guides/pdf-mexico-es.png" alt="Example PDF invoice - Mexican invoice in Spanish" />
+  </Tile>
+  <Tile href="/assets/guides/pdf-verifactu-es.pdf" title="Spanish VERI*FACTU invoice (es)" description="Includes the VERI*FACTU QR code and legend">
+    <img src="/assets/guides/pdf-verifactu-es.png" alt="Example PDF invoice - Spanish VERI*FACTU invoice in Spanish" />
+  </Tile>
+  <Tile href="/assets/guides/pdf-tbai-eu.pdf" title="Basque Country TicketBAI invoice (eu)" description="Includes the TicketBAI identifier and QR code">
+    <img src="/assets/guides/pdf-tbai-eu.png" alt="Example PDF invoice - Basque Country TicketBAI invoice in Basque" />
+  </Tile>
+</Columns>
 
 
 ## FAQ


### PR DESCRIPTION
The example gallery on the PDF guide hid each of the seven invoices behind an accordion, so comparing them meant opening one panel at a time.

Tiles show every preview at once and link straight to the PDF, replacing the per-accordion `<Frame caption="[View PDF](…)">` wrapper. Each tile keeps its previous title and gains a short description.

**Worth a look on the preview:** Mintlify's tile guidance assumes 16:9 or 4:3 landscape previews, and these invoice PNGs are portrait — so the preview area may crop or letterbox them. `cols={2}` is an easy fallback if it looks wrong.

🤖 Generated with [Claude Code](https://claude.com/claude-code)