### PR TITLE
Redesign the apps index with tiles

### DIFF
--- a/apps/index.mdx
+++ b/apps/index.mdx
@@ -11,7 +11,7 @@ Invopop apps extend the platform's core functionality by connecting to governmen
 ## Network
 
 <Columns cols={3}>
-  <Tile href="/apps/peppol" title="Peppol" description="Send documents on the Peppol network.">
+  <Tile href="/apps/peppol" title="Peppol" description="Send documents over Peppol.">
     <img src="https://assets.invopop.com/apps/peppol/icon.svg" width="76" alt="Peppol logo" />
   </Tile>
 </Columns>
@@ -23,7 +23,7 @@ Invopop apps extend the platform's core functionality by connecting to governmen
   <Tile href="/apps/argentina" title="Argentina" description="Submit invoices to ARCA.">
     <img src="https://assets.invopop.com/flags/ar.svg" width="76" alt="Flag of Argentina" />
   </Tile>
-  <Tile href="/apps/at-portugal" title="AT Portugal" description="Certified invoices and SAF-T data.">
+  <Tile href="/apps/at-portugal" title="AT Portugal" description="Certified invoices and SAF-T.">
     <img src="https://assets.invopop.com/apps/at-pt/icon.svg" width="76" alt="AT Portugal logo" />
   </Tile>
   <Tile href="/apps/choruspro-france" title="Chorus Pro France" description="B2G invoices via Chorus Pro.">
@@ -32,13 +32,13 @@ Invopop apps extend the platform's core functionality by connecting to governmen
   <Tile href="/apps/dian-colombia" title="DIAN Colombia" description="Submit invoices to DIAN.">
     <img src="https://assets.invopop.com/apps/dian-colombia/icon.svg" width="76" alt="DIAN Colombia logo" />
   </Tile>
-  <Tile href="/apps/denmark" title="Denmark" description="OIOUBL over the NemHandel network.">
+  <Tile href="/apps/denmark" title="Denmark" description="OIOUBL over NemHandel.">
     <img src="https://assets.invopop.com/flags/dk.svg" width="76" alt="Flag of Denmark" />
   </Tile>
   <Tile href="/apps/finland" title="Finland" description="Finvoice on operators and Peppol.">
     <img src="https://assets.invopop.com/flags/fi.svg" width="76" alt="Flag of Finland" />
   </Tile>
-  <Tile href="/apps/france" title="France" description="Plateforme Agréée B2B and B2C flows.">
+  <Tile href="/apps/france" title="France" description="Plateforme Agréée B2B and B2C.">
     <img src="https://assets.invopop.com/flags/fr.svg" width="76" alt="Flag of France" />
   </Tile>
   <Tile href="/apps/ilyda-greece" title="ILYDA Greece" description="IAPR invoices via myDATA.">
@@ -47,7 +47,7 @@ Invopop apps extend the platform's core functionality by connecting to governmen
   <Tile href="/apps/poland" title="Poland" description="FA(3) invoices through KSeF 2.0.">
     <img src="https://assets.invopop.com/flags/pl.svg" width="76" alt="Flag of Poland" />
   </Tile>
-  <Tile href="/apps/documentos-fiscais-electronicos-brazil" title="Documentos fiscais eletrônicos Brazil" description="NF-e, NFC-e and NFS-e via PlugNotas.">
+  <Tile href="/apps/documentos-fiscais-electronicos-brazil" title="DF-e Brazil" description="Send NF-e, NFC-e and NFS-e.">
     <img src="https://assets.invopop.com/apps/notas-fiscais-eletronicas-brazil/icon.svg" width="76" alt="Documentos fiscais eletrônicos Brazil logo" />
   </Tile>
   <Tile href="/apps/sat-mexico" title="SAT Mexico" description="Issue and import CFDI invoices.">
@@ -62,7 +62,7 @@ Invopop apps extend the platform's core functionality by connecting to governmen
   <Tile href="/apps/smart-receipts-italy" title="Smart receipts Italy" description="Issue documento commerciale.">
     <img src="https://assets.invopop.com/apps/agenzia-entrate/icon.svg" width="76" alt="Smart receipts Italy logo" />
   </Tile>
-  <Tile href="/apps/spain" title="Spain" description="All Spanish tax-agency integrations.">
+  <Tile href="/apps/spain" title="Spain" description="All Spanish tax integrations.">
     <img src="https://assets.invopop.com/flags/es.svg" width="76" alt="Flag of Spain" />
   </Tile>
   <Tile href="/apps/verifactu-spain" title="VERI*FACTU Spain" description="Send invoices under VERI*FACTU.">
@@ -77,7 +77,7 @@ Invopop apps extend the platform's core functionality by connecting to governmen
   <Tile href="/apps/email" title="Email" description="Send emails from your workflows.">
     <img src="https://assets.invopop.com/apps/email/icon.svg" width="76" alt="Email logo" />
   </Tile>
-  <Tile href="/apps/slack" title="Slack" description="Send workflow notifications to Slack.">
+  <Tile href="/apps/slack" title="Slack" description="Send notifications to Slack.">
     <img src="https://assets.invopop.com/apps/slack/icon.svg" width="76" alt="Slack logo" />
   </Tile>
 </Columns>
@@ -86,7 +86,7 @@ Invopop apps extend the platform's core functionality by connecting to governmen
 ## Format
 
 <Columns cols={3}>
-  <Tile href="/apps/pdf-generator" title="PDF Generator" description="Compliant PDFs from GOBL sources.">
+  <Tile href="/apps/pdf-generator" title="PDF Generator" description="Compliant PDFs from GOBL.">
     <img src="https://assets.invopop.com/apps/pdf/logo.svg" width="76" alt="PDF Generator logo" />
   </Tile>
   <Tile href="/apps/oasis-ubl" title="OASIS UBL" description="Convert GOBL to OASIS UBL.">
@@ -122,7 +122,7 @@ Invopop apps extend the platform's core functionality by connecting to governmen
 ## Automation
 
 <Columns cols={3}>
-  <Tile href="/apps/connect" title="Connect" description="Incoming and outgoing connections.">
+  <Tile href="/apps/connect" title="Connect" description="Custom endpoints for documents.">
     <img src="https://assets.invopop.com/apps/connect/icon.svg" width="76" alt="Connect logo" />
   </Tile>
   <Tile href="/apps/cron" title="Cron" description="Schedule periodic workflow runs.">

--- a/apps/index.mdx
+++ b/apps/index.mdx
@@ -10,140 +10,140 @@ Invopop apps extend the platform's core functionality by connecting to governmen
 
 ## Network
 
-<Columns cols={3}>
-  <Tile href="/apps/peppol" title="Peppol" description="Send documents over Peppol.">
-    <img src="https://assets.invopop.com/apps/peppol/icon.svg" width="76" alt="Peppol logo" />
+<Columns cols={4}>
+  <Tile href="/apps/peppol" title="Peppol" description="Send over Peppol.">
+    <img src="https://assets.invopop.com/apps/peppol/icon.svg" width="56" alt="Peppol logo" />
   </Tile>
 </Columns>
 
 
 ## Government
 
-<Columns cols={3}>
-  <Tile href="/apps/argentina" title="Argentina" description="Submit invoices to ARCA.">
-    <img src="https://assets.invopop.com/flags/ar.svg" width="76" alt="Flag of Argentina" />
+<Columns cols={4}>
+  <Tile href="/apps/argentina" title="Argentina" description="Submit to ARCA.">
+    <img src="https://assets.invopop.com/flags/ar.svg" width="56" alt="Flag of Argentina" />
   </Tile>
-  <Tile href="/apps/at-portugal" title="AT Portugal" description="Certified invoices and SAF-T.">
-    <img src="https://assets.invopop.com/apps/at-pt/icon.svg" width="76" alt="AT Portugal logo" />
+  <Tile href="/apps/at-portugal" title="AT Portugal" description="Invoices and SAF-T.">
+    <img src="https://assets.invopop.com/apps/at-pt/icon.svg" width="56" alt="AT Portugal logo" />
   </Tile>
-  <Tile href="/apps/choruspro-france" title="Chorus Pro France" description="B2G invoices via Chorus Pro.">
-    <img src="https://assets.invopop.com/apps/chroruspro/icon.svg" width="76" alt="Chorus Pro France logo" />
+  <Tile href="/apps/choruspro-france" title="Chorus Pro France" description="B2G via Chorus Pro.">
+    <img src="https://assets.invopop.com/apps/chroruspro/icon.svg" width="56" alt="Chorus Pro France logo" />
   </Tile>
-  <Tile href="/apps/dian-colombia" title="DIAN Colombia" description="Submit invoices to DIAN.">
-    <img src="https://assets.invopop.com/apps/dian-colombia/icon.svg" width="76" alt="DIAN Colombia logo" />
+  <Tile href="/apps/dian-colombia" title="DIAN Colombia" description="Submit to DIAN.">
+    <img src="https://assets.invopop.com/apps/dian-colombia/icon.svg" width="56" alt="DIAN Colombia logo" />
   </Tile>
-  <Tile href="/apps/denmark" title="Denmark" description="OIOUBL over NemHandel.">
-    <img src="https://assets.invopop.com/flags/dk.svg" width="76" alt="Flag of Denmark" />
+  <Tile href="/apps/denmark" title="Denmark" description="OIOUBL via NemHandel.">
+    <img src="https://assets.invopop.com/flags/dk.svg" width="56" alt="Flag of Denmark" />
   </Tile>
-  <Tile href="/apps/finland" title="Finland" description="Finvoice on operators and Peppol.">
-    <img src="https://assets.invopop.com/flags/fi.svg" width="76" alt="Flag of Finland" />
+  <Tile href="/apps/finland" title="Finland" description="Finvoice and Peppol.">
+    <img src="https://assets.invopop.com/flags/fi.svg" width="56" alt="Flag of Finland" />
   </Tile>
-  <Tile href="/apps/france" title="France" description="Plateforme Agréée B2B and B2C.">
-    <img src="https://assets.invopop.com/flags/fr.svg" width="76" alt="Flag of France" />
+  <Tile href="/apps/france" title="France" description="Plateforme Agréée.">
+    <img src="https://assets.invopop.com/flags/fr.svg" width="56" alt="Flag of France" />
   </Tile>
-  <Tile href="/apps/ilyda-greece" title="ILYDA Greece" description="IAPR invoices via myDATA.">
-    <img src="https://assets.invopop.com/apps/ilyda/icon.svg" width="76" alt="ILYDA Greece logo" />
+  <Tile href="/apps/ilyda-greece" title="ILYDA Greece" description="myDATA via ILYDA.">
+    <img src="https://assets.invopop.com/apps/ilyda/icon.svg" width="56" alt="ILYDA Greece logo" />
   </Tile>
-  <Tile href="/apps/poland" title="Poland" description="FA(3) invoices through KSeF 2.0.">
-    <img src="https://assets.invopop.com/flags/pl.svg" width="76" alt="Flag of Poland" />
+  <Tile href="/apps/poland" title="Poland" description="FA(3) via KSeF 2.0.">
+    <img src="https://assets.invopop.com/flags/pl.svg" width="56" alt="Flag of Poland" />
   </Tile>
-  <Tile href="/apps/documentos-fiscais-electronicos-brazil" title="DF-e Brazil" description="Send NF-e, NFC-e and NFS-e.">
-    <img src="https://assets.invopop.com/apps/notas-fiscais-eletronicas-brazil/icon.svg" width="76" alt="Documentos fiscais eletrônicos Brazil logo" />
+  <Tile href="/apps/documentos-fiscais-electronicos-brazil" title="DF-e Brazil" description="NF-e, NFC-e, NFS-e.">
+    <img src="https://assets.invopop.com/apps/notas-fiscais-eletronicas-brazil/icon.svg" width="56" alt="Documentos fiscais eletrônicos Brazil logo" />
   </Tile>
-  <Tile href="/apps/sat-mexico" title="SAT Mexico" description="Issue and import CFDI invoices.">
-    <img src="https://assets.invopop.com/apps/sat-mexico/icon.svg" width="76" alt="SAT Mexico logo" />
+  <Tile href="/apps/sat-mexico" title="SAT Mexico" description="CFDI invoices.">
+    <img src="https://assets.invopop.com/apps/sat-mexico/icon.svg" width="56" alt="SAT Mexico logo" />
   </Tile>
-  <Tile href="/apps/saudi-arabia" title="Saudi Arabia" description="Clear and report with FATOORA.">
-    <img src="https://assets.invopop.com/apps/zatca/icon.svg" width="76" alt="Saudi Arabia logo" />
+  <Tile href="/apps/saudi-arabia" title="Saudi Arabia" description="Clear with FATOORA.">
+    <img src="https://assets.invopop.com/apps/zatca/icon.svg" width="56" alt="Saudi Arabia logo" />
   </Tile>
-  <Tile href="/apps/sdi-italy" title="SDI Italy" description="Issue and receive through SDI.">
-    <img src="https://assets.invopop.com/apps/sdi-italy/icon.svg" width="76" alt="SDI Italy logo" />
+  <Tile href="/apps/sdi-italy" title="SDI Italy" description="Issue and receive.">
+    <img src="https://assets.invopop.com/apps/sdi-italy/icon.svg" width="56" alt="SDI Italy logo" />
   </Tile>
-  <Tile href="/apps/smart-receipts-italy" title="Smart receipts Italy" description="Issue documento commerciale.">
-    <img src="https://assets.invopop.com/apps/agenzia-entrate/icon.svg" width="76" alt="Smart receipts Italy logo" />
+  <Tile href="/apps/smart-receipts-italy" title="Smart receipts Italy" description="Documento commerciale.">
+    <img src="https://assets.invopop.com/apps/agenzia-entrate/icon.svg" width="56" alt="Smart receipts Italy logo" />
   </Tile>
-  <Tile href="/apps/spain" title="Spain" description="All Spanish tax integrations.">
-    <img src="https://assets.invopop.com/flags/es.svg" width="76" alt="Flag of Spain" />
+  <Tile href="/apps/spain" title="Spain" description="Spanish tax agencies.">
+    <img src="https://assets.invopop.com/flags/es.svg" width="56" alt="Flag of Spain" />
   </Tile>
-  <Tile href="/apps/verifactu-spain" title="VERI*FACTU Spain" description="Send invoices under VERI*FACTU.">
-    <img src="https://assets.invopop.com/apps/verifactu/icon.svg" width="76" alt="VERI*FACTU Spain logo" />
+  <Tile href="/apps/verifactu-spain" title="VERI*FACTU Spain" description="Send under VERI*FACTU.">
+    <img src="https://assets.invopop.com/apps/verifactu/icon.svg" width="56" alt="VERI*FACTU Spain logo" />
   </Tile>
 </Columns>
 
 
 ## Notify
 
-<Columns cols={3}>
-  <Tile href="/apps/email" title="Email" description="Send emails from your workflows.">
-    <img src="https://assets.invopop.com/apps/email/icon.svg" width="76" alt="Email logo" />
+<Columns cols={4}>
+  <Tile href="/apps/email" title="Email" description="Email from workflows.">
+    <img src="https://assets.invopop.com/apps/email/icon.svg" width="56" alt="Email logo" />
   </Tile>
-  <Tile href="/apps/slack" title="Slack" description="Send notifications to Slack.">
-    <img src="https://assets.invopop.com/apps/slack/icon.svg" width="76" alt="Slack logo" />
+  <Tile href="/apps/slack" title="Slack" description="Notify via Slack.">
+    <img src="https://assets.invopop.com/apps/slack/icon.svg" width="56" alt="Slack logo" />
   </Tile>
 </Columns>
 
 
 ## Format
 
-<Columns cols={3}>
-  <Tile href="/apps/pdf-generator" title="PDF Generator" description="Compliant PDFs from GOBL.">
-    <img src="https://assets.invopop.com/apps/pdf/logo.svg" width="76" alt="PDF Generator logo" />
+<Columns cols={4}>
+  <Tile href="/apps/pdf-generator" title="PDF Generator" description="PDFs from GOBL.">
+    <img src="https://assets.invopop.com/apps/pdf/logo.svg" width="56" alt="PDF Generator logo" />
   </Tile>
-  <Tile href="/apps/oasis-ubl" title="OASIS UBL" description="Convert GOBL to OASIS UBL.">
-    <img src="https://assets.invopop.com/apps/ubl/logo.svg" width="76" alt="OASIS UBL logo" />
+  <Tile href="/apps/oasis-ubl" title="OASIS UBL" description="GOBL to OASIS UBL.">
+    <img src="https://assets.invopop.com/apps/ubl/logo.svg" width="56" alt="OASIS UBL logo" />
   </Tile>
-  <Tile href="/apps/uncefact-cii" title="UN/CEFACT CII" description="Convert GOBL to UN/CEFACT CII.">
-    <img src="https://assets.invopop.com/apps/cii/logo.svg" width="76" alt="UN/CEFACT CII logo" />
+  <Tile href="/apps/uncefact-cii" title="UN/CEFACT CII" description="GOBL to CII.">
+    <img src="https://assets.invopop.com/apps/cii/logo.svg" width="56" alt="UN/CEFACT CII logo" />
   </Tile>
-  <Tile href="/apps/facturae-spain" title="Facturae Spain" description="Convert GOBL to Facturae.">
-    <img src="https://assets.invopop.com/apps/facturae/icon.svg" width="76" alt="Facturae Spain logo" />
+  <Tile href="/apps/facturae-spain" title="Facturae Spain" description="GOBL to Facturae.">
+    <img src="https://assets.invopop.com/apps/facturae/icon.svg" width="56" alt="Facturae Spain logo" />
   </Tile>
 </Columns>
 
 
 ## Document
 
-<Columns cols={3}>
-  <Tile href="/apps/portal" title="Portal" description="Turn receipts into full invoices.">
-    <img src="https://assets.invopop.com/apps/portal/icon.svg" width="76" alt="Portal logo" />
+<Columns cols={4}>
+  <Tile href="/apps/portal" title="Portal" description="Receipts to invoices.">
+    <img src="https://assets.invopop.com/apps/portal/icon.svg" width="56" alt="Portal logo" />
   </Tile>
 </Columns>
 
 
 ## Storage
 
-<Columns cols={3}>
-  <Tile href="/apps/google-drive" title="Google Drive" description="Upload documents to Google Drive.">
-    <img src="https://assets.invopop.com/apps/google-drive/icon.svg" width="76" alt="Google Drive logo" />
+<Columns cols={4}>
+  <Tile href="/apps/google-drive" title="Google Drive" description="Upload to Drive.">
+    <img src="https://assets.invopop.com/apps/google-drive/icon.svg" width="56" alt="Google Drive logo" />
   </Tile>
 </Columns>
 
 
 ## Automation
 
-<Columns cols={3}>
-  <Tile href="/apps/connect" title="Connect" description="Custom endpoints for documents.">
-    <img src="https://assets.invopop.com/apps/connect/icon.svg" width="76" alt="Connect logo" />
+<Columns cols={4}>
+  <Tile href="/apps/connect" title="Connect" description="Custom endpoints.">
+    <img src="https://assets.invopop.com/apps/connect/icon.svg" width="56" alt="Connect logo" />
   </Tile>
-  <Tile href="/apps/cron" title="Cron" description="Schedule periodic workflow runs.">
-    <img src="https://assets.invopop.com/apps/cron/icon.svg" width="76" alt="Cron logo" />
+  <Tile href="/apps/cron" title="Cron" description="Scheduled runs.">
+    <img src="https://assets.invopop.com/apps/cron/icon.svg" width="56" alt="Cron logo" />
   </Tile>
 </Columns>
 
 
 ## Integrations
 
-<Columns cols={3}>
-  <Tile href="/apps/chargebee" title="Chargebee" description="Import invoices from Chargebee.">
-    <img src="https://assets.invopop.com/apps/chargebee/icon.svg" width="76" alt="Chargebee logo" />
+<Columns cols={4}>
+  <Tile href="/apps/chargebee" title="Chargebee" description="Import from Chargebee.">
+    <img src="https://assets.invopop.com/apps/chargebee/icon.svg" width="56" alt="Chargebee logo" />
   </Tile>
-  <Tile href="/apps/stripe" title="Stripe" description="Import invoices from Stripe.">
-    <img src="https://assets.invopop.com/apps/stripe/icon.svg" width="76" alt="Stripe logo" />
+  <Tile href="/apps/stripe" title="Stripe" description="Import from Stripe.">
+    <img src="https://assets.invopop.com/apps/stripe/icon.svg" width="56" alt="Stripe logo" />
   </Tile>
-  <Tile href="/apps/netsuite" title="NetSuite" description="Compliant invoices from NetSuite.">
-    <img src="https://assets.invopop.com/apps/netsuite/logo.svg" width="76" alt="NetSuite logo" />
+  <Tile href="/apps/netsuite" title="NetSuite" description="Invoices from NetSuite.">
+    <img src="https://assets.invopop.com/apps/netsuite/logo.svg" width="56" alt="NetSuite logo" />
   </Tile>
-  <Tile href="/apps/sw-sapien" title="SW Sapien" description="Bulk import CFDIs via Efisco.">
-    <img src="https://assets.invopop.com/apps/sw-sapien/icon.svg" width="76" alt="SW Sapien logo" />
+  <Tile href="/apps/sw-sapien" title="SW Sapien" description="Bulk CFDI import.">
+    <img src="https://assets.invopop.com/apps/sw-sapien/icon.svg" width="56" alt="SW Sapien logo" />
   </Tile>
 </Columns>

--- a/apps/index.mdx
+++ b/apps/index.mdx
@@ -8,14 +8,6 @@ mode: wide
 Invopop apps extend the platform's core functionality by connecting to government systems, third-party services, and automation tools. Use apps in your workflows to submit invoices to tax authorities, send notifications, generate PDFs, and sync with your existing business tools.
 
 
-## Network
-
-<Columns cols={4}>
-  <Tile href="/apps/peppol" title="Peppol" description="Send over Peppol.">
-    <img src="https://assets.invopop.com/apps/peppol/icon.svg" width="56" alt="Peppol logo" />
-  </Tile>
-</Columns>
-
 
 ## Government
 
@@ -67,6 +59,14 @@ Invopop apps extend the platform's core functionality by connecting to governmen
   </Tile>
   <Tile href="/apps/verifactu-spain" title="VERI*FACTU Spain" description="Send under VERI*FACTU.">
     <img src="https://assets.invopop.com/apps/verifactu/icon.svg" width="56" alt="VERI*FACTU Spain logo" />
+  </Tile>
+</Columns>
+
+## Network
+
+<Columns cols={4}>
+  <Tile href="/apps/peppol" title="Peppol" description="Send over Peppol.">
+    <img src="https://assets.invopop.com/apps/peppol/icon.svg" width="56" alt="Peppol logo" />
   </Tile>
 </Columns>
 

--- a/apps/index.mdx
+++ b/apps/index.mdx
@@ -8,135 +8,142 @@ mode: wide
 Invopop apps extend the platform's core functionality by connecting to government systems, third-party services, and automation tools. Use apps in your workflows to submit invoices to tax authorities, send notifications, generate PDFs, and sync with your existing business tools.
 
 
-**Network**
+## Network
 
-<Columns cols="1">
-	<Card title="Peppol" icon="https://assets.invopop.com/apps/peppol/icon.svg" href="/apps/peppol" horizontal>
-		Submit invoices and documents to the Peppol network.
-	</Card>
+<Columns cols={3}>
+  <Tile href="/apps/peppol" title="Peppol" description="Send documents on the Peppol network.">
+    <img src="https://assets.invopop.com/apps/peppol/icon.svg" width="76" alt="Peppol logo" />
+  </Tile>
 </Columns>
 
-**Government**
 
-<Columns cols="1">
-	<Card title="Argentina" icon="https://assets.invopop.com/flags/ar.svg" href="/apps/argentina" horizontal>
-		Manage ARCA integrations and submit invoices to Argentina's tax authority.
-	</Card>
-	<Card title="AT Portugal" icon="https://assets.invopop.com/apps/at-pt/icon.svg" href="/apps/at-portugal" horizontal>
-		Submit certified invoices and periodic SAF-T data to Portugal's Autoridade Tributária.
-	</Card>
-	<Card title="Chorus Pro France" icon="https://assets.invopop.com/apps/chroruspro/icon.svg" href="/apps/choruspro-france" horizontal>
-		Submit B2G invoices to the French Chorus Pro system.
-	</Card>
-	<Card title="DIAN Colombia" icon="https://assets.invopop.com/apps/dian-colombia/icon.svg" href="/apps/dian-colombia" horizontal>
-		Submit invoices to the Colombian DIAN system.
-	</Card>
-	<Card title="Denmark" icon="https://assets.invopop.com/flags/dk.svg" href="/apps/denmark" horizontal>
-		Send and receive OIOUBL invoices over Denmark's NemHandel network.
-	</Card>
-	<Card title="Finland" icon="https://assets.invopop.com/flags/fi.svg" href="/apps/finland" horizontal>
-		Send and receive Finnish e-invoices across the domestic operator network and Peppol.
-	</Card>
-	<Card title="France" icon="https://assets.invopop.com/flags/fr.svg" href="/apps/france" horizontal>
-		Manage all French e-invoicing flows — Plateforme Agréée (B2B, B2C).
-	</Card>
-	<Card title="ILYDA Greece" icon="https://assets.invopop.com/apps/ilyda/icon.svg" href="/apps/ilyda-greece" horizontal>
-		Submit invoices to the Greek IAPR via the myDATA platform.
-	</Card>
-	<Card title="Poland" icon="https://assets.invopop.com/flags/pl.svg" href="/apps/poland" horizontal>
-		Register suppliers and issue FA(3) invoices through Poland's KSeF 2.0 system.
-	</Card>
-	<Card title="Documentos fiscais eletrônicos Brazil" icon="https://assets.invopop.com/apps/notas-fiscais-eletronicas-brazil/icon.svg" href="/apps/documentos-fiscais-electronicos-brazil" horizontal>
-		Send NF-e, NFC-e & NFS-e documents to the tax authorities in Brazil via PlugNotas.
-	</Card>
-	<Card title="SAT Mexico" icon="https://assets.invopop.com/apps/sat-mexico/icon.svg" href="/apps/sat-mexico" horizontal>
-		Issue and import CFDI invoices, onboard suppliers, and manage compliant submissions to Mexico's tax authority (SAT).
-	</Card>
-	<Card title="Saudi Arabia" icon="https://assets.invopop.com/apps/zatca/icon.svg" href="/apps/saudi-arabia" horizontal>
-		Clear and report e-invoices with ZATCA's FATOORA platform.
-	</Card>
-	<Card title="SDI Italy" icon="https://assets.invopop.com/apps/sdi-italy/icon.svg" href="/apps/sdi-italy" horizontal>
-		Issue and receive invoices through Italy's SDI system.
-	</Card>
-	<Card title="Smart receipts Italy" icon="https://assets.invopop.com/apps/agenzia-entrate/icon.svg" href="/apps/smart-receipts-italy" horizontal>
-		Issue documento commerciale in Italy.
-	</Card>
-	<Card title="Spain" icon="https://assets.invopop.com/flags/es.svg" href="/apps/spain" horizontal>
-		Manage all Spanish tax-agency integrations.
-	</Card>
-	<Card title="VERI*FACTU Spain" icon="https://assets.invopop.com/apps/verifactu/icon.svg" href="/apps/verifactu-spain" horizontal>
-		Convert and send invoices to the Spanish tax authorities using the VERI*FACTU system.
-	</Card>
+## Government
+
+<Columns cols={3}>
+  <Tile href="/apps/argentina" title="Argentina" description="Submit invoices to ARCA.">
+    <img src="https://assets.invopop.com/flags/ar.svg" width="76" alt="Flag of Argentina" />
+  </Tile>
+  <Tile href="/apps/at-portugal" title="AT Portugal" description="Certified invoices and SAF-T data.">
+    <img src="https://assets.invopop.com/apps/at-pt/icon.svg" width="76" alt="AT Portugal logo" />
+  </Tile>
+  <Tile href="/apps/choruspro-france" title="Chorus Pro France" description="B2G invoices via Chorus Pro.">
+    <img src="https://assets.invopop.com/apps/chroruspro/icon.svg" width="76" alt="Chorus Pro France logo" />
+  </Tile>
+  <Tile href="/apps/dian-colombia" title="DIAN Colombia" description="Submit invoices to DIAN.">
+    <img src="https://assets.invopop.com/apps/dian-colombia/icon.svg" width="76" alt="DIAN Colombia logo" />
+  </Tile>
+  <Tile href="/apps/denmark" title="Denmark" description="OIOUBL over the NemHandel network.">
+    <img src="https://assets.invopop.com/flags/dk.svg" width="76" alt="Flag of Denmark" />
+  </Tile>
+  <Tile href="/apps/finland" title="Finland" description="Finvoice on operators and Peppol.">
+    <img src="https://assets.invopop.com/flags/fi.svg" width="76" alt="Flag of Finland" />
+  </Tile>
+  <Tile href="/apps/france" title="France" description="Plateforme Agréée B2B and B2C flows.">
+    <img src="https://assets.invopop.com/flags/fr.svg" width="76" alt="Flag of France" />
+  </Tile>
+  <Tile href="/apps/ilyda-greece" title="ILYDA Greece" description="IAPR invoices via myDATA.">
+    <img src="https://assets.invopop.com/apps/ilyda/icon.svg" width="76" alt="ILYDA Greece logo" />
+  </Tile>
+  <Tile href="/apps/poland" title="Poland" description="FA(3) invoices through KSeF 2.0.">
+    <img src="https://assets.invopop.com/flags/pl.svg" width="76" alt="Flag of Poland" />
+  </Tile>
+  <Tile href="/apps/documentos-fiscais-electronicos-brazil" title="Documentos fiscais eletrônicos Brazil" description="NF-e, NFC-e and NFS-e via PlugNotas.">
+    <img src="https://assets.invopop.com/apps/notas-fiscais-eletronicas-brazil/icon.svg" width="76" alt="Documentos fiscais eletrônicos Brazil logo" />
+  </Tile>
+  <Tile href="/apps/sat-mexico" title="SAT Mexico" description="Issue and import CFDI invoices.">
+    <img src="https://assets.invopop.com/apps/sat-mexico/icon.svg" width="76" alt="SAT Mexico logo" />
+  </Tile>
+  <Tile href="/apps/saudi-arabia" title="Saudi Arabia" description="Clear and report with FATOORA.">
+    <img src="https://assets.invopop.com/apps/zatca/icon.svg" width="76" alt="Saudi Arabia logo" />
+  </Tile>
+  <Tile href="/apps/sdi-italy" title="SDI Italy" description="Issue and receive through SDI.">
+    <img src="https://assets.invopop.com/apps/sdi-italy/icon.svg" width="76" alt="SDI Italy logo" />
+  </Tile>
+  <Tile href="/apps/smart-receipts-italy" title="Smart receipts Italy" description="Issue documento commerciale.">
+    <img src="https://assets.invopop.com/apps/agenzia-entrate/icon.svg" width="76" alt="Smart receipts Italy logo" />
+  </Tile>
+  <Tile href="/apps/spain" title="Spain" description="All Spanish tax-agency integrations.">
+    <img src="https://assets.invopop.com/flags/es.svg" width="76" alt="Flag of Spain" />
+  </Tile>
+  <Tile href="/apps/verifactu-spain" title="VERI*FACTU Spain" description="Send invoices under VERI*FACTU.">
+    <img src="https://assets.invopop.com/apps/verifactu/icon.svg" width="76" alt="VERI*FACTU Spain logo" />
+  </Tile>
 </Columns>
 
-**Notify**
 
-<Columns cols="1">
-	<Card title="Email" icon="https://assets.invopop.com/apps/email/icon.svg" href="/apps/email" horizontal>
-		Send emails from your workflows, with or without attachments.
-	</Card>
-	<Card title="Slack" icon="https://assets.invopop.com/apps/slack/icon.svg" href="/apps/slack" horizontal>
-		Send notifications from your workflow via Slack.
-	</Card>
+## Notify
+
+<Columns cols={3}>
+  <Tile href="/apps/email" title="Email" description="Send emails from your workflows.">
+    <img src="https://assets.invopop.com/apps/email/icon.svg" width="76" alt="Email logo" />
+  </Tile>
+  <Tile href="/apps/slack" title="Slack" description="Send workflow notifications to Slack.">
+    <img src="https://assets.invopop.com/apps/slack/icon.svg" width="76" alt="Slack logo" />
+  </Tile>
 </Columns>
 
-**Format**
 
-<Columns cols="1">
-	<Card title="PDF Generator" icon="https://assets.invopop.com/apps/pdf/logo.svg" href="/apps/pdf-generator" horizontal>
-		Generate legally compliant PDFs from your GOBL sources.
-	</Card>
-	<Card title="OASIS UBL" icon="https://assets.invopop.com/apps/ubl/logo.svg" href="/apps/oasis-ubl" horizontal>
-		Convert GOBL to the OASIS UBL format.
-	</Card>
-	<Card title="UN/CEFACT CII" icon="https://assets.invopop.com/apps/cii/logo.svg" href="/apps/uncefact-cii" horizontal>
-		Convert GOBL to the UN/CEFACT CII format.
-	</Card>
-	<Card title="Facturae Spain" icon="https://assets.invopop.com/apps/facturae/icon.svg" href="/apps/facturae-spain" horizontal>
-		Convert GOBL into the Spanish Facturae format.
-	</Card>
+## Format
+
+<Columns cols={3}>
+  <Tile href="/apps/pdf-generator" title="PDF Generator" description="Compliant PDFs from GOBL sources.">
+    <img src="https://assets.invopop.com/apps/pdf/logo.svg" width="76" alt="PDF Generator logo" />
+  </Tile>
+  <Tile href="/apps/oasis-ubl" title="OASIS UBL" description="Convert GOBL to OASIS UBL.">
+    <img src="https://assets.invopop.com/apps/ubl/logo.svg" width="76" alt="OASIS UBL logo" />
+  </Tile>
+  <Tile href="/apps/uncefact-cii" title="UN/CEFACT CII" description="Convert GOBL to UN/CEFACT CII.">
+    <img src="https://assets.invopop.com/apps/cii/logo.svg" width="76" alt="UN/CEFACT CII logo" />
+  </Tile>
+  <Tile href="/apps/facturae-spain" title="Facturae Spain" description="Convert GOBL to Facturae.">
+    <img src="https://assets.invopop.com/apps/facturae/icon.svg" width="76" alt="Facturae Spain logo" />
+  </Tile>
 </Columns>
 
-**Document**
 
-<Columns cols="1">
-	<Card title="Portal" icon="https://assets.invopop.com/apps/portal/icon.svg" href="/apps/portal" horizontal>
-		Convert a simplified invoice or receipt into a full invoice.
-	</Card>
+## Document
+
+<Columns cols={3}>
+  <Tile href="/apps/portal" title="Portal" description="Turn receipts into full invoices.">
+    <img src="https://assets.invopop.com/apps/portal/icon.svg" width="76" alt="Portal logo" />
+  </Tile>
 </Columns>
 
-**Storage**
 
-<Columns cols="1">
-	<Card title="Google Drive" icon="https://assets.invopop.com/apps/google-drive/icon.svg" href="/apps/google-drive" horizontal>
-		Automatically upload invoices and documents to Google Drive.
-	</Card>
+## Storage
+
+<Columns cols={3}>
+  <Tile href="/apps/google-drive" title="Google Drive" description="Upload documents to Google Drive.">
+    <img src="https://assets.invopop.com/apps/google-drive/icon.svg" width="76" alt="Google Drive logo" />
+  </Tile>
 </Columns>
 
-**Automation**
 
-<Columns cols="1">
-	<Card title="Connect" icon="https://assets.invopop.com/apps/connect/icon.svg" href="/apps/connect" horizontal>
-		Create incoming and outgoing connections via multiple channels.
-	</Card>
-	<Card title="Cron" icon="https://assets.invopop.com/apps/cron/icon.svg" href="/apps/cron" horizontal>
-		Schedule periodic workflow execution for automated data imports and recurring processes.
-	</Card>
+## Automation
+
+<Columns cols={3}>
+  <Tile href="/apps/connect" title="Connect" description="Incoming and outgoing connections.">
+    <img src="https://assets.invopop.com/apps/connect/icon.svg" width="76" alt="Connect logo" />
+  </Tile>
+  <Tile href="/apps/cron" title="Cron" description="Schedule periodic workflow runs.">
+    <img src="https://assets.invopop.com/apps/cron/icon.svg" width="76" alt="Cron logo" />
+  </Tile>
 </Columns>
 
-**Integrations**
 
-<Columns cols="1">
-	<Card title="Chargebee" icon="https://assets.invopop.com/apps/chargebee/icon.svg" href="/apps/chargebee" horizontal>
-		Import and process invoices and credit notes from Chargebee.
-	</Card>
-	<Card title="Stripe" icon="https://assets.invopop.com/apps/stripe/icon.svg" href="/apps/stripe" horizontal>
-		Import and process invoices and credit notes from Stripe.
-	</Card>
-	<Card title="NetSuite" icon="https://assets.invopop.com/apps/netsuite/logo.svg" href="/apps/netsuite" horizontal>
-		Generate legally compliant invoices from NetSuite.
-	</Card>
-	<Card title="SW Sapien" icon="https://assets.invopop.com/apps/sw-sapien/icon.svg" href="/apps/sw-sapien" horizontal>
-		Bulk download and import CFDIs from Mexico's SAT using SW Sapien's Efisco service.
-	</Card>
+## Integrations
+
+<Columns cols={3}>
+  <Tile href="/apps/chargebee" title="Chargebee" description="Import invoices from Chargebee.">
+    <img src="https://assets.invopop.com/apps/chargebee/icon.svg" width="76" alt="Chargebee logo" />
+  </Tile>
+  <Tile href="/apps/stripe" title="Stripe" description="Import invoices from Stripe.">
+    <img src="https://assets.invopop.com/apps/stripe/icon.svg" width="76" alt="Stripe logo" />
+  </Tile>
+  <Tile href="/apps/netsuite" title="NetSuite" description="Compliant invoices from NetSuite.">
+    <img src="https://assets.invopop.com/apps/netsuite/logo.svg" width="76" alt="NetSuite logo" />
+  </Tile>
+  <Tile href="/apps/sw-sapien" title="SW Sapien" description="Bulk import CFDIs via Efisco.">
+    <img src="https://assets.invopop.com/apps/sw-sapien/icon.svg" width="76" alt="SW Sapien logo" />
+  </Tile>
 </Columns>


### PR DESCRIPTION
Applies the tile treatment from the guides index to the apps directory, in a three-column grid. All 31 apps, the eight categories, their order and every destination are unchanged.

- Each app's existing mark — product logo or country flag — becomes the tile preview at 76px.
- Category labels are now `##` headings rather than bold paragraphs, so they appear in the table of contents.
- **Descriptions are rewritten to fit.** `Tile` truncates its description to a single line with an ellipsis instead of wrapping, and the old card copy ran as long as 118 characters ("Issue and import CFDI invoices, onboard suppliers, and manage compliant submissions to Mexico's tax authority (SAT)"). Every description is now 38 characters or fewer. The longer text still lives on each app's own page.

Verified all 31 `href`s resolve to existing pages and all 31 icon URLs return 200. Alt text distinguishes flags ("Flag of Denmark") from product marks ("Peppol logo").

🤖 Generated with [Claude Code](https://claude.com/claude-code)