### PR TITLE
Render the go-live screenshots at half their pixel size

### DIFF
--- a/guides/how-to-go-live.mdx
+++ b/guides/how-to-go-live.mdx
@@ -16,7 +16,7 @@ Have you set up your sandbox account and everything is working correctly? Time t
       <img
         src="/assets/guides/go-live-configure-org.png"
         alt="Configure Organization"
-        width="350"
+        width="348"
       />
     </Frame>
 
@@ -27,6 +27,7 @@ Have you set up your sandbox account and everything is working correctly? Time t
   	 <Frame caption="Create a Billing Account">
       <img
         src="/assets/guides/go-live-create-billing-account.png"
+        width="819"
         alt="Create a billing account"
       />
     </Frame>
@@ -36,7 +37,7 @@ Have you set up your sandbox account and everything is working correctly? Time t
     Fill your invoicing information and click on **Save**.
      <Frame caption="Create a Billing Account">
       <img
-        width="850"
+        width="857"
         src="/assets/guides/go-live-invoicing-information.png"
         alt="Add your invoicing information"
       />
@@ -55,7 +56,7 @@ Have you set up your sandbox account and everything is working correctly? Time t
 
   	 <Frame caption="Add a card on Stripe">
       <img
-        width="460"
+        width="466"
         src="/assets/guides/go-live-stripe.png"
         alt="Stripe screenshot"
       />
@@ -76,7 +77,7 @@ Have you set up your sandbox account and everything is working correctly? Time t
 
     <Frame caption="Build your subscription">
       <img
-        width="500"
+        width="834"
         src="/assets/guides/go-live-subscription.png"
         alt="Billing account subscription form"
       />
@@ -88,7 +89,7 @@ Have you set up your sandbox account and everything is working correctly? Time t
 			Once you introduce your payment details on Stripe you will return to the billing accounts screen. Click on **Workspaces** (in the side menu), then on *New workspace*. Assign a name, select the **Live** type and the billing account you just created. Click *Create workspace*.
   	 <Frame caption="Create your live workspace">
       <img
-        width="600"
+        width="836"
         src="/assets/guides/go-live-new-workspace.png"
         alt="Create your live workspace"
       />


### PR DESCRIPTION
The widths in the go-live guide were approximations of half the source size, so the screenshots were being resampled instead of displayed at 2x. Each is now set to exactly half its natural width, so they render crisply on retina displays.

| Screenshot | Natural | Was | Now |
| --- | --- | --- | --- |
| `go-live-configure-org.png` | 696 | 350 | 348 |
| `go-live-create-billing-account.png` | 1638 | — | 819 |
| `go-live-invoicing-information.png` | 1714 | 850 | 857 |
| `go-live-stripe.png` | 932 | 460 | 466 |
| `go-live-subscription.png` | 1668 | 500 | 834 |
| `go-live-new-workspace.png` | 1672 | 600 | 836 |

The subscription and workspace shots were the furthest off, and the billing account shot had no width at all so it filled the container.

🤖 Generated with [Claude Code](https://claude.com/claude-code)